### PR TITLE
feat: add cart line item and summary card

### DIFF
--- a/client/src/components/base/CartSummary.module.scss
+++ b/client/src/components/base/CartSummary.module.scss
@@ -1,0 +1,48 @@
+@import '../../styles/mixins';
+@import '../../styles/variables';
+
+.summary {
+  position: sticky;
+  top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+}
+
+.total {
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  margin-top: 0.5rem;
+}
+
+.checkout {
+  @include button-style(var(--color-primary), #fff);
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+.coupon {
+  display: flex;
+  gap: 0.5rem;
+  input {
+    flex: 1;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+  button {
+    @include button-style(var(--color-primary), #fff);
+    padding: 0.5rem 1rem;
+  }
+}

--- a/client/src/components/base/CartSummary.tsx
+++ b/client/src/components/base/CartSummary.tsx
@@ -1,0 +1,61 @@
+import styles from './CartSummary.module.scss';
+
+export interface CartSummaryProps {
+  subtotal: number;
+  discount: number;
+  delivery: number;
+  coupon: string;
+  onCouponChange: (c: string) => void;
+  onApplyCoupon: () => void;
+  onCheckout: () => void;
+}
+
+const CartSummary = ({
+  subtotal,
+  discount,
+  delivery,
+  coupon,
+  onCouponChange,
+  onApplyCoupon,
+  onCheckout,
+}: CartSummaryProps) => {
+  const total = subtotal - discount + delivery;
+  return (
+    <div className={styles.summary}>
+      <div className={styles.coupon}>
+        <input
+          type="text"
+          placeholder="Coupon code"
+          value={coupon}
+          onChange={(e) => onCouponChange(e.target.value)}
+        />
+        <button type="button" onClick={onApplyCoupon} aria-label="Apply coupon">
+          Apply
+        </button>
+      </div>
+      <div className={styles.row}>
+        <span>Subtotal</span>
+        <span>₹{subtotal}</span>
+      </div>
+      {discount > 0 && (
+        <div className={styles.row}>
+          <span>Discount</span>
+          <span>-₹{discount}</span>
+        </div>
+      )}
+      <div className={styles.row}>
+        <span>Delivery</span>
+        <span>₹{delivery}</span>
+      </div>
+      <div className={styles.total}>
+        <span>Total</span>
+        <span>₹{total}</span>
+      </div>
+      <button type="button" className={styles.checkout} onClick={onCheckout}>
+        Checkout
+      </button>
+    </div>
+  );
+};
+
+export default CartSummary;

--- a/client/src/components/base/OrderLineItem.module.scss
+++ b/client/src/components/base/OrderLineItem.module.scss
@@ -1,0 +1,43 @@
+@import '../../styles/mixins';
+@import '../../styles/variables';
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+
+  img {
+    width: 64px;
+    height: 64px;
+    object-fit: cover;
+    border-radius: 4px;
+  }
+}
+
+.info {
+  flex: 1;
+}
+
+.title {
+  margin: 0 0 0.25rem 0;
+  font-size: 1rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.remove {
+  @include button-style(red, #fff);
+  padding: 0.3rem 0.6rem;
+}

--- a/client/src/components/base/OrderLineItem.tsx
+++ b/client/src/components/base/OrderLineItem.tsx
@@ -1,0 +1,37 @@
+import PriceBlock from './PriceBlock';
+import QuantityStepper from './QuantityStepper';
+import styles from './OrderLineItem.module.scss';
+
+export interface OrderLineItemProps {
+  image?: string;
+  title: string;
+  price: number;
+  quantity: number;
+  onQuantityChange: (q: number) => void;
+  onRemove: () => void;
+}
+
+const OrderLineItem = ({
+  image,
+  title,
+  price,
+  quantity,
+  onQuantityChange,
+  onRemove,
+}: OrderLineItemProps) => (
+  <div className={styles.item}>
+    {image && <img src={image} alt={title} />}
+    <div className={styles.info}>
+      <h4 className={styles.title}>{title}</h4>
+      <PriceBlock price={price} />
+    </div>
+    <div className={styles.actions}>
+      <QuantityStepper value={quantity} onChange={onQuantityChange} />
+      <button type="button" className={styles.remove} onClick={onRemove} aria-label="Remove item">
+        Remove
+      </button>
+    </div>
+  </div>
+);
+
+export default OrderLineItem;

--- a/client/src/components/base/OrderLineItemSkeleton.tsx
+++ b/client/src/components/base/OrderLineItemSkeleton.tsx
@@ -1,0 +1,17 @@
+import Shimmer from '../Shimmer';
+import styles from './OrderLineItem.module.scss';
+
+const OrderLineItemSkeleton = () => (
+  <div className={styles.item}>
+    <Shimmer width={64} height={64} />
+    <div className={styles.info}>
+      <Shimmer width="70%" height={16} style={{ marginBottom: 8 }} />
+      <Shimmer width="40%" height={16} />
+    </div>
+    <div className={styles.actions}>
+      <Shimmer width={120} height={32} />
+    </div>
+  </div>
+);
+
+export default OrderLineItemSkeleton;

--- a/client/src/components/base/index.ts
+++ b/client/src/components/base/index.ts
@@ -7,3 +7,6 @@ export { default as QuantityStepper } from './QuantityStepper';
 export { default as PriceBlock } from './PriceBlock';
 export { default as NotificationsCard } from './NotificationsCard';
 export { default as ModalSheet } from './ModalSheet';
+export { default as OrderLineItem } from './OrderLineItem';
+export { default as OrderLineItemSkeleton } from './OrderLineItemSkeleton';
+export { default as CartSummary } from './CartSummary';

--- a/client/src/pages/Cart/Cart.module.scss
+++ b/client/src/pages/Cart/Cart.module.scss
@@ -16,51 +16,19 @@
     margin-top: 2rem;
   }
 
+  .content {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    @include respond(md) {
+      grid-template-columns: 2fr 1fr;
+      align-items: flex-start;
+    }
+  }
+
   .list {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-  }
-
-  .item {
-    background: #fff;
-    border-radius: 8px;
-    padding: 0.75rem;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.05);
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-
-    img {
-      width: 50px;
-      height: 50px;
-      object-fit: cover;
-      border-radius: 4px;
-    }
-
-    justify-content: space-between;
-
-    .info {
-      flex: 1;
-      h4 {
-        margin: 0;
-        font-size: 1rem;
-      }
-      span {
-        color: #555;
-        font-size: 0.85rem;
-      }
-    }
-
-    button {
-      @include button-style(red, #fff);
-      padding: 0.3rem 0.6rem;
-    }
-  }
-
-  .total {
-    margin-top: 1rem;
-    font-weight: bold;
-    text-align: right;
   }
 }

--- a/client/src/pages/Cart/Cart.tsx
+++ b/client/src/pages/Cart/Cart.tsx
@@ -1,5 +1,10 @@
-import { QuantityStepper, PriceBlock } from '../../components/base';
+import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import {
+  OrderLineItem,
+  OrderLineItemSkeleton,
+  CartSummary,
+} from '../../components/base';
 import { removeFromCart, updateQuantity } from '../../store/slices/cartSlice';
 import type { RootState } from '../../store';
 import styles from './Cart.module.scss';
@@ -7,32 +12,66 @@ import styles from './Cart.module.scss';
 const Cart = () => {
   const items = useSelector((state: RootState) => state.cart.items);
   const dispatch = useDispatch();
-  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  const [loading, setLoading] = useState(true);
+  const [coupon, setCoupon] = useState('');
+  const [discount, setDiscount] = useState(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setLoading(false), 500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const subtotal = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  const delivery = items.length > 0 && subtotal <= 200 ? 40 : 0;
+
+  const applyCoupon = () => {
+    if (coupon.trim().toLowerCase() === 'save10') {
+      setDiscount(Math.round(subtotal * 0.1));
+    } else {
+      setDiscount(0);
+    }
+  };
 
   return (
     <div className={styles.cart}>
       <h2>Your Cart</h2>
-      {items.length === 0 ? (
+      {loading ? (
+        <div className={styles.list}>
+          {[1, 2].map((i) => (
+            <OrderLineItemSkeleton key={i} />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
         <p className={styles.empty}>Your cart is empty.</p>
       ) : (
-        <>
+        <div className={styles.content}>
           <div className={styles.list}>
             {items.map((it) => (
-              <div key={it.id} className={styles.item}>
-                {it.image && <img src={it.image} alt={it.name} />}
-                  <div className={styles.info}>
-                    <h4>{it.name}</h4>
-                    <PriceBlock price={it.price} />
-                    <QuantityStepper value={it.quantity} onChange={(q) => dispatch(updateQuantity({ id: it.id, quantity: q }))} />
-                  </div>
-                <button onClick={() => dispatch(removeFromCart(it.id))}>
-                  Remove
-                </button>
-              </div>
+              <OrderLineItem
+                key={it.id}
+                image={it.image}
+                title={it.name}
+                price={it.price}
+                quantity={it.quantity}
+                onQuantityChange={(q) =>
+                  dispatch(updateQuantity({ id: it.id, quantity: q }))
+                }
+                onRemove={() => dispatch(removeFromCart(it.id))}
+              />
             ))}
           </div>
-          <div className={styles.total}>Total: ₹{total}</div>
-        </>
+          <CartSummary
+            subtotal={subtotal}
+            discount={discount}
+            delivery={delivery}
+            coupon={coupon}
+            onCouponChange={setCoupon}
+            onApplyCoupon={applyCoupon}
+            onCheckout={() => {
+              /* placeholder */
+            }}
+          />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add reusable order line item component with price and quantity controls
- introduce sticky cart summary with coupon support and totals
- update cart page with skeleton states and accurate amount calculation

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test"*
- `npm run build` *(fails: Property 'date' does not exist on type '{}', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689e2bda81a88332af5e19642c689ce5