### PR TITLE
feat: add reusable storefront components

### DIFF
--- a/client/src/components/base/FacetFilterBar.module.scss
+++ b/client/src/components/base/FacetFilterBar.module.scss
@@ -1,8 +1,14 @@
 .bar {
   display: flex;
-  overflow-x: auto;
+  align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm);
+}
+
+.categories {
+  display: flex;
+  overflow-x: auto;
+  gap: var(--spacing-sm);
 }
 
 .chip {
@@ -13,9 +19,64 @@
   color: var(--color-text);
   cursor: pointer;
   white-space: nowrap;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
 }
 
 .active {
   background: var(--color-primary);
   color: #fff;
+}
+
+.desktopFilters {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  margin-left: auto;
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.availability {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.mobileToggle {
+  display: none;
+  margin-left: auto;
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--color-primary);
+  color: #fff;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+}
+
+.priceRange {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 600px) {
+  .desktopFilters {
+    display: none;
+  }
+
+  .mobileToggle {
+    display: block;
+  }
 }

--- a/client/src/components/base/FacetFilterBar.tsx
+++ b/client/src/components/base/FacetFilterBar.tsx
@@ -1,37 +1,116 @@
-import { motion } from 'framer-motion';
+import { useState } from 'react';
+import ModalSheet from './ModalSheet';
 import styles from './FacetFilterBar.module.scss';
 
-export interface FacetFilterBarProps {
-  facets: string[];
-  active?: string;
-  onSelect: (f: string) => void;
-  onSort?: () => void;
-  onFilter?: () => void;
+export interface SortOption {
+  value: string;
+  label: string;
 }
 
-const FacetFilterBar = ({ facets, active, onSelect, onSort, onFilter }: FacetFilterBarProps) => (
-  <div className={styles.bar}>
-    {facets.map((f) => (
-      <motion.div
-        key={f}
-        className={`${styles.chip} ${active === f ? styles.active : ''}`}
-        whileTap={{ scale: 0.95 }}
-        onClick={() => onSelect(f)}
-      >
-        {f}
-      </motion.div>
-    ))}
-    {onSort && (
-      <motion.div className={styles.chip} whileTap={{ scale: 0.95 }} onClick={onSort}>
+export interface FacetFilterBarProps {
+  categories: string[];
+  activeCategory?: string;
+  onCategoryChange: (c: string) => void;
+  price: number;
+  minPrice: number;
+  maxPrice: number;
+  onPriceChange: (p: number) => void;
+  rating: number;
+  onRatingChange: (r: number) => void;
+  available: boolean;
+  onAvailabilityChange: (v: boolean) => void;
+  sort: string;
+  sortOptions: SortOption[];
+  onSortChange: (v: string) => void;
+}
+
+const FacetFilterBar = ({
+  categories,
+  activeCategory,
+  onCategoryChange,
+  price,
+  minPrice,
+  maxPrice,
+  onPriceChange,
+  rating,
+  onRatingChange,
+  available,
+  onAvailabilityChange,
+  sort,
+  sortOptions,
+  onSortChange,
+}: FacetFilterBarProps) => {
+  const [open, setOpen] = useState(false);
+
+  const filters = (
+    <div className={styles.filters}>
+      <label className={styles.priceRange}>
+        Price ₹{price}
+        <input
+          type="range"
+          min={minPrice}
+          max={maxPrice}
+          value={price}
+          onChange={(e) => onPriceChange(Number(e.target.value))}
+        />
+      </label>
+      <label>
+        Rating
+        <select value={rating} onChange={(e) => onRatingChange(Number(e.target.value))}>
+          <option value={0}>Any</option>
+          {[1, 2, 3, 4, 5].map((r) => (
+            <option key={r} value={r}>
+              {r}+
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className={styles.availability}>
+        <input
+          type="checkbox"
+          checked={available}
+          onChange={(e) => onAvailabilityChange(e.target.checked)}
+        />
+        In stock
+      </label>
+      <label>
         Sort
-      </motion.div>
-    )}
-    {onFilter && (
-      <motion.div className={styles.chip} whileTap={{ scale: 0.95 }} onClick={onFilter}>
-        Filter
-      </motion.div>
-    )}
-  </div>
-);
+        <select value={sort} onChange={(e) => onSortChange(e.target.value)}>
+          {sortOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+
+  return (
+    <>
+      <div className={styles.bar}>
+        <div className={styles.categories}>
+          {categories.map((c) => (
+            <button
+              key={c}
+              type="button"
+              className={`${styles.chip} ${activeCategory === c ? styles.active : ''}`}
+              onClick={() => onCategoryChange(c)}
+            >
+              {c}
+            </button>
+          ))}
+        </div>
+        <div className={styles.desktopFilters}>{filters}</div>
+        <button type="button" className={styles.mobileToggle} onClick={() => setOpen(true)}>
+          Filters
+        </button>
+      </div>
+      <ModalSheet open={open} onClose={() => setOpen(false)}>
+        {filters}
+      </ModalSheet>
+    </>
+  );
+};
 
 export default FacetFilterBar;

--- a/client/src/components/base/ModalSheet.module.scss
+++ b/client/src/components/base/ModalSheet.module.scss
@@ -13,4 +13,15 @@
   border-top-left-radius: var(--radius-lg);
   border-top-right-radius: var(--radius-lg);
   padding: var(--spacing-md);
+  max-height: 80vh;
+  overflow-y: auto;
+  touch-action: pan-y;
+}
+
+.handle {
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--color-text-secondary);
+  margin: 0 auto var(--spacing-md);
 }

--- a/client/src/components/base/ModalSheet.tsx
+++ b/client/src/components/base/ModalSheet.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import styles from './ModalSheet.module.scss';
 
@@ -7,23 +8,43 @@ export interface ModalSheetProps {
   children: React.ReactNode;
 }
 
-const ModalSheet = ({ open, onClose, children }: ModalSheetProps) => (
-  <AnimatePresence>
-    {open && (
-      <motion.div className={styles.overlay} initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={onClose}>
+const ModalSheet = ({ open, onClose, children }: ModalSheetProps) => {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    if (open) window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  return (
+    <AnimatePresence>
+      {open && (
         <motion.div
-          className={styles.sheet}
-          initial={{ y: '100%' }}
-          animate={{ y: 0 }}
-          exit={{ y: '100%' }}
-          transition={{ type: 'spring', stiffness: 200, damping: 20 }}
-          onClick={(e) => e.stopPropagation()}
+          className={styles.overlay}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
         >
-          {children}
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            className={styles.sheet}
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'spring', stiffness: 200, damping: 20 }}
+            drag="y"
+            dragConstraints={{ top: 0, bottom: 0 }}
+            onDragEnd={(_, info) => info.offset.y > 100 && onClose()}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className={styles.handle} />
+            {children}
+          </motion.div>
         </motion.div>
-      </motion.div>
-    )}
-  </AnimatePresence>
-);
+      )}
+    </AnimatePresence>
+  );
+};
 
 export default ModalSheet;

--- a/client/src/components/base/OrderCard.module.scss
+++ b/client/src/components/base/OrderCard.module.scss
@@ -6,19 +6,32 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-sm);
+}
+
+.thumbs {
+  display: flex;
+  gap: var(--spacing-xs);
+
+  img {
+    width: 48px;
+    height: 48px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+  }
 }
 
 .info {
   flex: 1;
   text-align: left;
-}
 
-.status {
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-  font-size: var(--font-size-sm);
-  text-transform: capitalize;
+  h4 {
+    margin: 0 0 var(--spacing-xs);
+  }
+
+  .date {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+  }
 }
 
 .actions {
@@ -32,5 +45,14 @@
     cursor: pointer;
     background: var(--color-primary);
     color: #fff;
+
+    &:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+    }
   }
+}
+
+.status {
+  margin-left: var(--spacing-sm);
 }

