### PR TITLE
Add rich shop details view and reusable product cards

### DIFF
--- a/client/src/components/ProductCard/ProductCard.module.scss
+++ b/client/src/components/ProductCard/ProductCard.module.scss
@@ -1,0 +1,61 @@
+@import "../../styles/mixins";
+@import "../../styles/variables";
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: translateY(-3px);
+  }
+
+  img {
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
+  }
+
+  .info {
+    padding: 0.75rem;
+
+    h4 {
+      margin: 0.25rem 0;
+      font-size: 1.1rem;
+    }
+
+    .price {
+      font-weight: 600;
+      color: #111;
+    }
+
+    .desc {
+      font-size: 0.85rem;
+      color: #555;
+    }
+
+    .stock {
+      font-size: 0.85rem;
+      color: #777;
+    }
+  }
+
+  .actions {
+    margin-top: auto;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    padding: 0.75rem;
+
+    button {
+      @include button-style($primary-color, #fff);
+      padding: 0.4rem 0.8rem;
+    }
+  }
+}

--- a/client/src/components/ProductCard/ProductCard.tsx
+++ b/client/src/components/ProductCard/ProductCard.tsx
@@ -1,0 +1,92 @@
+import { motion } from 'framer-motion';
+import { useDispatch } from 'react-redux';
+import api from '../../api/client';
+import { addToCart } from '../../store/slices/cartSlice';
+import fallbackImage from '../../assets/no-image.svg';
+import styles from './ProductCard.module.scss';
+
+export interface BasicProduct {
+  _id: string;
+  name: string;
+  price: number;
+  description?: string;
+  image?: string;
+  stock?: number;
+}
+
+interface Props {
+  product: BasicProduct;
+  showActions?: boolean;
+  onAddToCart?: () => void;
+  onShowInterest?: () => void;
+  onClick?: () => void;
+  className?: string;
+}
+
+const ProductCard = ({
+  product,
+  showActions = true,
+  onAddToCart,
+  onShowInterest,
+  onClick,
+  className = '',
+}: Props) => {
+  const dispatch = useDispatch();
+
+  const handleAdd = async () => {
+    try {
+      await api.post('/cart', { productId: product._id, quantity: 1 });
+      dispatch(
+        addToCart({
+          id: product._id,
+          name: product.name,
+          price: product.price,
+          quantity: 1,
+          image: product.image,
+        })
+      );
+    } catch {
+      alert('Failed to add to cart');
+    }
+  };
+
+  const handleInterest = async () => {
+    try {
+      await api.post(`/interests/${product._id}`, { quantity: 1 });
+      alert('Interest sent');
+    } catch {
+      alert('Failed to send interest');
+    }
+  };
+
+  return (
+    <motion.div
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      className={`${styles.card} ${className}`}
+      onClick={onClick}
+    >
+      <img
+        src={product.image || 'https://via.placeholder.com/200'}
+        alt={product.name}
+        onError={(e) => (e.currentTarget.src = fallbackImage)}
+      />
+      <div className={styles.info}>
+        <h4>{product.name}</h4>
+        <p className={styles.price}>₹{product.price}</p>
+        {product.description && <p className={styles.desc}>{product.description}</p>}
+        {product.stock !== undefined && (
+          <p className={styles.stock}>Available: {product.stock}</p>
+        )}
+      </div>
+      {showActions && (
+        <div className={styles.actions} onClick={(e) => e.stopPropagation()}>
+          <button onClick={onAddToCart || handleAdd}>Add to Cart</button>
+          <button onClick={onShowInterest || handleInterest}>Interested</button>
+        </div>
+      )}
+    </motion.div>
+  );
+};
+
+export default ProductCard;

