### PR TITLE
Add user verification request flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,6 +27,7 @@ import TabLayout from './layouts/TabLayout';
 import AdminLogin from './pages/AdminLogin/AdminLogin';
 import AdminDashboard from './pages/AdminDashboard';
 import AdminPanel from './pages/AdminPanel';
+import VerificationRequests from './pages/VerificationRequests';
 import AdminProtectedRoute from './components/AdminProtectedRoute';
 import { setUser } from './store/slices/userSlice';
 import type { AppDispatch } from './store';
@@ -56,6 +57,7 @@ function App() {
         <Route element={<AdminProtectedRoute />}>
           <Route path="/admin-dashboard" element={<AdminDashboard />} />
           <Route path="/admin-panel" element={<AdminPanel />} />
+          <Route path="/admin/verification-requests" element={<VerificationRequests />} />
         </Route>
         <Route element={<ProtectedRoute />}>
           <Route element={<TabLayout />}>

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -27,3 +27,16 @@ export const fetchPendingShops = async () => {
 export const approveShop = async (id: string) => {
   await adminApi.put(`/shops/approve/${id}`);
 };
+
+export const fetchVerificationRequests = async () => {
+  const res = await adminApi.get('/verified/requests');
+  return res.data;
+};
+
+export const acceptVerification = async (id: string) => {
+  await adminApi.post(`/verified/accept/${id}`);
+};
+
+export const rejectVerification = async (id: string) => {
+  await adminApi.post(`/verified/reject/${id}`);
+};

--- a/client/src/api/profile.ts
+++ b/client/src/api/profile.ts
@@ -36,7 +36,8 @@ export const updateProfile = async (data: UpdateProfileData) => {
 };
 
 export const requestVerification = async (data: VerifyRequest) => {
-  await api.post('/verified/apply', data);
+  const res = await api.post('/verified/apply', data);
+  return res.data;
 };
 
 export const requestBusiness = async (data: BusinessRequest) => {

--- a/client/src/pages/Profile/Profile.module.scss
+++ b/client/src/pages/Profile/Profile.module.scss
@@ -56,6 +56,21 @@
       margin-top: 0.5rem;
       @include button-style($primary-color, #fff);
     }
+
+    .status {
+      font-weight: 600;
+      margin-top: 0.5rem;
+
+      &.verified {
+        color: #22c55e;
+      }
+      &.pending {
+        color: #fbbf24;
+      }
+      &.rejected {
+        color: #ef4444;
+      }
+    }
   }
 
   .actionsGrid {

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -68,7 +68,7 @@ const Profile = () => {
     );
   }
 
-  if (user.role !== 'verified') {
+  if (!user.isVerified) {
     actions.push({ label: 'Request Verification', icon: FiUserCheck, onClick: () => setShowVerify(true) });
   }
 
@@ -89,6 +89,12 @@ const Profile = () => {
     try {
       setSubmitting(true);
       await requestVerification(verifyForm);
+      dispatch(setUser({
+        ...user,
+        profession: verifyForm.profession,
+        bio: verifyForm.bio,
+        verificationStatus: 'pending',
+      }));
       setShowVerify(false);
     } finally {
       setSubmitting(false);
@@ -126,6 +132,13 @@ const Profile = () => {
         <p>{user.phone}</p>
         <p>{user.location}</p>
         {user.address && <p>{user.address}</p>}
+        {user.isVerified ? (
+          <p className={styles.status + ' ' + styles.verified}>Verified</p>
+        ) : user.verificationStatus === 'pending' ? (
+          <p className={styles.status + ' ' + styles.pending}>Pending</p>
+        ) : user.verificationStatus === 'rejected' ? (
+          <p className={styles.status + ' ' + styles.rejected}>Rejected</p>
+        ) : null}
         <button className={styles.editBtn} onClick={() => setShowEdit(true)}>
           Edit Profile
         </button>

--- a/client/src/pages/VerificationRequests/VerificationRequests.scss
+++ b/client/src/pages/VerificationRequests/VerificationRequests.scss
@@ -1,0 +1,21 @@
+.verification-requests {
+  padding: 2rem;
+
+  ul {
+    list-style: none;
+    padding: 0;
+
+    li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.5rem 0;
+      border-bottom: 1px solid #ddd;
+
+      .actions {
+        display: flex;
+        gap: 0.5rem;
+      }
+    }
+  }
+}

--- a/client/src/pages/VerificationRequests/VerificationRequests.tsx
+++ b/client/src/pages/VerificationRequests/VerificationRequests.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import {
+  fetchVerificationRequests,
+  acceptVerification,
+  rejectVerification,
+} from '../../api/admin';
+import './VerificationRequests.scss';
+
+interface Request {
+  _id: string;
+  user: { _id: string; name: string; phone: string; profession: string; bio: string; };
+  createdAt: string;
+}
+
+const VerificationRequests = () => {
+  const [requests, setRequests] = useState<Request[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionId, setActionId] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await fetchVerificationRequests();
+        setRequests(data);
+      } catch {
+        setRequests([]);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleAccept = async (id: string) => {
+    try {
+      setActionId(id);
+      await acceptVerification(id);
+      setRequests((prev) => prev.filter((r) => r.user._id !== id));
+    } finally {
+      setActionId('');
+    }
+  };
+
+  const handleReject = async (id: string) => {
+    try {
+      setActionId(id);
+      await rejectVerification(id);
+      setRequests((prev) => prev.filter((r) => r.user._id !== id));
+    } finally {
+      setActionId('');
+    }
+  };
+
+  return (
+    <div className="verification-requests">
+      <h1>Verification Requests</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <ul>
+          {requests.map((req) => (
+            <li key={req._id}>
+              <div>
+                <strong>{req.user.name}</strong> - {req.user.phone}
+                <div>{req.user.profession}</div>
+                <div>{req.user.bio}</div>
+              </div>
+              <div className="actions">
+                <button onClick={() => handleAccept(req.user._id)} disabled={actionId === req.user._id}>
+                  {actionId === req.user._id ? '...' : 'Accept'}
+                </button>
+                <button onClick={() => handleReject(req.user._id)} disabled={actionId === req.user._id}>
+                  Reject
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default VerificationRequests;

--- a/client/src/pages/VerificationRequests/index.ts
+++ b/client/src/pages/VerificationRequests/index.ts
@@ -1,0 +1,1 @@
+export { default } from './VerificationRequests';

--- a/client/src/store/slices/userSlice.ts
+++ b/client/src/store/slices/userSlice.ts
@@ -6,6 +6,10 @@ export interface UserState {
   location: string;
   role: string;
   address?: string;
+  isVerified?: boolean;
+  verificationStatus?: string;
+  profession?: string;
+  bio?: string;
 }
 
 const initialState: UserState = {
@@ -13,6 +17,7 @@ const initialState: UserState = {
   phone: '',
   location: '',
   role: 'user',
+  isVerified: false,
 };
 
 const userSlice = createSlice({

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -40,6 +40,9 @@ exports.signup = async (req, res) => {
         address: user.address,
         role: user.role,
         isVerified: user.isVerified,
+        verificationStatus: user.verificationStatus,
+        profession: user.profession,
+        bio: user.bio,
       },
     });
   } catch (err) {
@@ -76,6 +79,9 @@ exports.login = async (req, res) => {
         location: user.location,
         address: user.address,
         isVerified: user.isVerified,
+        verificationStatus: user.verificationStatus,
+        profession: user.profession,
+        bio: user.bio,
       },
     });
   } catch (err) {

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -24,6 +24,9 @@ exports.updateProfile = async (req, res) => {
         address: updatedUser.address,
         role: updatedUser.role,
         isVerified: updatedUser.isVerified,
+        verificationStatus: updatedUser.verificationStatus,
+        profession: updatedUser.profession,
+        bio: updatedUser.bio,
       },
     });
   } catch (err) {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -13,6 +13,12 @@ const userSchema = new mongoose.Schema(
       default: "customer",
     },
     isVerified: { type: Boolean, default: false },
+    verificationStatus: {
+      type: String,
+      enum: ["pending", "verified", "rejected"],
+    },
+    profession: { type: String, default: "" },
+    bio: { type: String, default: "" },
   },
   { timestamps: true }
 );

--- a/server/routes/verifiedUserRoutes.js
+++ b/server/routes/verifiedUserRoutes.js
@@ -1,20 +1,23 @@
 const express = require("express");
 const router = express.Router();
 const protect = require("../middleware/authMiddleware");
+const protectAdmin = require("../middleware/adminAuth");
 const {
   applyForVerification,
   getAllVerifiedUsers,
   markInterest,
-  getMyRequests,
-  acceptRequest,
   getAcceptedProviders,
+  getVerificationRequests,
+  acceptVerificationRequest,
+  rejectVerificationRequest,
 } = require("../controllers/verifiedUserController");
 
 router.post("/apply", protect, applyForVerification);
 router.get("/all", protect, getAllVerifiedUsers);
 router.post("/interest/:id", protect, markInterest);
-router.get("/requests", protect, getMyRequests);
-router.post("/accept/:userId", protect, acceptRequest);
+router.get("/requests", protectAdmin, getVerificationRequests);
+router.post("/accept/:userId", protectAdmin, acceptVerificationRequest);
+router.post("/reject/:userId", protectAdmin, rejectVerificationRequest);
 router.get("/accepted", protect, getAcceptedProviders);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow users to request verification with profession and bio
- admin can list, accept or reject verification requests
- display verification status on the profile page
- add admin page to manage verification requests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in server *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6880882f5d0083328218ada068f5ae39