--- a/client/src/components/base/OrderCard.tsx
+++ b/client/src/components/base/OrderCard.tsx
@@ -1,38 +1,71 @@
-import { motion } from 'framer-motion';
 import PriceBlock from './PriceBlock';
+import StatusChip, { Status } from '../ui/StatusChip';
 import styles from './OrderCard.module.scss';
 
+export interface OrderItem {
+  id: string;
+  title: string;
+  image: string;
+}
+
 export interface OrderCardProps {
-  order: any;
-  onCancel?: () => void;
+  items: OrderItem[];
+  shop: string;
+  date: string; // ISO string
+  status: Status;
+  quantity: number;
+  total: number;
   onAccept?: () => void;
   onReject?: () => void;
+  onCall?: () => void;
   className?: string;
 }
 
-const OrderCard = ({ order, onCancel, onAccept, onReject, className = '' }: OrderCardProps) => {
-  return (
-    <motion.div whileHover={{ scale: 1.01 }} className={`${styles.card} ${className}`}>
-      {order.product?.image && (
-        <img src={order.product.image} alt={order.product.name} style={{ width: 60, height: 60, objectFit: 'cover', borderRadius: 'var(--radius-sm)' }} />
-      )}
-      <div className={styles.info}>
-        <h4>{order.product?.name}</h4>
-        {order.product?.shop?.name && <p>{order.product.shop.name}</p>}
-        <PriceBlock price={order.product?.price || 0} />
-        <p>Qty: {order.quantity}</p>
-        <p>{new Date(order.createdAt).toLocaleDateString()}</p>
+const OrderCard = ({
+  items,
+  shop,
+  date,
+  status,
+  quantity,
+  total,
+  onAccept,
+  onReject,
+  onCall,
+  className = '',
+}: OrderCardProps) => (
+  <div className={`${styles.card} ${className}`}>
+    <div className={styles.thumbs}>
+      {items.slice(0, 3).map((item) => (
+        <img key={item.id} src={item.image} alt={item.title} />
+      ))}
+    </div>
+    <div className={styles.info}>
+      <h4>{shop}</h4>
+      <p className={styles.date}>{new Date(date).toLocaleDateString()}</p>
+      <p className={styles.qty}>Qty: {quantity}</p>
+      <PriceBlock price={total} />
+    </div>
+    <StatusChip status={status} className={styles.status} />
+    {(onAccept || onReject || onCall) && (
+      <div className={styles.actions}>
+        {onCall && (
+          <button type="button" onClick={onCall} aria-label="Call shop">
+            Call
+          </button>
+        )}
+        {onAccept && (
+          <button type="button" onClick={onAccept} aria-label="Accept order">
+            Accept
+          </button>
+        )}
+        {onReject && (
+          <button type="button" onClick={onReject} aria-label="Reject order">
+            Reject
+          </button>
+        )}
       </div>
-      <span className={styles.status}>{order.status}</span>
-      {(onCancel || onAccept || onReject) && (
-        <div className={styles.actions}>
-          {onCancel && <button onClick={onCancel}>Cancel</button>}
-          {onAccept && <button onClick={onAccept}>Accept</button>}
-          {onReject && <button onClick={onReject}>Reject</button>}
-        </div>
-      )}
-    </motion.div>
-  );
-};
+    )}
+  </div>
+);
 
 export default OrderCard;

