### PR TITLE
Fix improper return placement in Profile component

### DIFF
--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { FiShoppingCart, FiSettings, FiShoppingBag, FiPackage, FiUserCheck, FiUsers } from 'react-icons/fi';
 import type { RootState } from '../../store';
-import { setUser, clearUser } from '../../store/slices/userSlice';
+import { setUser } from '../../store/slices/userSlice';
 import { type Theme } from '../../store/slices/themeSlice';
 import type { AppDispatch } from '../../store';
 import {
@@ -44,8 +44,6 @@ const Profile = () => {
     };
     loadUser();
   }, [dispatch]);
-
-  };
 
   const avatar = user.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(user.name)}`;
 


### PR DESCRIPTION
## Summary
- remove stray closing brace in Profile component causing `return` outside function
- clean up unused import in user slice

## Testing
- `npm run lint`
- `npm run build` *(fails: Property 'date' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689d9f2fd940833297a2131668607954