### PR TITLE
Implement product management and interest flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,9 @@ import Settings from './pages/Settings/Settings';
 import Cart from './pages/Cart/Cart';
 import Events from './pages/Events/Events';
 import VoiceOrder from './pages/VoiceOrder/VoiceOrder';
+import ManageProducts from './pages/ManageProducts/ManageProducts';
+import ReceivedInterests from './pages/ReceivedInterests/ReceivedInterests';
+import MyInterests from './pages/MyInterests/MyInterests';
 import TabLayout from './layouts/TabLayout';
 import AdminLogin from './pages/AdminLogin/AdminLogin';
 import AdminDashboard from './pages/AdminDashboard';
@@ -62,9 +65,12 @@ function App() {
             <Route path="/events" element={<Events />} />
             <Route path="/special-shop" element={<SpecialShop />} />
             <Route path="/voice-order" element={<VoiceOrder />} />
-            <Route path="/profile" element={<Profile />} />
-            <Route path="/settings" element={<Settings />} />
-          </Route>
+          <Route path="/profile" element={<Profile />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/manage-products" element={<ManageProducts />} />
+          <Route path="/interests/received" element={<ReceivedInterests />} />
+          <Route path="/interests/my" element={<MyInterests />} />
+        </Route>
           <Route path="/shops/:id" element={<ShopDetails />} />
           <Route path="/product/:id" element={<ProductDetails />} />
           <Route path="/events/:id" element={<EventDetails />} />

--- a/client/src/pages/ManageProducts/ManageProducts.module.scss
+++ b/client/src/pages/ManageProducts/ManageProducts.module.scss
@@ -1,0 +1,36 @@
+.manageProducts {
+  padding: 1rem;
+}
+.grid {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.card {
+  border: 1px solid #ddd;
+  padding: 1rem;
+  border-radius: 4px;
+}
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.form {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/client/src/pages/ManageProducts/ManageProducts.tsx
+++ b/client/src/pages/ManageProducts/ManageProducts.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from '../../store';
+import {
+  fetchMyProducts,
+  createProduct,
+  updateProduct,
+  deleteProduct,
+  type Product,
+} from '../../store/slices/productSlice';
+import styles from './ManageProducts.module.scss';
+
+const emptyForm: Partial<Product> = { name: '', description: '', price: 0, category: '', image: '', stock: 0, shop: '' };
+
+const ManageProducts = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const { items, loading } = useSelector((s: RootState) => s.products);
+  const [showModal, setShowModal] = useState(false);
+  const [form, setForm] = useState<Partial<Product>>(emptyForm);
+  const [editId, setEditId] = useState<string | null>(null);
+
+  useEffect(() => {
+    dispatch(fetchMyProducts());
+  }, [dispatch]);
+
+  const openNew = () => {
+    setForm(emptyForm);
+    setEditId(null);
+    setShowModal(true);
+  };
+
+  const openEdit = (p: Product) => {
+    setEditId(p._id);
+    setForm({ ...p });
+    setShowModal(true);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editId) {
+      dispatch(updateProduct({ id: editId, data: form }));
+    } else {
+      dispatch(createProduct(form));
+    }
+    setShowModal(false);
+  };
+
+  return (
+    <div className={styles.manageProducts}>
+      <h2>Manage Products</h2>
+      <button onClick={openNew}>Add Product</button>
+      {loading && <p>Loading...</p>}
+      <div className={styles.grid}>
+        {items.map((p) => (
+          <div key={p._id} className={styles.card}>
+            <h4>{p.name}</h4>
+            <p>₹{p.price}</p>
+            <div className={styles.actions}>
+              <button onClick={() => openEdit(p)}>Edit</button>
+              <button onClick={() => dispatch(deleteProduct(p._id))}>Delete</button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {showModal && (
+        <div className={styles.modal}>
+          <form onSubmit={handleSubmit} className={styles.form}>
+            <label>
+              Name
+              <input value={form.name || ''} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+            </label>
+            <label>
+              Description
+              <input value={form.description || ''} onChange={(e) => setForm({ ...form, description: e.target.value })} />
+            </label>
+            <label>
+              Price
+              <input type="number" value={form.price || 0} onChange={(e) => setForm({ ...form, price: Number(e.target.value) })} />
+            </label>
+            <label>
+              Category
+              <input value={form.category || ''} onChange={(e) => setForm({ ...form, category: e.target.value })} />
+            </label>
+            <label>
+              Image URL
+              <input value={form.image || ''} onChange={(e) => setForm({ ...form, image: e.target.value })} />
+            </label>
+            <label>
+              Stock
+              <input type="number" value={form.stock || 0} onChange={(e) => setForm({ ...form, stock: Number(e.target.value) })} />
+            </label>
+            <label>
+              Shop ID
+              <input value={form.shop as string || ''} onChange={(e) => setForm({ ...form, shop: e.target.value })} />
+            </label>
+            <div className={styles.actions}>
+              <button type="submit">Save</button>
+              <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ManageProducts;

--- a/client/src/pages/MyInterests/MyInterests.module.scss
+++ b/client/src/pages/MyInterests/MyInterests.module.scss
@@ -1,0 +1,8 @@
+.myInterests {
+  padding: 1rem;
+}
+.card {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/client/src/pages/MyInterests/MyInterests.tsx
+++ b/client/src/pages/MyInterests/MyInterests.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import api from '../../api/client';
+import styles from './MyInterests.module.scss';
+
+interface Interest {
+  _id: string;
+  productId: { name: string };
+  quantity: number;
+  status: string;
+}
+
+const MyInterests = () => {
+  const [list, setList] = useState<Interest[]>([]);
+
+  const load = async () => {
+    try {
+      const res = await api.get('/interests/my');
+      setList(res.data);
+    } catch {
+      setList([]);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const cancel = async (id: string) => {
+    await api.post(`/interests/${id}/cancel`);
+    load();
+  };
+
+  return (
+    <div className={styles.myInterests}>
+      <h2>My Interests</h2>
+      {list.map((i) => (
+        <div key={i._id} className={styles.card}>
+          <p>
+            {i.productId?.name} - Qty {i.quantity} ({i.status})
+          </p>
+          {i.status === 'pending' && (
+            <button onClick={() => cancel(i._id)}>Cancel</button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MyInterests;

--- a/client/src/pages/ReceivedInterests/ReceivedInterests.module.scss
+++ b/client/src/pages/ReceivedInterests/ReceivedInterests.module.scss
@@ -1,0 +1,12 @@
+.receivedInterests {
+  padding: 1rem;
+}
+.card {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/client/src/pages/ReceivedInterests/ReceivedInterests.tsx
+++ b/client/src/pages/ReceivedInterests/ReceivedInterests.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import api from '../../api/client';
+import styles from './ReceivedInterests.module.scss';
+
+interface Interest {
+  _id: string;
+  userId: { name: string };
+  productId: { name: string };
+  quantity: number;
+  status: string;
+}
+
+const ReceivedInterests = () => {
+  const [list, setList] = useState<Interest[]>([]);
+
+  const load = async () => {
+    try {
+      const res = await api.get('/interests/received');
+      setList(res.data);
+    } catch {
+      setList([]);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const act = async (id: string, action: 'accept' | 'reject') => {
+    await api.post(`/interests/${id}/${action}`);
+    load();
+  };
+
+  return (
+    <div className={styles.receivedInterests}>
+      <h2>Received Interests</h2>
+      {list.map((i) => (
+        <div key={i._id} className={styles.card}>
+          <p>{i.userId?.name} interested in {i.productId?.name}</p>
+          <p>Qty: {i.quantity}</p>
+          {i.status === 'pending' && (
+            <div className={styles.actions}>
+              <button onClick={() => act(i._id, 'accept')}>Accept</button>
+              <button onClick={() => act(i._id, 'reject')}>Reject</button>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ReceivedInterests;

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import userReducer from './slices/userSlice';
 import cartReducer from './slices/cartSlice';
+import productReducer from './slices/productSlice';
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
     cart: cartReducer,
+    products: productReducer,
   },
 });
 

--- a/client/src/store/slices/productSlice.ts
+++ b/client/src/store/slices/productSlice.ts
@@ -1,0 +1,74 @@
+import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit';
+import api from '../../api/client';
+
+export interface Product {
+  _id: string;
+  name: string;
+  description: string;
+  price: number;
+  category: string;
+  image?: string;
+  stock: number;
+  shop: string;
+}
+
+interface ProductState {
+  items: Product[];
+  loading: boolean;
+}
+
+const initialState: ProductState = { items: [], loading: false };
+
+export const fetchMyProducts = createAsyncThunk('products/fetchMy', async () => {
+  const res = await api.get('/products/my');
+  return res.data as Product[];
+});
+
+export const createProduct = createAsyncThunk('products/create', async (data: Partial<Product>) => {
+  const res = await api.post('/products', data);
+  return res.data as Product;
+});
+
+export const updateProduct = createAsyncThunk(
+  'products/update',
+  async ({ id, data }: { id: string; data: Partial<Product> }) => {
+    const res = await api.put(`/products/${id}`, data);
+    return res.data as Product;
+  }
+);
+
+export const deleteProduct = createAsyncThunk('products/delete', async (id: string) => {
+  await api.delete(`/products/${id}`);
+  return id;
+});
+
+const productSlice = createSlice({
+  name: 'products',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchMyProducts.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(fetchMyProducts.fulfilled, (state, action) => {
+        state.loading = false;
+        state.items = action.payload;
+      })
+      .addCase(fetchMyProducts.rejected, (state) => {
+        state.loading = false;
+      })
+      .addCase(createProduct.fulfilled, (state, action) => {
+        state.items.push(action.payload);
+      })
+      .addCase(updateProduct.fulfilled, (state, action) => {
+        const idx = state.items.findIndex((p) => p._id === action.payload._id);
+        if (idx >= 0) state.items[idx] = action.payload;
+      })
+      .addCase(deleteProduct.fulfilled, (state, action: PayloadAction<string>) => {
+        state.items = state.items.filter((p) => p._id !== action.payload);
+      });
+  },
+});
+
+export default productSlice.reducer;

--- a/server/controllers/interestController.js
+++ b/server/controllers/interestController.js
@@ -1,0 +1,86 @@
+const Interest = require('../models/Interest');
+const Product = require('../models/Product');
+const Shop = require('../models/Shop');
+
+exports.createInterest = async (req, res) => {
+  try {
+    const { productId, quantity, businessId, shopId } = req.body;
+    const interest = await Interest.create({
+      userId: req.user._id,
+      businessId,
+      productId,
+      shopId,
+      quantity,
+      status: 'pending',
+    });
+    res.status(201).json(interest);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to create interest' });
+  }
+};
+
+exports.getMyInterests = async (req, res) => {
+  try {
+    const interests = await Interest.find({ userId: req.user._id })
+      .populate('productId')
+      .populate('shopId');
+    res.json(interests);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch interests' });
+  }
+};
+
+exports.getReceivedInterests = async (req, res) => {
+  try {
+    const interests = await Interest.find({ businessId: req.user._id })
+      .populate('userId', 'name phone')
+      .populate('productId');
+    res.json(interests);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch interests' });
+  }
+};
+
+exports.acceptInterest = async (req, res) => {
+  try {
+    const interest = await Interest.findById(req.params.id);
+    if (!interest) return res.status(404).json({ error: 'Interest not found' });
+    if (interest.businessId.toString() !== req.user._id.toString())
+      return res.status(403).json({ error: 'Not authorized' });
+    interest.status = 'completed';
+    await interest.save();
+    res.json(interest);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to accept interest' });
+  }
+};
+
+exports.rejectInterest = async (req, res) => {
+  try {
+    const interest = await Interest.findById(req.params.id);
+    if (!interest) return res.status(404).json({ error: 'Interest not found' });
+    if (interest.businessId.toString() !== req.user._id.toString())
+      return res.status(403).json({ error: 'Not authorized' });
+    interest.status = 'rejected';
+    await interest.save();
+    res.json(interest);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to reject interest' });
+  }
+};
+
+exports.cancelInterest = async (req, res) => {
+  try {
+    const interest = await Interest.findById(req.params.id);
+    if (!interest) return res.status(404).json({ error: 'Interest not found' });
+    if (interest.userId.toString() !== req.user._id.toString())
+      return res.status(403).json({ error: 'Not authorized' });
+    if (interest.status !== 'pending')
+      return res.status(400).json({ error: 'Cannot cancel now' });
+    interest.status = 'cancelled';
+    await interest.save();
+    res.json(interest);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to cancel interest' });
+  }
+};

--- a/server/controllers/productController.js
+++ b/server/controllers/productController.js
@@ -1,0 +1,79 @@
+const Product = require('../models/Product');
+const Shop = require('../models/Shop');
+
+exports.createProduct = async (req, res) => {
+  try {
+    const { name, description, price, category, image, stock, shopId } = req.body;
+    const shop = await Shop.findOne({ _id: shopId, owner: req.user._id });
+    if (!shop) return res.status(404).json({ error: 'Shop not found' });
+
+    const product = await Product.create({
+      shop: shopId,
+      name,
+      description,
+      price,
+      category,
+      image,
+      stock,
+    });
+    res.status(201).json(product);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to add product' });
+  }
+};
+
+exports.updateProduct = async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id);
+    if (!product) return res.status(404).json({ error: 'Product not found' });
+    const shop = await Shop.findOne({ _id: product.shop, owner: req.user._id });
+    if (!shop) return res.status(403).json({ error: 'Not authorized' });
+
+    const { name, description, price, category, image, stock } = req.body;
+    if (name !== undefined) product.name = name;
+    if (description !== undefined) product.description = description;
+    if (price !== undefined) product.price = price;
+    if (category !== undefined) product.category = category;
+    if (image !== undefined) product.image = image;
+    if (stock !== undefined) product.stock = stock;
+    await product.save();
+    res.json(product);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update product' });
+  }
+};
+
+exports.deleteProduct = async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id);
+    if (!product) return res.status(404).json({ error: 'Product not found' });
+    const shop = await Shop.findOne({ _id: product.shop, owner: req.user._id });
+    if (!shop) return res.status(403).json({ error: 'Not authorized' });
+
+    await product.deleteOne();
+    res.json({ message: 'Product deleted' });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to delete product' });
+  }
+};
+
+exports.getMyProducts = async (req, res) => {
+  try {
+    const shops = await Shop.find({ owner: req.user._id });
+    const shopIds = shops.map((s) => s._id);
+    const products = await Product.find({ shop: { $in: shopIds } });
+    res.json(products);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch products' });
+  }
+};
+
+exports.getProductById = async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id);
+    if (!product) return res.status(404).json({ error: 'Product not found' });
+    res.json(product);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch product' });
+  }
+};

--- a/server/models/Interest.js
+++ b/server/models/Interest.js
@@ -1,0 +1,20 @@
+const mongoose = require("mongoose");
+
+const interestSchema = new mongoose.Schema(
+  {
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    businessId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    productId: { type: mongoose.Schema.Types.ObjectId, ref: "Product", required: true },
+    shopId: { type: mongoose.Schema.Types.ObjectId, ref: "Shop", required: true },
+    quantity: { type: Number, default: 1 },
+    status: {
+      type: String,
+      enum: ["pending", "accepted", "rejected", "cancelled", "completed"],
+      default: "pending",
+    },
+    createdAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("Interest", interestSchema);

--- a/server/models/Product.js
+++ b/server/models/Product.js
@@ -5,9 +5,10 @@ const productSchema = new mongoose.Schema(
     shop: { type: mongoose.Schema.Types.ObjectId, ref: "Shop", required: true },
     name: { type: String, required: true },
     description: { type: String, default: "" },
-    quantity: { type: String, required: true },
-    category: { type: String, enum: ["all", "sale"], default: "all" },
+    price: { type: Number, required: true },
+    category: { type: String, default: "general" },
     image: { type: String, default: "" },
+    stock: { type: Number, default: 0 },
   },
   { timestamps: true }
 );

--- a/server/routes/interestRoutes.js
+++ b/server/routes/interestRoutes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+const protect = require('../middleware/authMiddleware');
+const {
+  createInterest,
+  getMyInterests,
+  getReceivedInterests,
+  acceptInterest,
+  rejectInterest,
+  cancelInterest,
+} = require('../controllers/interestController');
+
+router.post('/', protect, createInterest);
+router.get('/my', protect, getMyInterests);
+router.get('/received', protect, getReceivedInterests);
+router.post('/:id/accept', protect, acceptInterest);
+router.post('/:id/reject', protect, rejectInterest);
+router.post('/:id/cancel', protect, cancelInterest);
+
+module.exports = router;

--- a/server/routes/productRoutes.js
+++ b/server/routes/productRoutes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const router = express.Router();
+const protect = require('../middleware/authMiddleware');
+const {
+  createProduct,
+  updateProduct,
+  deleteProduct,
+  getMyProducts,
+  getProductById,
+} = require('../controllers/productController');
+
+router.post('/', protect, createProduct);
+router.put('/:id', protect, updateProduct);
+router.delete('/:id', protect, deleteProduct);
+router.get('/my', protect, getMyProducts);
+router.get('/:id', protect, getProductById);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -14,6 +14,8 @@ const specialShopRoutes = require("./routes/specialShopRoutes");
 const notificationRoutes = require("./routes/notificationRoutes");
 const orderRoutes = require("./routes/orderRoutes");
 const adminRoutes = require("./routes/adminRoutes");
+const productRoutes = require("./routes/productRoutes");
+const interestRoutes = require("./routes/interestRoutes");
 
 const app = express();
 app.use(cors());
@@ -30,6 +32,8 @@ app.use("/api/special-shop", specialShopRoutes);
 app.use("/api/notifications", notificationRoutes);
 app.use("/api/orders", orderRoutes);
 app.use("/api/admin", adminRoutes);
+app.use("/api/products", productRoutes);
+app.use("/api/interests", interestRoutes);
 
 mongoose
   .connect(process.env.MONGO_URI)


### PR DESCRIPTION
## Summary
- add product and interest schemas
- implement product/interest controllers and routes
- expose new APIs in server
- manage products with Redux on frontend
- add pages for interest flows
- allow expressing interest in shop products

## Testing
- `npm --prefix client run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix server test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687e06fe34d08332a3ac7fa95cb30a42