--- a/client/src/components/base/ProductCard.module.scss
+++ b/client/src/components/base/ProductCard.module.scss
@@ -53,26 +53,29 @@
     font-size: var(--font-size-md);
     font-weight: 600;
     margin: 0 0 var(--spacing-xs);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 }
 
-.actions {
-  display: flex;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-sm);
+.cta {
+  margin: 0 var(--spacing-sm) var(--spacing-sm);
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--color-primary);
+  color: #fff;
+  cursor: pointer;
+  transition: background var(--transition-fast);
 
-  button {
-    flex: 1;
-    padding: 0.4rem 0.8rem;
-    border: none;
-    border-radius: var(--radius-sm);
-    background: var(--color-primary);
-    color: #fff;
-    cursor: pointer;
-    transition: background var(--transition-fast);
+  &:hover {
+    background: var(--color-primary-hover);
+  }
 
-    &:hover {
-      background: var(--color-primary-hover);
-    }
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 }

--- a/client/src/components/base/ProductCard.tsx
+++ b/client/src/components/base/ProductCard.tsx
@@ -1,116 +1,49 @@
-import { motion } from 'framer-motion';
-import { AiFillStar } from 'react-icons/ai';
-import { useDispatch } from 'react-redux';
-import api from '../../api/client';
-import { addToCart } from '../../store/slices/cartSlice';
-import fallbackImage from '../../assets/no-image.svg';
-import WishlistHeart from '../ui/WishlistHeart';
 import PriceBlock from './PriceBlock';
