### PR TITLE
Fix BasicProduct import error

### DIFF
--- a/client/src/pages/ShopDetails/ShopDetails.tsx
+++ b/client/src/pages/ShopDetails/ShopDetails.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import api from '../../api/client';
 import { sampleShops } from '../../data/sampleData';
 import Shimmer from '../../components/Shimmer';
-import ProductCard, { BasicProduct } from '../../components/ProductCard/ProductCard';
+import ProductCard, { type BasicProduct } from '../../components/ProductCard/ProductCard';
 import './ShopDetails.scss';
 import fallbackImage from '../../assets/no-image.svg';
 


### PR DESCRIPTION
## Summary
- update ShopDetails to use `type` import for `BasicProduct`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687fbd5aa5d88332a8e96315b5f7c485