### PR TITLE
Fix add product modal

### DIFF
--- a/server/controllers/productController.js
+++ b/server/controllers/productController.js
@@ -3,12 +3,19 @@ const Shop = require('../models/Shop');
 
 exports.createProduct = async (req, res) => {
   try {
-    const { name, description, price, category, image, stock, shopId } = req.body;
-    const shop = await Shop.findOne({ _id: shopId, owner: req.user._id });
+    const { name, description, price, category, image, stock } = req.body;
+    if (!name || price === undefined) {
+      return res.status(400).json({ error: 'Name and price are required' });
+    }
+    if (price <= 0) {
+      return res.status(400).json({ error: 'Price must be greater than 0' });
+    }
+
+    const shop = await Shop.findOne({ owner: req.user._id });
     if (!shop) return res.status(404).json({ error: 'Shop not found' });
 
     const product = await Product.create({
-      shop: shopId,
+      shop: shop._id,
       name,
       description,
       price,
@@ -32,7 +39,12 @@ exports.updateProduct = async (req, res) => {
     const { name, description, price, category, image, stock } = req.body;
     if (name !== undefined) product.name = name;
     if (description !== undefined) product.description = description;
-    if (price !== undefined) product.price = price;
+    if (price !== undefined) {
+      if (price <= 0) {
+        return res.status(400).json({ error: 'Price must be greater than 0' });
+      }
+      product.price = price;
+    }
     if (category !== undefined) product.category = category;
     if (image !== undefined) product.image = image;
     if (stock !== undefined) product.stock = stock;


### PR DESCRIPTION
## Summary
- hook up loader for Manage Products page
- add validation and modal for adding products
- link new products to business owner automatically
- validate product price on update

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_687e0ee27c608332aac7f481db53d919