### PR TITLE
feat: add home page carousel sections

### DIFF
--- a/client/src/components/ui/HorizontalCarousel.module.scss
+++ b/client/src/components/ui/HorizontalCarousel.module.scss
@@ -1,0 +1,55 @@
+.wrapper {
+  position: relative;
+}
+
+.container {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  gap: var(--spacing-sm);
+  padding-bottom: var(--spacing-sm);
+  -webkit-overflow-scrolling: touch;
+}
+
+.container::-webkit-scrollbar {
+  display: none;
+}
+
+.item {
+  flex: 0 0 70%;
+  scroll-snap-align: start;
+
+  @media (min-width: 768px) {
+    flex-basis: 33.33%;
+  }
+
+  @media (min-width: 1024px) {
+    flex-basis: 25%;
+  }
+}
+
+.chevron {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.8);
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  display: none;
+  z-index: 1;
+}
+
+.left {
+  left: -0.5rem;
+}
+
+.right {
+  right: -0.5rem;
+}
+
+@media (min-width: 768px) {
+  .chevron {
+    display: block;
+  }
+}

--- a/client/src/components/ui/HorizontalCarousel.tsx
+++ b/client/src/components/ui/HorizontalCarousel.tsx
@@ -1,0 +1,50 @@
+import { ReactNode, useRef } from 'react';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+import styles from './HorizontalCarousel.module.scss';
+
+interface Props {
+  children: ReactNode[] | ReactNode;
+}
+
+const HorizontalCarousel = ({ children }: Props) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const scroll = (dir: number) => {
+    if (containerRef.current) {
+      const width = containerRef.current.clientWidth;
+      containerRef.current.scrollBy({ left: dir * width, behavior: 'smooth' });
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <button
+        type="button"
+        aria-label="previous"
+        className={`${styles.chevron} ${styles.left}`}
+        onClick={() => scroll(-1)}
+      >
+        <FaChevronLeft />
+      </button>
+      <div className={styles.container} ref={containerRef}>
+        {Array.isArray(children)
+          ? children.map((child, idx) => (
+              <div key={idx} className={styles.item}>
+                {child}
+              </div>
+            ))
+          : <div className={styles.item}>{children}</div>}
+      </div>
+      <button
+        type="button"
+        aria-label="next"
+        className={`${styles.chevron} ${styles.right}`}
+        onClick={() => scroll(1)}
+      >
+        <FaChevronRight />
+      </button>
+    </div>
+  );
+};
+
+export default HorizontalCarousel;

