### PR TITLE
feat: add shop hero and product grid

### DIFF
--- a/client/src/data/sampleData.ts
+++ b/client/src/data/sampleData.ts
@@ -10,6 +10,8 @@ export const sampleShops = [
     image: 'https://source.unsplash.com/400x300/?cafe,coffee',
     banner: 'https://source.unsplash.com/600x250/?coffee,shop',
     description: 'Cozy place for freshly brewed coffee and snacks.',
+    contact: '1234567890',
+    rating: 4.5,
     products: [
       {
         _id: 'p1',

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -22,6 +22,7 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  scroll-behavior: smooth;
 }
 
 h1 {

--- a/client/src/pages/ShopDetails/ShopDetails.scss
+++ b/client/src/pages/ShopDetails/ShopDetails.scss
@@ -1,47 +1,106 @@
 .shop-details {
-  padding: 2rem;
+  display: flex;
+  flex-direction: column;
 
-  .header {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
+  .hero {
+    width: 100%;
 
-    .banner {
+    .cover {
       width: 100%;
-      max-height: 250px;
+      height: 200px;
       object-fit: cover;
       border-radius: 12px;
     }
 
+    .content {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-top: -40px;
+      padding: 0 1rem 1rem;
+    }
+
+    .logo {
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      object-fit: cover;
+      border: 4px solid #fff;
+      background: #fff;
+    }
+
     .info {
-      text-align: center;
+      flex: 1;
 
       h2 {
-        margin: 0.5rem 0;
-        font-size: 2rem;
+        margin: 0;
+        font-size: 1.5rem;
       }
 
-      p {
-        margin: 0.2rem 0;
+      .rating {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        margin-top: 0.25rem;
+      }
+
+      .area {
+        margin-top: 0.25rem;
         color: #555;
       }
+    }
 
-      .desc {
-        margin-top: 0.5rem;
-      }
+    .call {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      background: var(--color-primary, #1a1a1a);
+      color: #fff;
+      padding: 0.5rem 0.75rem;
+      border-radius: 8px;
+      text-decoration: none;
     }
   }
 
-  .section-title {
-    margin: 2rem 0 1rem;
-    font-size: 1.5rem;
+  .filters {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    display: flex;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    background: #fff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+
+    input {
+      flex: 1;
+      padding: 0.5rem;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+    }
+
+    select {
+      padding: 0.5rem;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+    }
   }
 
-  .product-list {
+  .product-grid {
     display: grid;
     gap: 1rem;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    padding: 1rem;
+    grid-template-columns: repeat(2, 1fr);
+
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+    @media (min-width: 1024px) {
+      grid-template-columns: repeat(4, 1fr);
+    }
+    @media (min-width: 1280px) {
+      grid-template-columns: repeat(5, 1fr);
+    }
   }
 
   .placeholder-card {
@@ -51,3 +110,4 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
   }
 }
+


### PR DESCRIPTION
## Summary
- implement shop hero with cover, logo, rating, area and optional call action
- add sticky filter/sort bar and responsive product grid using ProductCard
- enable smooth scrolling and extend sample shop data

## Testing
- `npm run lint`
- `npm run build` *(fails: Property 'date' does not exist on type '{}', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689e26da6b348332b7fa8eb12ceecd36