### PR TITLE
Fix MyOrders scss imports

### DIFF
--- a/client/src/pages/MyOrders/MyOrders.module.scss
+++ b/client/src/pages/MyOrders/MyOrders.module.scss
@@ -1,3 +1,5 @@
+@import "../../styles/variables";
+@import "../../styles/mixins";
 .myOrders {
   padding: 1rem;
 }


### PR DESCRIPTION
## Summary
- add missing style imports in `MyOrders.module.scss`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6880713436348332ad9fc5d125539a83