### PR TITLE
feat: add gallery and sticky cart to product page

### DIFF
--- a/client/src/pages/ProductDetails/ProductDetails.scss
+++ b/client/src/pages/ProductDetails/ProductDetails.scss
@@ -1,59 +1,120 @@
 .product-details {
   padding: 1.5rem;
+  padding-bottom: 6rem;
 
-  .product-img {
-    width: 100%;
-    max-height: 300px;
-    object-fit: cover;
-    border-radius: 12px;
-    margin-bottom: 1.5rem;
-  }
+  .gallery {
+    .main-image {
+      width: 100%;
+      aspect-ratio: 1;
+      overflow: hidden;
+      border-radius: 12px;
 
-  .info {
-    text-align: center;
-
-    h1 {
-      font-size: 2rem;
-      margin-bottom: 0.3rem;
-    }
-
-    .meta {
-      color: #777;
-      margin-bottom: 1rem;
-    }
-
-    .price {
-      font-size: 1.5rem;
-      font-weight: bold;
-      color: #222;
-      margin-bottom: 0.5rem;
-
-      .discount {
-        color: #d63031;
-        margin-left: 0.6rem;
-        font-size: 1rem;
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
       }
     }
 
-    .desc {
-      color: #333;
-      line-height: 1.5;
-      margin-bottom: 1.5rem;
+    .thumbnails {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+      overflow-x: auto;
+
+      img {
+        width: 64px;
+        aspect-ratio: 1;
+        object-fit: cover;
+        border-radius: 8px;
+        border: 2px solid transparent;
+        cursor: pointer;
+      }
+
+      img.active {
+        border-color: #27ae60;
+      }
     }
+  }
+
+  .title {
+    font-size: 2rem;
+    margin: 1rem 0 0.5rem;
+    text-align: center;
+  }
+
+  .price-block {
+    justify-content: center;
+    margin-bottom: 1rem;
+  }
+
+  .collapsibles {
+    margin-top: 1rem;
+
+    details {
+      margin-bottom: 0.75rem;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 0.5rem 1rem;
+
+      summary {
+        cursor: pointer;
+        font-weight: 600;
+      }
+
+      p {
+        margin-top: 0.5rem;
+        color: #333;
+      }
+    }
+  }
+
+  .related {
+    margin-top: 2rem;
+  }
+
+  .cta-bar {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    background: #fff;
+    box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
 
     .add-cart-btn {
+      flex: 1;
       background-color: #27ae60;
-      color: white;
-      padding: 0.75rem 1.8rem;
+      color: #fff;
+      padding: 0.75rem;
       font-weight: 600;
       border: none;
       border-radius: 10px;
       cursor: pointer;
-      transition: all 0.2s ease;
+      transition: background 0.2s ease;
 
       &:hover {
         background-color: #1e874b;
       }
     }
   }
+
+  @media (min-width: 768px) {
+    padding-bottom: 1.5rem;
+
+    .cta-bar {
+      position: static;
+      box-shadow: none;
+      padding: 0;
+      margin-top: 1.5rem;
+
+      .add-cart-btn {
+        width: auto;
+      }
+    }
+  }
 }
+


### PR DESCRIPTION
## Summary
- implement image gallery with thumbnails and lazy loading
- add collapsible description and reviews with related product slider
- introduce sticky mobile cart bar with quantity stepper

## Testing
- `npm run lint`
- `npm run build` *(fails: Property 'date' does not exist on type '{}' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e298ac9048332a56e8e96402e077d