+import WishlistHeart from '../ui/WishlistHeart';
 import styles from './ProductCard.module.scss';
 
 export interface Product {
-  _id: string;
-  name: string;
+  id: string;
+  title: string;
+  image: string;
   price: number;
   mrp?: number;
   discount?: number;
-  image?: string;
-  rating?: number;
-  description?: string;
-  stock?: number;
 }
 
-interface Props {
+interface ProductCardProps {
   product: Product;
-  showActions?: boolean;
-  onAddToCart?: () => void;
-  onPlaceOrder?: () => void;
+  ctaLabel: string;
+  onCtaClick: (product: Product) => void;
   onClick?: () => void;
   className?: string;
 }
 
-const ProductCard = ({
-  product,
-  showActions = true,
-  onAddToCart,
-  onPlaceOrder,
-  onClick,
-  className = '',
-}: Props) => {
-  const dispatch = useDispatch();
-
-  const handleAdd = async () => {
-    try {
-      await api.post('/cart', { productId: product._id, quantity: 1 });
-      dispatch(
-        addToCart({
-          id: product._id,
-          name: product.name,
-          price: product.price,
-          quantity: 1,
-          image: product.image,
-        })
-      );
-    } catch {
-      alert('Failed to add to cart');
-    }
-  };
-
-  const handleOrder = async () => {
-    try {
-      const qty = parseInt(prompt('Quantity', '1') || '1', 10);
-      await api.post(`/orders/place/${product._id}`, { quantity: qty });
-      alert('Order request sent');
-    } catch {
-      alert('Failed to send order');
-    }
-  };
-
-  const computedDiscount =
-    product.discount !== undefined
-      ? product.discount
-      : product.mrp
-      ? Math.round(((product.mrp - product.price) / product.mrp) * 100)
-      : undefined;
-
+const ProductCard = ({ product, ctaLabel, onCtaClick, onClick, className = '' }: ProductCardProps) => {
   return (
-    <motion.div
-      whileHover={{ scale: 1.01 }}
-      whileTap={{ scale: 0.98 }}
-      className={`${styles.card} ${className}`}
-      onClick={onClick}
-    >
+    <div className={`${styles.card} ${className}`} onClick={onClick}>
       <div className={styles.imageWrapper}>
-        <img
-          src={product.image || 'https://via.placeholder.com/200'}
-          alt={product.name}
-          loading="lazy"
-          onError={(e) => (e.currentTarget.src = fallbackImage)}
-        />
-        {computedDiscount && (
-          <span className={styles.badge}>{computedDiscount}% OFF</span>
-        )}
+        <img src={product.image} alt={product.title} loading="lazy" />
+        {product.discount && <span className={styles.badge}>{product.discount}% OFF</span>}
         <div className={styles.wishlist}>
           <WishlistHeart />
         </div>
       </div>
       <div className={styles.info}>
-        <h4>{product.name}</h4>
+        <h4>{product.title}</h4>
         <PriceBlock price={product.price} mrp={product.mrp} discount={product.discount} />
-        {product.rating && (
-          <div>
-            <AiFillStar color="var(--color-warning)" />
-            <span>{product.rating.toFixed(1)}</span>
-          </div>
-        )}
       </div>
-      {showActions && (
-        <div className={styles.actions} onClick={(e) => e.stopPropagation()}>
-          <button onClick={onAddToCart || handleAdd}>Add to Cart</button>
-          <button onClick={onPlaceOrder || handleOrder}>Order</button>
-        </div>
-      )}
-    </motion.div>
+      <button
+        type="button"
+        className={styles.cta}
+        onClick={(e) => {
+          e.stopPropagation();
+          onCtaClick(product);
+        }}
+      >
+        {ctaLabel}
+      </button>
+    </div>
   );
 };
 

--- a/client/src/components/base/QuantityStepper.module.scss
+++ b/client/src/components/base/QuantityStepper.module.scss
@@ -5,8 +5,8 @@
 }
 
 .button {
-  width: 28px;
-  height: 28px;
+  width: 44px;
+  height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -14,9 +14,19 @@
   border: 1px solid var(--color-primary);
   border-radius: var(--radius-sm);
   cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
 }
 
 .value {
-  min-width: 24px;
+  min-width: 32px;
   text-align: center;
 }

--- a/client/src/components/base/QuantityStepper.tsx
+++ b/client/src/components/base/QuantityStepper.tsx
@@ -13,11 +13,25 @@ const QuantityStepper = ({ value, min = 1, max = 99, onChange }: QuantityStepper
   const inc = () => value < max && onChange(value + 1);
   return (
     <div className={styles.stepper}>
-      <motion.button className={styles.button} whileTap={{ scale: 0.9 }} onClick={dec}>
+      <motion.button
+        type="button"
+        className={styles.button}
+        whileTap={{ scale: 0.95 }}
+        onClick={dec}
+        disabled={value <= min}
+        aria-label="Decrease quantity"
+      >
         -
       </motion.button>
       <span className={styles.value}>{value}</span>
-      <motion.button className={styles.button} whileTap={{ scale: 0.9 }} onClick={inc}>
+      <motion.button
+        type="button"
+        className={styles.button}
+        whileTap={{ scale: 0.95 }}
+        onClick={inc}
+        disabled={value >= max}
+        aria-label="Increase quantity"
+      >
         +
       </motion.button>
     </div>

--- a/client/src/layouts/TabLayout.tsx
+++ b/client/src/layouts/TabLayout.tsx
@@ -39,7 +39,7 @@ const TabLayout = () => {
 
   useEffect(() => {
     if (location.pathname === "/") navigate("/home");
-  }, [location.pathname]);
+  }, [location.pathname, navigate]);
 
   return (
     <div className="tab-layout">

--- a/client/src/pages/MyOrders/MyOrders.tsx
+++ b/client/src/pages/MyOrders/MyOrders.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import api from '../../api/client';
 import Shimmer from '../../components/Shimmer';
 import { OrderCard } from '../../components/base';
@@ -19,7 +19,7 @@ const MyOrders = () => {
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     try {
       const params = new URLSearchParams();
@@ -32,11 +32,11 @@ const MyOrders = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [status, search]);
 
   useEffect(() => {
     load();
-  }, [status, search]);
+  }, [load]);
 
   const cancel = async (id: string) => {
     await api.post(`/orders/cancel/${id}`);

--- a/client/src/pages/ReceivedOrders/ReceivedOrders.tsx
+++ b/client/src/pages/ReceivedOrders/ReceivedOrders.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import api from '../../api/client';
 import Shimmer from '../../components/Shimmer';
 import { OrderCard } from '../../components/base';
@@ -20,7 +20,7 @@ const ReceivedOrders = () => {
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     try {
       const params = new URLSearchParams();
@@ -33,11 +33,11 @@ const ReceivedOrders = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [status, search]);
 
   useEffect(() => {
     load();
-  }, [status, search]);
+  }, [load]);
 
   const act = async (id: string, action: 'accept' | 'reject') => {
     await api.post(`/orders/${action}/${id}`);

--- a/client/src/pages/UiPreview.tsx
+++ b/client/src/pages/UiPreview.tsx
@@ -1,16 +1,89 @@
+import { useState } from 'react';
 import Toolbar from '../components/ui/Toolbar';
 import SectionHeader from '../components/ui/SectionHeader';
-import PriceBlock from '../components/ui/PriceBlock';
 import StatusChip from '../components/ui/StatusChip';
+import {
+  ProductCard,
+  OrderCard,
+  FacetFilterBar,
+  QuantityStepper,
+  ModalSheet,
+  type Product,
+} from '../components/base';
 
 const UiPreview = () => {
+  const [qty, setQty] = useState(1);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [category, setCategory] = useState('All');
+  const [price, setPrice] = useState(50);
+  const [rating, setRating] = useState(0);
+  const [available, setAvailable] = useState(false);
+  const [sort, setSort] = useState('relevance');
+
+  const product: Product = {
+    id: '1',
+    title: 'Sample Product With A Very Long Name',
+    image: 'https://via.placeholder.com/300x400',
+    price: 199,
+    mrp: 299,
+    discount: 33,
+  };
+
+  const order = {
+    items: [{ id: '1', title: 'Sample', image: 'https://via.placeholder.com/80' }],
+    shop: 'Demo Shop',
+    date: new Date().toISOString(),
+    status: 'pending' as const,
+    quantity: 1,
+    total: 199,
+  };
+
   return (
     <>
       <Toolbar title={<span>Preview</span>} actions={<button>Action</button>} />
-      <div className="container" style={{ paddingTop: 'var(--space-4)' }}>
+      <div
+        className="container"
+        style={{
+          paddingTop: 'var(--space-4)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--space-4)',
+        }}
+      >
         <SectionHeader title="Featured" href="#" />
-        <PriceBlock price={199} mrp={299} />
-        <div style={{ marginTop: 'var(--space-4)', display: 'flex', gap: 'var(--space-2)' }}>
+        <ProductCard
+          product={product}
+          ctaLabel="Add to Cart"
+          onCtaClick={() => alert('Added to cart')}
+        />
+        <OrderCard {...order} />
+        <FacetFilterBar
+          categories={['All', 'Men', 'Women']}
+          activeCategory={category}
+          onCategoryChange={setCategory}
+          price={price}
+          minPrice={0}
+          maxPrice={100}
+          onPriceChange={setPrice}
+          rating={rating}
+          onRatingChange={setRating}
+          available={available}
+          onAvailabilityChange={setAvailable}
+          sort={sort}
+          sortOptions={[
+            { value: 'relevance', label: 'Relevance' },
+            { value: 'price', label: 'Price' },
+          ]}
+          onSortChange={setSort}
+        />
+        <QuantityStepper value={qty} min={1} max={5} onChange={setQty} />
+        <button type="button" onClick={() => setSheetOpen(true)}>
+          Open Sheet
+        </button>
+        <ModalSheet open={sheetOpen} onClose={() => setSheetOpen(false)}>
+          <div style={{ padding: '1rem' }}>Hello from sheet</div>
+        </ModalSheet>
+        <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
           <StatusChip status="pending" />
           <StatusChip status="accepted" />
           <StatusChip status="rejected" />


### PR DESCRIPTION
## Summary
- build reusable ProductCard with clamped title, wishlist and CTA
- add OrderCard, FacetFilterBar, QuantityStepper and ModalSheet utilities
- wire demo usages and tidy lint warnings

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689e1851923c83328866593ce0a205b0