--- a/client/src/data/sampleData.ts
+++ b/client/src/data/sampleData.ts
@@ -8,6 +8,8 @@ export const sampleShops = [
     address: '123 Main St, Town Center',
     isOpen: true,
     image: 'https://source.unsplash.com/400x300/?cafe,coffee',
+    banner: 'https://source.unsplash.com/600x250/?coffee,shop',
+    description: 'Cozy place for freshly brewed coffee and snacks.',
     products: [
       {
         _id: 'p1',

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../../api/client";
 import Shimmer from "../../components/Shimmer";
+import ProductCard from "../../components/ProductCard/ProductCard";
 import {
   sampleOffers,
   sampleVerifiedUsers,
@@ -146,49 +147,52 @@ const Section = ({ title, data, type, navigate, settings, loading }: SectionProp
           key={item?._id || idx}
           className="card"
           whileHover={{ scale: 1.03 }}
-          onClick={() =>
-            !loading &&
-            navigate(
-              type === "product"
-                ? `/product/${item._id}`
-                : type === "user"
-                ? `/verified-users/${item._id}`
-                : `/events/${item._id}`
-            )
-          }
         >
           {loading ? (
             <>
               <Shimmer className="rounded" style={{ height: 150 }} />
               <div className="card-info">
-                <Shimmer style={{ height: 16, marginTop: 8, width: "60%" }} />
-                {type === "event" && (
-                  <Shimmer style={{ height: 14, marginTop: 4, width: "40%" }} />
+                <Shimmer style={{ height: 16, marginTop: 8, width: '60%' }} />
+                {type === 'event' && (
+                  <Shimmer style={{ height: 14, marginTop: 4, width: '40%' }} />
                 )}
               </div>
             </>
+          ) : type === 'product' ? (
+            <ProductCard
+              product={item}
+              showActions={false}
+              onClick={() => navigate(`/product/${item._id}`)}
+            />
           ) : (
             <>
               <img
                 src={item.image}
                 alt={item.name || item.title}
                 onError={(e) => (e.currentTarget.src = fallbackImage)}
+                onClick={() =>
+                  navigate(
+                    type === 'user'
+                      ? `/verified-users/${item._id}`
+                      : `/events/${item._id}`
+                  )
+                }
               />
               <div className="card-info">
                 <h4>{item.name || item.title}</h4>
-                {type === "event" && (
+                {type === 'event' && (
                   <p>
                     Ends in {Math.ceil(
-                      (new Date(item.startDate || item.date).getTime() - Date.now()) /
+                      (new Date(item.startDate || item.date).getTime() -
+                        Date.now()) /
                         (1000 * 60 * 60 * 24)
-                    )}{" "}
+                    )}{' '}
                     days
                   </p>
                 )}
               </div>
             </>
           )}
-       
         </motion.div>
       ))}
     </Slider>

--- a/client/src/pages/ManageProducts/ManageProducts.module.scss
+++ b/client/src/pages/ManageProducts/ManageProducts.module.scss
@@ -6,10 +6,11 @@
   gap: 1rem;
   flex-wrap: wrap;
 }
-.card {
-  border: 1px solid #ddd;
-  padding: 1rem;
-  border-radius: 4px;
+.cardWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
 }
 .actions {
   display: flex;

--- a/client/src/pages/ManageProducts/ManageProducts.tsx
+++ b/client/src/pages/ManageProducts/ManageProducts.tsx
@@ -9,6 +9,7 @@ import {
   type Product,
 } from '../../store/slices/productSlice';
 import Loader from '../../components/Loader';
+import ProductCard from '../../components/ProductCard/ProductCard';
 import styles from './ManageProducts.module.scss';
 
 const emptyForm: Partial<Product> = { name: '', description: '', price: 0, category: '', image: '', stock: 0 };
@@ -69,9 +70,8 @@ const ManageProducts = () => {
       {loading && <p>Loading...</p>}
       <div className={styles.grid}>
         {items.map((p) => (
-          <div key={p._id} className={styles.card}>
-            <h4>{p.name}</h4>
-            <p>₹{p.price}</p>
+          <div key={p._id} className={styles.cardWrapper}>
+            <ProductCard product={p} showActions={false} />
             <div className={styles.actions}>
               <button onClick={() => openEdit(p)}>Edit</button>
               <button onClick={() => dispatch(deleteProduct(p._id))}>Delete</button>

--- a/client/src/pages/ShopDetails/ShopDetails.scss
+++ b/client/src/pages/ShopDetails/ShopDetails.scss
@@ -7,7 +7,7 @@
     align-items: center;
     gap: 1rem;
 
-    img {
+    .banner {
       width: 100%;
       max-height: 250px;
       object-fit: cover;
@@ -26,6 +26,10 @@
         margin: 0.2rem 0;
         color: #555;
       }
+
+      .desc {
+        margin-top: 0.5rem;
+      }
     }
   }
 
@@ -40,41 +44,10 @@
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   }
 
-  .product-card {
-    background: white;
+  .placeholder-card {
+    background: #fff;
     padding: 1rem;
     border-radius: 12px;
-    text-align: center;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-
-    img {
-      width: 100%;
-      height: 120px;
-      object-fit: cover;
-      border-radius: 8px;
-    }
-
-    h4 {
-      margin: 0.5rem 0 0.2rem;
-    }
-
-    p {
-      color: #333;
-      margin-bottom: 0.5rem;
-    }
-
-    button {
-      padding: 0.4rem 1rem;
-      background-color: #0070f3;
-      color: white;
-      border: none;
-      border-radius: 6px;
-      cursor: pointer;
-      transition: background 0.2s ease;
-
-      &:hover {
-        background-color: #0056c7;
-      }
-    }
   }
 }

--- a/client/src/pages/ShopDetails/ShopDetails.tsx
+++ b/client/src/pages/ShopDetails/ShopDetails.tsx
@@ -1,19 +1,11 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import api from '../../api/client';
 import { sampleShops } from '../../data/sampleData';
-import { useDispatch } from 'react-redux';
-import { addToCart } from '../../store/slices/cartSlice';
-import Shimmer from "../../components/Shimmer";
-import "./ShopDetails.scss";
-import fallbackImage from "../../assets/no-image.svg";
-
-interface Product {
-  _id: string;
-  name: string;
-  price: number;
-  image?: string;
-}
+import Shimmer from '../../components/Shimmer';
+import ProductCard, { BasicProduct } from '../../components/ProductCard/ProductCard';
+import './ShopDetails.scss';
+import fallbackImage from '../../assets/no-image.svg';
 
 interface Shop {
   _id: string;
@@ -22,18 +14,16 @@ interface Shop {
   location: string;
   address: string;
   image?: string;
+  banner?: string;
+  description?: string;
   owner?: string;
-  products: Product[];
 }
 
 const ShopDetails = () => {
   const { id } = useParams();
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
 
   const [shop, setShop] = useState<Shop | null>(null);
-  const [products, setProducts] = useState<Product[]>([]);
-  const [quantities, setQuantities] = useState<Record<string, number>>({});
+  const [products, setProducts] = useState<BasicProduct[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -66,10 +56,10 @@ const ShopDetails = () => {
         <h3 className="section-title">Products</h3>
         <div className="product-list">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="product-card">
+            <div key={i} className="placeholder-card">
               <Shimmer className="rounded" style={{ height: 120 }} />
               <Shimmer style={{ height: 16, marginTop: 8 }} />
-              <Shimmer style={{ height: 16, width: "50%", marginBottom: 8 }} />
+              <Shimmer style={{ height: 16, width: '50%', marginBottom: 8 }} />
             </div>
           ))}
         </div>
@@ -80,7 +70,8 @@ const ShopDetails = () => {
     <div className="shop-details">
       <div className="header">
         <img
-          src={shop.image || "https://via.placeholder.com/500x250"}
+          className="banner"
+          src={shop.banner || shop.image || 'https://via.placeholder.com/500x250'}
           alt={shop.name}
           onError={(e) => (e.currentTarget.src = fallbackImage)}
         />
@@ -89,41 +80,14 @@ const ShopDetails = () => {
           <p>{shop.category}</p>
           <p>{shop.location}</p>
           <p>{shop.address}</p>
+          {shop.description && <p className="desc">{shop.description}</p>}
         </div>
       </div>
 
       <h3 className="section-title">Products</h3>
       <div className="product-list">
         {products.map((product) => (
-          <div key={product._id} className="product-card">
-            <img
-              src={product.image || "https://via.placeholder.com/200"}
-              alt={product.name}
-              onError={(e) => (e.currentTarget.src = fallbackImage)}
-            />
-            <h4>{product.name}</h4>
-            <p>₹{product.price}</p>
-            <input
-              type="number"
-              min={1}
-              value={quantities[product._id] || 1}
-              onChange={(e) =>
-                setQuantities({ ...quantities, [product._id]: Number(e.target.value) })
-              }
-            />
-            <button
-              onClick={() =>
-                api.post('/interests/', {
-                  productId: product._id,
-                  quantity: quantities[product._id] || 1,
-                  businessId: shop?.owner,
-                  shopId: shop?._id,
-                })
-              }
-            >
-              I'm Interested
-            </button>
-          </div>
+          <ProductCard key={product._id} product={product} />
         ))}
       </div>
     </div>

--- a/client/src/pages/SpecialShop/SpecialShop.tsx
+++ b/client/src/pages/SpecialShop/SpecialShop.tsx
@@ -1,12 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import { motion } from 'framer-motion';
 import api from '../../api/client';
 import { sampleSpecialProducts } from '../../data/sampleHomeData';
 import Shimmer from '../../components/Shimmer';
-import { addToCart } from '../../store/slices/cartSlice';
-import fallbackImage from '../../assets/no-image.svg';
+import ProductCard from '../../components/ProductCard/ProductCard';
 import styles from './SpecialShop.module.scss';
 
 interface Product {
@@ -23,7 +20,6 @@ const SpecialShop = () => {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState('');
-  const dispatch = useDispatch();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -81,39 +77,11 @@ const SpecialShop = () => {
               <Shimmer style={{ height: 16, marginTop: 8, width: '60%' }} />
             </div>
           ) : (
-            <motion.div
-              whileHover={{ scale: 1.02 }}
+            <ProductCard
               key={p._id}
-              className={styles.card}
-            >
-              <img
-                src={p.image || 'https://via.placeholder.com/200'}
-                alt={p.name}
-                onError={(e) => (e.currentTarget.src = fallbackImage)}
-                onClick={() => navigate(`/product/${p._id}`)}
-              />
-              <h3 className={styles.name}>{p.name}</h3>
-              {p.description && <p className={styles.desc}>{p.description}</p>}
-              <p className={styles.price}>₹{p.price}</p>
-              <motion.button
-                className={styles.add}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                onClick={() =>
-                  dispatch(
-                    addToCart({
-                      id: p._id,
-                      name: p.name,
-                      price: p.price,
-                      quantity: 1,
-                      image: p.image,
-                    })
-                  )
-                }
-              >
-                Add to Cart
-              </motion.button>
-            </motion.div>
+              product={p}
+              onClick={() => navigate(`/product/${p._id}`)}
+            />
           )
         )}
       </div>

--- a/server/controllers/interestController.js
+++ b/server/controllers/interestController.js
@@ -4,7 +4,19 @@ const Shop = require('../models/Shop');
 
 exports.createInterest = async (req, res) => {
   try {
-    const { productId, quantity, businessId, shopId } = req.body;
+    let { productId, quantity, businessId, shopId } = req.body;
+    productId = productId || req.params.productId;
+
+    if (!productId) {
+      return res.status(400).json({ error: 'Product ID required' });
+    }
+
+    const product = await Product.findById(productId);
+    if (!product) return res.status(404).json({ error: 'Product not found' });
+
+    businessId = businessId || product.createdBy;
+    shopId = shopId || product.shop;
+
     const interest = await Interest.create({
       userId: req.user._id,
       businessId,

--- a/server/controllers/shopController.js
+++ b/server/controllers/shopController.js
@@ -5,7 +5,7 @@ const { promoteToBusiness } = require("./userController");
 
 exports.createShop = async (req, res) => {
   try {
-    const { name, category, location, address, image } = req.body;
+    const { name, category, location, address, image, banner, description } = req.body;
     const owner = req.user._id;
 
     const shop = await Shop.create({
@@ -15,6 +15,8 @@ exports.createShop = async (req, res) => {
       address,
       image,
       owner,
+      banner,
+      description,
       status: "pending",
     });
     res.status(201).json({ message: "Shop created", shop });

--- a/server/models/Shop.js
+++ b/server/models/Shop.js
@@ -17,6 +17,8 @@ const shopSchema = new mongoose.Schema(
     location: { type: String, required: true },
     address: { type: String, default: "" },
     image: { type: String, default: "" },
+    banner: { type: String, default: "" },
+    description: { type: String, default: "" },
   },
   { timestamps: true }
 );

--- a/server/routes/interestRoutes.js
+++ b/server/routes/interestRoutes.js
@@ -11,6 +11,7 @@ const {
 } = require('../controllers/interestController');
 
 router.post('/', protect, createInterest);
+router.post('/:productId', protect, createInterest);
 router.get('/my', protect, getMyInterests);
 router.get('/received', protect, getReceivedInterests);
 router.post('/:id/accept', protect, acceptInterest);


### PR DESCRIPTION
## Summary
- extend `Shop` model with `banner` and `description` fields
- support posting interests via `/api/interests/:productId`
- compute shop and business ids in `createInterest`
- create `ProductCard` component used across pages
- redesign Shop Details page using new product card
- integrate product cards into Home carousel, Special Shop and Manage Products pages
- update sample shop data with banner and description

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_687fb90ae3b88332b6060f0183b01768