### PR TITLE
feat: add sticky filterable product grid

### DIFF
--- a/client/src/pages/SpecialShop/SpecialShop.module.scss
+++ b/client/src/pages/SpecialShop/SpecialShop.module.scss
@@ -3,34 +3,61 @@
 
 .shop {
   padding: 1rem;
-  @include respond(md) { padding: 2rem; }
-
-  h2 {
-    font-size: 1.8rem;
-    margin-bottom: 1rem;
+  @include respond(md) {
+    padding: 2rem;
   }
 
-  .filters {
+  .toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: #fff;
+    padding-bottom: 0.75rem;
+    margin-bottom: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    border-bottom: 1px solid #eee;
+
+    input {
+      width: 100%;
+      padding: 0.45rem 0.6rem;
+      border-radius: 6px;
+      border: 1px solid #ccc;
+      font-size: 0.9rem;
+    }
+  }
+
+  .applied {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
     margin-bottom: 1rem;
 
-    input,
-    select {
-      padding: 0.45rem 0.6rem;
-      border-radius: 6px;
-      border: 1px solid #ccc;
-      font-size: 0.9rem;
-      flex: 1;
-      min-width: 140px;
+    .chip {
+      padding: 0.4rem 0.8rem;
+      border: none;
+      border-radius: 999px;
+      background: #f2f2f2;
+      font-size: 0.85rem;
+      cursor: pointer;
     }
   }
 
   .grid {
     display: grid;
     gap: 1rem;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
+
+    @include respond(md) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+    @include respond(lg) {
+      grid-template-columns: repeat(4, 1fr);
+    }
+    @include respond(xl) {
+      grid-template-columns: repeat(5, 1fr);
+    }
   }
 
   .card {
@@ -41,42 +68,27 @@
     display: flex;
     flex-direction: column;
     text-align: center;
-    cursor: pointer;
-    transition: transform 0.2s ease;
+  }
 
-    &:hover {
-      transform: translateY(-3px);
-    }
+  .pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 1rem;
 
-    img {
-      width: 100%;
-      height: 140px;
-      object-fit: cover;
-      border-radius: 8px;
-      margin-bottom: 0.5rem;
-    }
-
-    .name {
-      font-weight: 600;
-      margin: 0.25rem 0;
-    }
-
-    .desc {
-      font-size: 0.85rem;
-      color: #666;
-      flex: 1;
-    }
-
-    .price {
-      margin-top: 0.5rem;
-      font-weight: bold;
-      color: #111;
-    }
-
-    .add {
-      margin-top: 0.5rem;
-      @include button-style($primary-color, #fff);
+    button {
       padding: 0.4rem 0.8rem;
+      border: 1px solid #ccc;
+      background: #fff;
+      border-radius: 6px;
+      cursor: pointer;
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
     }
   }
 }
+

--- a/client/src/pages/SpecialShop/SpecialShop.tsx
+++ b/client/src/pages/SpecialShop/SpecialShop.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import api from '../../api/client';
 import { sampleSpecialProducts } from '../../data/sampleHomeData';
 import Shimmer from '../../components/Shimmer';
-import { ProductCard } from '../../components/base';
+import { FacetFilterBar, ProductCard } from '../../components/base';
 import styles from './SpecialShop.module.scss';
 
 interface Product {
@@ -13,80 +13,222 @@ interface Product {
   price: number;
   category?: string;
   image?: string;
+  rating?: number;
+  available?: boolean;
 }
 
+const SORT_OPTIONS = [
+  { value: 'relevance', label: 'Relevance' },
+  { value: 'priceAsc', label: 'Price: Low to High' },
+  { value: 'priceDesc', label: 'Price: High to Low' },
+];
+
+const PAGE_SIZE = 6;
+
 const SpecialShop = () => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
-  const [search, setSearch] = useState('');
-  const [category, setCategory] = useState('');
-  const navigate = useNavigate();
+
+  const [search, setSearch] = useState(searchParams.get('q') ?? '');
+  const [category, setCategory] = useState(searchParams.get('category') ?? '');
+  const [price, setPrice] = useState<number>(
+    Number(searchParams.get('price')) || 1000,
+  );
+  const [rating, setRating] = useState<number>(
+    Number(searchParams.get('rating')) || 0,
+  );
+  const [available, setAvailable] = useState(
+    searchParams.get('available') === '1',
+  );
+  const [sort, setSort] = useState(
+    searchParams.get('sort') || SORT_OPTIONS[0].value,
+  );
+  const [page, setPage] = useState<number>(
+    Number(searchParams.get('page')) || 1,
+  );
+
+  const minPrice = 0;
+  const maxPrice = 1000;
 
   useEffect(() => {
+    const params: Record<string, string> = {};
+    if (search) params.q = search;
+    if (category) params.category = category;
+    if (price !== maxPrice) params.price = String(price);
+    if (rating) params.rating = String(rating);
+    if (available) params.available = '1';
+    if (sort !== SORT_OPTIONS[0].value) params.sort = sort;
+    if (page > 1) params.page = String(page);
+    setSearchParams(params);
+  }, [search, category, price, rating, available, sort, page, setSearchParams]);
+
+  useEffect(() => {
+    setLoading(true);
     api
-      .get('/special-shop')
+      .get('/special-shop', {
+        params: { q: search, category, price, rating, available, sort, page },
+      })
       .then((res) => {
-        if (Array.isArray(res.data) && res.data.length > 0) {
-          setProducts(res.data);
-        } else {
-          setProducts(sampleSpecialProducts as unknown as Product[]);
-        }
+        const data =
+          Array.isArray(res.data) && res.data.length > 0
+            ? res.data
+            : (sampleSpecialProducts as unknown as Product[]);
+        setProducts(data);
       })
       .catch(() =>
-        setProducts(sampleSpecialProducts as unknown as Product[])
+        setProducts(sampleSpecialProducts as unknown as Product[]),
       )
       .finally(() => setLoading(false));
-  }, []);
+  }, [search, category, price, rating, available, sort, page]);
 
   const categories = useMemo(
-    () => Array.from(new Set(products.map((p) => p.category).filter(Boolean))),
-    [products]
+    () =>
+      Array.from(
+        new Set(
+          products
+            .map((p) => p.category)
+            .filter((c): c is string => Boolean(c)),
+        ),
+      ),
+    [products],
   );
 
   const filtered = products.filter((p) => {
     return (
       (!category || p.category === category) &&
-      p.name.toLowerCase().includes(search.toLowerCase())
+      p.name.toLowerCase().includes(search.toLowerCase()) &&
+      p.price <= price &&
+      (rating === 0 || (p.rating ?? 0) >= rating) &&
+      (!available || p.available)
     );
   });
 
+  const sorted = [...filtered].sort((a, b) => {
+    if (sort === 'priceAsc') return a.price - b.price;
+    if (sort === 'priceDesc') return b.price - a.price;
+    return 0;
+  });
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const paginated = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const appliedFilters = [
+    search && { label: `Search: ${search}`, onRemove: () => setSearch('') },
+    category && { label: category, onRemove: () => setCategory('') },
+    price !== maxPrice && {
+      label: `≤₹${price}`,
+      onRemove: () => setPrice(maxPrice),
+    },
+    rating > 0 && {
+      label: `${rating}+★`,
+      onRemove: () => setRating(0),
+    },
+    available && { label: 'In stock', onRemove: () => setAvailable(false) },
+    sort !== SORT_OPTIONS[0].value && {
+      label: SORT_OPTIONS.find((o) => o.value === sort)?.label || '',
+      onRemove: () => setSort(SORT_OPTIONS[0].value),
+    },
+  ].filter(Boolean) as { label: string; onRemove: () => void }[];
+
   return (
     <div className={styles.shop}>
-      <h2>Special Shop</h2>
-      <div className={styles.filters}>
+      <div className={styles.toolbar}>
         <input
           type="text"
           placeholder="Search products"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
         />
-        <select value={category} onChange={(e) => setCategory(e.target.value)}>
-          <option value="">All Categories</option>
-          {categories.map((c) => (
-            <option key={c} value={c}>
-              {c}
-            </option>
+        <FacetFilterBar
+          categories={categories}
+          activeCategory={category}
+          onCategoryChange={(c) => {
+            setCategory(c);
+            setPage(1);
+          }}
+          price={price}
+          minPrice={minPrice}
+          maxPrice={maxPrice}
+          onPriceChange={(p) => {
+            setPrice(p);
+            setPage(1);
+          }}
+          rating={rating}
+          onRatingChange={(r) => {
+            setRating(r);
+            setPage(1);
+          }}
+          available={available}
+          onAvailabilityChange={(v) => {
+            setAvailable(v);
+            setPage(1);
+          }}
+          sort={sort}
+          sortOptions={SORT_OPTIONS}
+          onSortChange={(v) => {
+            setSort(v);
+            setPage(1);
+          }}
+        />
+      </div>
+
+      {appliedFilters.length > 0 && (
+        <div className={styles.applied}>
+          {appliedFilters.map((f) => (
+            <button key={f.label} className={styles.chip} onClick={f.onRemove}>
+              {f.label} ✕
+            </button>
           ))}
-        </select>
-      </div>
+        </div>
+      )}
+
       <div className={styles.grid}>
-        {(loading ? Array.from({ length: 4 }) : filtered).map((p, i) =>
-          loading ? (
-            <div key={i} className={styles.card}>
-              <Shimmer className="rounded" style={{ height: 140 }} />
-              <Shimmer style={{ height: 16, marginTop: 8, width: '60%' }} />
-            </div>
-          ) : (
-            <ProductCard
-              key={p._id}
-              product={p}
-              onClick={() => navigate(`/product/${p._id}`)}
-            />
-          )
-        )}
+        {loading
+          ? Array.from({ length: PAGE_SIZE }).map((_, i) => (
+              <div key={i} className={styles.card}>
+                <Shimmer className="rounded" style={{ height: 140 }} />
+                <Shimmer style={{ height: 16, marginTop: 8, width: '60%' }} />
+              </div>
+            ))
+          : paginated.map((p) => (
+              <ProductCard
+                key={p._id}
+                product={p}
+                onClick={() => navigate(`/product/${p._id}`)}
+              />
+            ))}
       </div>
+
+      {!loading && totalPages > 1 && (
+        <div className={styles.pagination}>
+          <button
+            type="button"
+            disabled={page === 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Previous
+          </button>
+          <span>
+            Page {page} of {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            Next
+          </button>
+        </div>
+      )}
     </div>
   );
 };
 
 export default SpecialShop;
+


### PR DESCRIPTION
## Summary
- add responsive product grid with sticky toolbar and facet filters
- show applied filter chips synced to URL query
- support paginated results with skeleton loaders

## Testing
- `npm run lint`
- `npm run build` *(fails: src/pages/Events/Events.tsx(76,60): error TS18046: 'ev' is of type 'unknown'.)*

------
https://chatgpt.com/codex/tasks/task_e_689e23e52d24833282c1111cf01a99f9