### PR TITLE
Add animated landing hero with trust indicators

### DIFF
--- a/client/src/pages/LandingPage/LandingPage.scss
+++ b/client/src/pages/LandingPage/LandingPage.scss
@@ -2,41 +2,31 @@
 @import "../../styles/mixins";
 
 .landing-page {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh;
-  padding: 2rem;
-  background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
-  text-align: center;
+  width: 100%;
+  overflow-x: hidden;
 
-  @include respond(md) {
-    padding: 4rem;
+  .landing-toolbar {
+    background: transparent;
+    box-shadow: none;
   }
 
-  @include respond(lg) {
-    padding: 6rem;
-  }
-
-  .content {
-    max-width: 600px;
-    width: 100%;
-    animation: fadeIn 1s ease-out;
+  .hero {
+    min-height: 60vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 2rem;
+    background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
 
     @include respond(md) {
-      max-width: 700px;
-      text-align: left;
+      padding: 4rem;
     }
 
     .logo {
-      width: 120px;
-      margin: 0 auto 1.5rem;
       display: block;
-
-      @include respond(lg) {
-        width: 160px;
-        margin: 0 0 1.5rem;
-      }
+      margin: 0 0 1.5rem;
     }
 
     h1 {
@@ -57,6 +47,7 @@
       font-size: 1.1rem;
       color: #555;
       margin: 1rem 0 2rem;
+      max-width: 600px;
     }
 
     .buttons {
@@ -67,10 +58,6 @@
       @media (min-width: 600px) {
         flex-direction: row;
         justify-content: center;
-      }
-
-      @include respond(md) {
-        justify-content: flex-start;
       }
 
       button {
@@ -102,6 +89,59 @@
           }
         }
       }
+    }
+  }
+
+  .features {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 3rem 2rem;
+    text-align: center;
+
+    @include respond(md) {
+      flex-direction: row;
+      justify-content: center;
+    }
+
+    .feature-card {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      max-width: 300px;
+      margin: 0 auto;
+
+      h3 {
+        margin: 0.5rem 0 0.25rem;
+        font-size: 1.25rem;
+        font-weight: 600;
+      }
+
+      p {
+        color: #555;
+        font-size: 0.95rem;
+      }
+    }
+  }
+
+  .trust-band {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    padding: 1.5rem 2rem;
+    background: #f9f9f9;
+    text-align: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      white-space: nowrap;
     }
   }
 }

--- a/client/src/pages/LandingPage/LandingPage.tsx
+++ b/client/src/pages/LandingPage/LandingPage.tsx
@@ -1,21 +1,44 @@
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
-import "./LandingPage.scss";
-import logo from "../../assets/logo.png"; // ✅ using logo from src/assets
+import { FaStore, FaCalendarAlt, FaTags, FaStar, FaCheckCircle, FaCalendarCheck } from "react-icons/fa";
+import Toolbar from "../../components/ui/Toolbar";
+import logo from "../../assets/logo.png";
 import fallbackImage from "../../assets/no-image.svg";
+import "./LandingPage.scss";
+
+const features = [
+  { icon: FaStore, title: "Discover Shops", copy: "Find and connect with local businesses." },
+  { icon: FaCalendarAlt, title: "Attend Events", copy: "Stay updated on what's happening nearby." },
+  { icon: FaTags, title: "Exclusive Deals", copy: "Grab offers from verified merchants." },
+];
+
+const stats = [
+  { icon: FaStar, label: "4.8/5 rating" },
+  { icon: FaCheckCircle, label: "2k+ verified" },
+  { icon: FaCalendarCheck, label: "500+ events" },
+];
 
 const LandingPage = () => {
   const navigate = useNavigate();
 
   return (
     <div className="landing-page">
-      <motion.div
-        className="content"
-        initial={{ opacity: 0, y: 30 }}
+      <Toolbar title={<span>Manacity</span>} className="landing-toolbar" />
+
+      <motion.section
+        className="hero"
+        initial={{ opacity: 0, y: 40 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.7, ease: "easeOut" }}
+        transition={{ duration: 0.8, ease: "easeOut" }}
       >
-        <img src={logo} alt="Manacity Logo" className="logo" onError={(e) => (e.currentTarget.src = fallbackImage)} />
+        <img
+          src={logo}
+          alt="Manacity Logo"
+          width={160}
+          height={160}
+          className="logo"
+          onError={(e) => (e.currentTarget.src = fallbackImage)}
+        />
 
         <h1>
           Welcome to <span>Manacity</span>
@@ -41,7 +64,42 @@ const LandingPage = () => {
             Sign Up
           </motion.button>
         </div>
-      </motion.div>
+      </motion.section>
+
+      <motion.section
+        className="features"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.3 }}
+      >
+        {features.map(({ icon: Icon, title, copy }) => (
+          <motion.div
+            key={title}
+            className="feature-card"
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.5 }}
+          >
+            <Icon size={40} />
+            <h3>{title}</h3>
+            <p>{copy}</p>
+          </motion.div>
+        ))}
+      </motion.section>
+
+      <motion.section
+        className="trust-band"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.5 }}
+      >
+        {stats.map(({ icon: Icon, label }) => (
+          <div key={label} className="stat">
+            <Icon size={24} />
+            <span>{label}</span>
+          </div>
+        ))}
+      </motion.section>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add full-bleed hero with login/signup CTA
- showcase three animated feature cards
- display trust indicators for ratings, verified shops and events

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c8efe54833293777d455bb4bd9a