### PR TITLE
feat: add theme tokens and price block component

### DIFF
--- a/client/src/components/ui/PriceBlock.module.scss
+++ b/client/src/components/ui/PriceBlock.module.scss
@@ -1,0 +1,20 @@
+.priceBlock {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.price {
+  font-weight: 600;
+}
+
+.mrp {
+  text-decoration: line-through;
+  color: #777;
+  font-size: var(--font-size-sm);
+}
+
+.discount {
+  color: var(--color-success);
+  font-size: var(--font-size-sm);
+}

--- a/client/src/components/ui/PriceBlock.tsx
+++ b/client/src/components/ui/PriceBlock.tsx
@@ -1,0 +1,40 @@
+import styles from './PriceBlock.module.scss';
+
+interface PriceBlockProps {
+  price: number;
+  mrp?: number;
+  discount?: number;
+  className?: string;
+}
+
+const PriceBlock = ({ price, mrp, discount, className = '' }: PriceBlockProps) => {
+  const computedDiscount =
+    discount !== undefined
+      ? discount
+      : mrp
+      ? Math.round(((mrp - price) / mrp) * 100)
+      : undefined;
+
+  return (
+    <div className={`${styles.priceBlock} ${className}`}>
+      <span className={styles.price} aria-label={`Price ₹${price}`}>
+        ₹{price}
+      </span>
+      {mrp && (
+        <span className={styles.mrp} aria-label={`MRP ₹${mrp}`}>
+          ₹{mrp}
+        </span>
+      )}
+      {computedDiscount && (
+        <span
+          className={styles.discount}
+          aria-label={`${computedDiscount}% off`}
+        >
+          {computedDiscount}% off
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default PriceBlock;

--- a/client/src/components/ui/ProductCard.module.scss
+++ b/client/src/components/ui/ProductCard.module.scss
@@ -60,21 +60,10 @@
     overflow: hidden;
   }
 
-  .priceRow {
+  .row {
     display: flex;
     align-items: center;
     gap: var(--spacing-xs);
-  }
-
-  .mrp {
-    text-decoration: line-through;
-    color: #777;
-    font-size: var(--font-size-sm);
-  }
-
-  .discount {
-    color: var(--color-success);
-    font-size: var(--font-size-sm);
   }
 }
 

--- a/client/src/components/ui/ProductCard.tsx
+++ b/client/src/components/ui/ProductCard.tsx
@@ -5,6 +5,7 @@ import api from '../../api/client';
 import { addToCart } from '../../store/slices/cartSlice';
 import fallbackImage from '../../assets/no-image.svg';
 import WishlistHeart from './WishlistHeart';
+import PriceBlock from './PriceBlock';
 import styles from './ProductCard.module.scss';
 
 export interface Product {
@@ -95,15 +96,13 @@ const ProductCard = ({
       </div>
       <div className={styles.info}>
         <h4>{product.name}</h4>
-        <div className={styles.priceRow}>
-          <span>₹{product.price}</span>
-          {product.mrp && <span className={styles.mrp}>₹{product.mrp}</span>}
-          {computedDiscount && (
-            <span className={styles.discount}>{computedDiscount}% off</span>
-          )}
-        </div>
+        <PriceBlock
+          price={product.price}
+          mrp={product.mrp}
+          discount={computedDiscount}
+        />
         {product.rating && (
-          <div className={styles.priceRow}>
+          <div className={styles.row}>
             <AiFillStar color="var(--color-warning)" />
             <span>{product.rating.toFixed(1)}</span>
           </div>

--- a/client/src/styles/_theme.scss
+++ b/client/src/styles/_theme.scss
@@ -1,23 +1,36 @@
+/**
+ * Global design tokens and theme definitions.
+ * Tokens for typography, spacing, radii and shadows live on :root
+ * so that they apply to every theme. Colour tokens are namespaced
+ * under data-theme attributes.
+ */
 :root {
+  /* Typography */
   --font-family-sans: 'Inter', 'DM Sans', sans-serif;
   --font-size-sm: 0.875rem;
   --font-size-md: 1rem;
   --font-size-lg: 1.25rem;
 
+  /* Radii */
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
 
-  --shadow-sm: 0 2px 4px rgba(0,0,0,0.08);
-  --shadow-md: 0 4px 10px rgba(0,0,0,0.1);
+  /* Shadows */
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 10px rgba(0, 0, 0, 0.1);
 
+  /* Spacing */
   --spacing-xs: 4px;
   --spacing-sm: 8px;
   --spacing-md: 16px;
   --spacing-lg: 24px;
   --spacing-xl: 32px;
+}
 
-  /* Light theme colours */
+/* Light theme (default) */
+:root,
+[data-theme='light'] {
   --color-primary: #ff3e6c;
   --color-primary-hover: #ff6b81;
   --color-text: #3a3a3a;
@@ -29,18 +42,30 @@
   --color-info: #3b82f6;
 }
 
+/* Dark theme */
 [data-theme='dark'] {
+  --color-primary: #ff3e6c;
+  --color-primary-hover: #ff6b81;
   --color-text: #f5f5f5;
   --color-surface: #1f1f1f;
   --color-card: #2b2b2b;
-  --shadow-sm: 0 2px 4px rgba(0,0,0,0.6);
-  --shadow-md: 0 4px 10px rgba(0,0,0,0.8);
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.6);
+  --shadow-md: 0 4px 10px rgba(0, 0, 0, 0.8);
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-danger: #ef4444;
+  --color-info: #3b82f6;
 }
 
+/* Colourful theme with brand accents */
 [data-theme='colorful'] {
   --color-primary: #ff9800;
   --color-primary-hover: #ffb74d;
   --color-text: #222222;
   --color-surface: #fff8e1;
   --color-card: #ffffff;
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-danger: #ef4444;
+  --color-info: #3b82f6;
 }


### PR DESCRIPTION
## Summary
- organize global design tokens with explicit light/dark/colorful themes
- add reusable `PriceBlock` component and integrate into `ProductCard`

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689e0c914828833295df62b871568818