--- a/client/src/pages/Home/Home.scss
+++ b/client/src/pages/Home/Home.scss
@@ -63,23 +63,14 @@
   .section {
     margin-bottom: 2rem;
 
-    h2 {
-      margin-bottom: 1rem;
-      font-size: 1.5rem;
-
-      @include respond(lg) {
-        font-size: 1.75rem;
-      }
-    }
-
     .card {
       background: #fff;
       border-radius: 1rem;
       overflow: hidden;
-      margin-right: 1rem;
       cursor: pointer;
       box-shadow: 0 2px 10px rgba(0, 0, 0, 0.07);
       transition: 0.3s;
+      width: 100%;
 
       img {
         width: 100%;

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -1,19 +1,24 @@
-import "./Home.scss";
-import { motion } from "framer-motion";
-import Slider from "react-slick";
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import api from "../../api/client";
-import Shimmer from "../../components/Shimmer";
-import { ProductCard } from '../../components/base';
+import './Home.scss';
+import { motion } from 'framer-motion';
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../../api/client';
+import Shimmer from '../../components/Shimmer';
+import ProductCard from '../../components/ui/ProductCard';
+import SectionHeader from '../../components/ui/SectionHeader';
+import HorizontalCarousel from '../../components/ui/HorizontalCarousel';
 import {
   sampleOffers,
   sampleVerifiedUsers,
   sampleEvents,
   sampleSpecialProducts,
   banner,
-} from "../../data/sampleHomeData";
-import fallbackImage from "../../assets/no-image.svg";
+} from '../../data/sampleHomeData';
+import fallbackImage from '../../assets/no-image.svg';
+
+type NavigateFn = ReturnType<typeof useNavigate>;
+
+type SectionType = 'product' | 'user' | 'event';
 
 const Home = () => {
   const navigate = useNavigate();
@@ -23,34 +28,38 @@ const Home = () => {
   const [events, setEvents] = useState<any[]>([]);
   const [specialProducts, setSpecialProducts] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const fetched = useRef(false);
 
   useEffect(() => {
+    if (fetched.current) return;
+    fetched.current = true;
+
     Promise.all([
-      api.get("/home/offers"),
-      api.get("/home/verified-users"),
-      api.get("/home/events"),
-      api.get("/home/special-products"),
+      api.get('/home/offers'),
+      api.get('/home/verified-users'),
+      api.get('/home/events'),
+      api.get('/home/special-products'),
     ])
       .then(([offRes, userRes, evRes, spRes]) => {
         setOffers(
           Array.isArray(offRes.data) && offRes.data.length > 0
             ? offRes.data
-            : sampleOffers
+            : sampleOffers,
         );
         setUsers(
           Array.isArray(userRes.data) && userRes.data.length > 0
             ? userRes.data
-            : sampleVerifiedUsers
+            : sampleVerifiedUsers,
         );
         setEvents(
           Array.isArray(evRes.data) && evRes.data.length > 0
             ? evRes.data
-            : sampleEvents
+            : sampleEvents,
         );
         setSpecialProducts(
           Array.isArray(spRes.data) && spRes.data.length > 0
             ? spRes.data
-            : sampleSpecialProducts
+            : sampleSpecialProducts,
         );
       })
       .catch(() => {
@@ -62,19 +71,6 @@ const Home = () => {
       .finally(() => setLoading(false));
   }, []);
 
-  const settings = {
-    dots: false,
-    infinite: false,
-    speed: 600,
-    slidesToShow: 2,
-    slidesToScroll: 1,
-    responsive: [
-      { breakpoint: 1024, settings: { slidesToShow: 3 } },
-      { breakpoint: 768, settings: { slidesToShow: 2 } },
-      { breakpoint: 480, settings: { slidesToShow: 1 } },
-    ],
-  };
-
   return (
     <div className="home">
       {/* Admin Banner */}
@@ -85,7 +81,11 @@ const Home = () => {
         transition={{ duration: 0.6 }}
         onClick={() => banner.link && navigate(banner.link)}
       >
-        <img src={banner.image} alt="Admin Update" onError={(e) => (e.currentTarget.src = fallbackImage)} />
+        <img
+          src={banner.image}
+          alt="Admin Update"
+          onError={(e) => (e.currentTarget.src = fallbackImage)}
+        />
         <div className="banner-text">
           <h3>{banner.title}</h3>
           <p>{banner.subtitle}</p>
@@ -97,33 +97,33 @@ const Home = () => {
         title="Shop Offers"
         data={offers}
         type="product"
-        navigate={navigate}
-        settings={settings}
         loading={loading}
+        seeAll="/shops"
+        navigate={navigate}
       />
       <Section
         title="Verified Users"
         data={users}
         type="user"
-        navigate={navigate}
-        settings={settings}
         loading={loading}
+        seeAll="/verified-users"
+        navigate={navigate}
       />
       <Section
         title="Events"
         data={events}
         type="event"
-        navigate={navigate}
-        settings={settings}
         loading={loading}
+        seeAll="/events"
+        navigate={navigate}
       />
       <Section
         title="Special Shop Products"
         data={specialProducts}
         type="product"
-        navigate={navigate}
-        settings={settings}
         loading={loading}
+        seeAll="/special-shop"
+        navigate={navigate}
       />
     </div>
   );
@@ -132,70 +132,68 @@ const Home = () => {
 interface SectionProps {
   title: string;
   data: any[];
-  type: string;
-  navigate: any;
-  settings: any;
+  type: SectionType;
   loading: boolean;
+  seeAll: string;
+  navigate: NavigateFn;
 }
 
-const Section = ({ title, data, type, navigate, settings, loading }: SectionProps) => (
+const Section = ({ title, data, type, loading, seeAll, navigate }: SectionProps) => (
   <div className="section">
-    <h2>{title}</h2>
-    <Slider {...settings}>
-      {(loading ? Array.from({ length: 3 }) : data).map((item: any, idx: number) => (
-        <motion.div
-          key={item?._id || idx}
-          className="card"
-          whileHover={{ scale: 1.03 }}
-        >
-          {loading ? (
-            <>
-              <Shimmer className="rounded" style={{ height: 150 }} />
-              <div className="card-info">
-                <Shimmer style={{ height: 16, marginTop: 8, width: '60%' }} />
-                {type === 'event' && (
-                  <Shimmer style={{ height: 14, marginTop: 4, width: '40%' }} />
-                )}
-              </div>
-            </>
-          ) : type === 'product' ? (
-            <ProductCard
-              product={item}
-              showActions={false}
-              onClick={() => navigate(`/product/${item._id}`)}
+    <SectionHeader title={title} onClick={() => navigate(seeAll)} />
+    <HorizontalCarousel>
+      {(loading ? Array.from({ length: 3 }) : data).map((item: any, idx: number) =>
+        loading ? (
+          <div key={idx} className="card">
+            <Shimmer className="rounded" style={{ height: 150 }} />
+            <div className="card-info">
+              <Shimmer style={{ height: 16, marginTop: 8, width: '60%' }} />
+              {type === 'event' && (
+                <Shimmer style={{ height: 14, marginTop: 4, width: '40%' }} />
+              )}
+            </div>
+          </div>
+        ) : type === 'product' ? (
+          <ProductCard
+            key={item._id}
+            product={item}
+            showActions={false}
+            onClick={() => navigate(`/product/${item._id}`)}
+          />
+        ) : (
+          <motion.div
+            key={item._id}
+            className="card"
+            whileHover={{ scale: 1.03 }}
+          >
+            <img
+              src={item.image}
+              alt={item.name || item.title}
+              onError={(e) => (e.currentTarget.src = fallbackImage)}
+              onClick={() =>
+                navigate(
+                  type === 'user'
+                    ? `/verified-users/${item._id}`
+                    : `/events/${item._id}`,
+                )
+              }
             />
-          ) : (
-            <>
-              <img
-                src={item.image}
-                alt={item.name || item.title}
-                onError={(e) => (e.currentTarget.src = fallbackImage)}
-                onClick={() =>
-                  navigate(
-                    type === 'user'
-                      ? `/verified-users/${item._id}`
-                      : `/events/${item._id}`
-                  )
-                }
-              />
-              <div className="card-info">
-                <h4>{item.name || item.title}</h4>
-                {type === 'event' && (
-                  <p>
-                    Ends in {Math.ceil(
-                      (new Date(item.startDate || item.date).getTime() -
-                        Date.now()) /
-                        (1000 * 60 * 60 * 24)
-                    )}{' '}
-                    days
-                  </p>
-                )}
-              </div>
-            </>
-          )}
-        </motion.div>
-      ))}
-    </Slider>
+            <div className="card-info">
+              <h4>{item.name || item.title}</h4>
+              {type === 'event' && (
+                <p>
+                  Ends in {Math.ceil(
+                    (new Date(item.startDate || item.date).getTime() - Date.now()) /
+                      (1000 * 60 * 60 * 24),
+                  )}{' '}
+                  days
+                </p>
+              )}
+            </div>
+          </motion.div>
+        ),
+      )}
+    </HorizontalCarousel>
   </div>
 );
 


### PR DESCRIPTION
## Summary
- add reusable HorizontalCarousel component with scroll snapping and chevrons
- display banner, offers, verified users, events and special products on home using SectionHeader
- show skeletons while loading and avoid double fetching

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689e1e7154848332b2bbef0b2f1a36d4