### PR TITLE
Implement global theme system

### DIFF
--- a/client/src/components/ThemeProvider.tsx
+++ b/client/src/components/ThemeProvider.tsx
@@ -1,0 +1,13 @@
+import { useEffect, type ReactNode } from 'react';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../store';
+
+const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const theme = useSelector((state: RootState) => state.theme);
+  useEffect(() => {
+    document.body.className = `theme-${theme}`;
+  }, [theme]);
+  return <>{children}</>;
+};
+
+export default ThemeProvider;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,11 +7,14 @@ import 'slick-carousel/slick/slick-theme.css'
 import './styles/main.scss';
 import App from './App.tsx'
 import { store } from './store'
+import ThemeProvider from './components/ThemeProvider';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Provider store={store}>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </Provider>
   </StrictMode>,
 )

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -5,6 +5,8 @@ import { motion } from 'framer-motion';
 import { FiLogOut, FiShoppingCart, FiSettings, FiShoppingBag, FiPackage, FiUserCheck, FiUsers } from 'react-icons/fi';
 import type { RootState } from '../../store';
 import { setUser, clearUser } from '../../store/slices/userSlice';
+import { setTheme, type Theme } from '../../store/slices/themeSlice';
+import type { AppDispatch } from '../../store';
 import {
   getCurrentUser,
   updateProfile,
@@ -14,10 +16,8 @@ import {
 import styles from './Profile.module.scss';
 import Loader from '../../components/Loader';
 
-export type Theme = 'colored' | 'light' | 'dark';
-
 const Profile = () => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
   const user = useSelector((state: RootState) => state.user as any);
 
@@ -29,7 +29,7 @@ const Profile = () => {
   const [showBusiness, setShowBusiness] = useState(false);
   const [businessForm, setBusinessForm] = useState({ name: '', category: '', location: '', address: '' });
   const [submitting, setSubmitting] = useState(false);
-  const [theme, setTheme] = useState<Theme>('colored');
+  const theme = useSelector((state: RootState) => state.theme as Theme);
 
   useEffect(() => {
     const loadUser = async () => {
@@ -111,7 +111,11 @@ const Profile = () => {
   return (
     <div className={`${styles.profile} ${styles[theme]}`}>
       <motion.div className={styles.userCard} initial={{ opacity: 0, y: 30 }} animate={{ opacity: 1, y: 0 }}>
-        <select className={styles.themeSelect} value={theme} onChange={(e) => setTheme(e.target.value as Theme)}>
+        <select
+          className={styles.themeSelect}
+          value={theme}
+          onChange={(e) => dispatch(setTheme(e.target.value as Theme))}
+        >
           <option value="colored">Colored</option>
           <option value="light">Light</option>
           <option value="dark">Dark</option>

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -2,12 +2,14 @@ import { configureStore } from '@reduxjs/toolkit';
 import userReducer from './slices/userSlice';
 import cartReducer from './slices/cartSlice';
 import productReducer from './slices/productSlice';
+import themeReducer from './slices/themeSlice';
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
     cart: cartReducer,
     products: productReducer,
+    theme: themeReducer,
   },
 });
 

--- a/client/src/store/slices/themeSlice.ts
+++ b/client/src/store/slices/themeSlice.ts
@@ -1,0 +1,20 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export type Theme = 'colored' | 'light' | 'dark';
+
+const stored = (localStorage.getItem('theme') as Theme) || 'colored';
+
+const themeSlice = createSlice({
+  name: 'theme',
+  initialState: stored as Theme,
+  reducers: {
+    setTheme(_state, action: PayloadAction<Theme>) {
+      localStorage.setItem('theme', action.payload);
+      return action.payload;
+    },
+  },
+});
+
+export const { setTheme } = themeSlice.actions;
+export default themeSlice.reducer;
+export type ThemeState = ReturnType<typeof themeSlice.reducer>;

--- a/client/src/styles/_base.scss
+++ b/client/src/styles/_base.scss
@@ -1,9 +1,22 @@
 body {
   font-family: $font-body;
-  color: #111;
-  background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
   min-height: 100vh;
   line-height: 1.5;
+}
+
+body.theme-colored {
+  background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
+  color: #111;
+}
+
+body.theme-light {
+  background: #f7f7f7;
+  color: #111;
+}
+
+body.theme-dark {
+  background: #111;
+  color: #f7f7f7;
 }
 
 h1,


### PR DESCRIPTION
## Summary
- introduce `themeSlice` for persisting light/dark/colored themes
- add `ThemeProvider` to apply theme classes on `body`
- wire theme slice into Redux store and main App
- update Profile to use global theme state
- define theme styles in `_base.scss`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687e6d907278833291f8ba3555baa3bb