### PR TITLE
Use dedicated hover color variable in landing page

### DIFF
--- a/client/src/pages/LandingPage/LandingPage.scss
+++ b/client/src/pages/LandingPage/LandingPage.scss
@@ -87,7 +87,7 @@
           border: none;
 
           &:hover {
-            background: darken($primary-color, 10%);
+            background: $primary-color-hover;
           }
         }
 

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -1,4 +1,5 @@
 $primary-color: var(--color-primary);
+$primary-color-hover: var(--color-primary-hover);
 $gradient-start: #FF3E6C;
 $gradient-middle: #FF6B81;
 $gradient-end: #FF3E6C;


### PR DESCRIPTION
## Summary
- define `$primary-color-hover` Sass variable
- use hover color variable instead of `darken()` in landing page buttons

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_689d76ef47e883328ec496445a551a04