### PR TITLE
fix: import Status type in OrderCard

### DIFF
--- a/client/src/components/base/OrderCard.tsx
+++ b/client/src/components/base/OrderCard.tsx
@@ -1,5 +1,5 @@
 import PriceBlock from './PriceBlock';
-import StatusChip, { Status } from '../ui/StatusChip';
+import StatusChip, { type Status } from '../ui/StatusChip';
 import styles from './OrderCard.module.scss';
 
 export interface OrderItem {


### PR DESCRIPTION
## Summary
- avoid runtime import of type-only Status from StatusChip

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e1ac37e148332b3bac936ff42c45b