### PR TITLE
feat: enhance order listing with filters and grouping

### DIFF
--- a/client/src/components/base/OrderCard.tsx
+++ b/client/src/components/base/OrderCard.tsx
@@ -17,6 +17,7 @@ export interface OrderCardProps {
   total: number;
   onAccept?: () => void;
   onReject?: () => void;
+  onCancel?: () => void;
   onCall?: () => void;
   className?: string;
 }
@@ -30,6 +31,7 @@ const OrderCard = ({
   total,
   onAccept,
   onReject,
+  onCancel,
   onCall,
   className = '',
 }: OrderCardProps) => (
@@ -46,7 +48,7 @@ const OrderCard = ({
       <PriceBlock price={total} />
     </div>
     <StatusChip status={status} className={styles.status} />
-    {(onAccept || onReject || onCall) && (
+    {(onAccept || onReject || onCancel || onCall) && (
       <div className={styles.actions}>
         {onCall && (
           <button type="button" onClick={onCall} aria-label="Call shop">
@@ -61,6 +63,11 @@ const OrderCard = ({
         {onReject && (
           <button type="button" onClick={onReject} aria-label="Reject order">
             Reject
+          </button>
+        )}
+        {onCancel && (
+          <button type="button" onClick={onCancel} aria-label="Cancel order">
+            Cancel
           </button>
         )}
       </div>

--- a/client/src/pages/MyOrders/MyOrders.module.scss
+++ b/client/src/pages/MyOrders/MyOrders.module.scss
@@ -1,13 +1,46 @@
 @import "../../styles/variables";
 @import "../../styles/mixins";
+
 .myOrders {
   padding: 1rem;
 }
+
 .filters {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin-bottom: 1rem;
 }
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+
+  .chip {
+    padding: 0.4rem 0.8rem;
+    border: none;
+    border-radius: 999px;
+    background: #f2f2f2;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+}
+
+.group {
+  margin-bottom: 1rem;
+}
+
+.month {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  padding: 0.25rem 0;
+  font-weight: bold;
+  z-index: 1;
+}
+
 .empty {
   text-align: center;
   margin-top: 2rem;
@@ -19,54 +52,7 @@
 }
 
 .card {
-  border: 1px solid #ddd;
-  padding: 0.75rem;
   margin-bottom: 0.75rem;
-  border-radius: 6px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s;
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-  &:hover {
-    transform: translateY(-2px);
-  }
-
-  img {
-    width: 60px;
-    height: 60px;
-    object-fit: cover;
-    border-radius: 4px;
-  }
-
-  .info {
-    flex: 1;
-    h4 {
-      margin: 0 0 2px 0;
-    }
-    p {
-      margin: 0;
-      font-size: 0.85rem;
-    }
-  }
-
-  .status {
-    padding: 0.25rem 0.5rem;
-    font-size: 0.75rem;
-    border-radius: 4px;
-    text-transform: capitalize;
-    font-weight: bold;
-    &.pending { background: #e5e7eb; color: #555; }
-    &.accepted { background: #d1fae5; color: #065f46; }
-    &.rejected { background: #fee2e2; color: #991b1b; }
-    &.cancelled { background: #ffedd5; color: #9a3412; }
-  }
-
-  button {
-    margin-left: 0.5rem;
-    @include button-style(red, #fff);
-    padding: 0.25rem 0.5rem;
-  }
 }
 
 .browse {

--- a/client/src/pages/MyOrders/MyOrders.tsx
+++ b/client/src/pages/MyOrders/MyOrders.tsx
@@ -1,53 +1,83 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import api from '../../api/client';
 import Shimmer from '../../components/Shimmer';
 import { OrderCard } from '../../components/base';
 import fallbackImage from '../../assets/no-image.svg';
+import { type Status } from '../../components/ui/StatusChip';
 import styles from './MyOrders.module.scss';
 
 interface Order {
   _id: string;
-  product: { name: string; image?: string; shop?: { name: string } };
+  product: { name: string; image?: string; price: number; shop?: { name: string } };
   quantity: number;
-  status: string;
+  status: Status;
   createdAt: string;
 }
 
 const MyOrders = () => {
   const [list, setList] = useState<Order[]>([]);
-  const [status, setStatus] = useState('');
-  const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const params = new URLSearchParams();
-      if (status) params.append('status', status);
-      if (search) params.append('search', search);
-      const res = await api.get(`/orders/my?${params.toString()}`);
+      const res = await api.get(`/orders/my?${searchParams.toString()}`);
       setList(res.data);
     } catch {
       setList([]);
     } finally {
       setLoading(false);
     }
-  }, [status, search]);
+  }, [searchParams]);
 
   useEffect(() => {
     load();
   }, [load]);
+
+  const updateFilter = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (value) params.set(key, value);
+    else params.delete(key);
+    setSearchParams(params);
+  };
 
   const cancel = async (id: string) => {
     await api.post(`/orders/cancel/${id}`);
     load();
   };
 
+  const groups = useMemo(() => {
+    const map = new Map<string, Order[]>();
+    list.forEach((o) => {
+      const month = new Date(o.createdAt).toLocaleDateString(undefined, {
+        month: 'long',
+        year: 'numeric',
+      });
+      if (!map.has(month)) map.set(month, []);
+      map.get(month)!.push(o);
+    });
+    return Array.from(map.entries());
+  }, [list]);
+
+  const status = searchParams.get('status') ?? '';
+  const shop = searchParams.get('shop') ?? '';
+  const date = searchParams.get('date') ?? '';
+  const price = searchParams.get('price') ?? '';
+
+  const chips = [
+    status && { label: `Status: ${status}`, onRemove: () => updateFilter('status', '') },
+    date && { label: `Date: ${date}`, onRemove: () => updateFilter('date', '') },
+    shop && { label: `Shop: ${shop}`, onRemove: () => updateFilter('shop', '') },
+    price && { label: `Price ≤ ${price}`, onRemove: () => updateFilter('price', '') },
+  ].filter(Boolean) as { label: string; onRemove: () => void }[];
+
   return (
     <div className={styles.myOrders}>
       <h2>My Orders</h2>
       <div className={styles.filters}>
-        <select value={status} onChange={(e) => setStatus(e.target.value)}>
+        <select value={status} onChange={(e) => updateFilter('status', e.target.value)}>
           <option value="">All Statuses</option>
           <option value="pending">Pending</option>
           <option value="accepted">Accepted</option>
@@ -55,12 +85,32 @@ const MyOrders = () => {
           <option value="cancelled">Cancelled</option>
         </select>
         <input
+          type="date"
+          value={date}
+          onChange={(e) => updateFilter('date', e.target.value)}
+        />
+        <input
           type="text"
-          placeholder="Search"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Shop"
+          value={shop}
+          onChange={(e) => updateFilter('shop', e.target.value)}
+        />
+        <input
+          type="number"
+          placeholder="Max Price"
+          value={price}
+          onChange={(e) => updateFilter('price', e.target.value)}
         />
       </div>
+      {chips.length > 0 && (
+        <div className={styles.chips}>
+          {chips.map((c) => (
+            <button key={c.label} className={styles.chip} onClick={c.onRemove}>
+              {c.label} ✕
+            </button>
+          ))}
+        </div>
+      )}
       {loading ? (
         [1, 2, 3].map((n) => (
           <Shimmer key={n} className={`${styles.card} shimmer rounded`} style={{ height: 80 }} />
@@ -68,12 +118,32 @@ const MyOrders = () => {
       ) : list.length === 0 ? (
         <div className={styles.empty}>
           <img src={fallbackImage} alt="No orders" />
-          <p>You haven\u2019t placed any orders yet.</p>
+          <p>You haven’t placed any orders yet.</p>
           <a href="/shops" className={styles.browse}>Browse Shops</a>
         </div>
       ) : (
-        list.map((i) => (
-          <OrderCard key={i._id} order={i} onCancel={i.status === 'pending' ? () => cancel(i._id) : undefined} />
+        groups.map(([month, orders]) => (
+          <div key={month} className={styles.group}>
+            <div className={styles.month}>{month}</div>
+            {orders.map((i) => (
+              <OrderCard
+                key={i._id}
+                items={[
+                  {
+                    id: i._id,
+                    title: i.product.name,
+                    image: i.product.image || fallbackImage,
+                  },
+                ]}
+                shop={i.product.shop?.name || ''}
+                date={i.createdAt}
+                status={i.status}
+                quantity={i.quantity}
+                total={i.product.price * i.quantity}
+                onCancel={i.status === 'pending' ? () => cancel(i._id) : undefined}
+              />
+            ))}
+          </div>
         ))
       )}
     </div>
@@ -81,3 +151,4 @@ const MyOrders = () => {
 };
 
 export default MyOrders;
+

--- a/client/src/pages/ReceivedOrders/ReceivedOrders.tsx
+++ b/client/src/pages/ReceivedOrders/ReceivedOrders.tsx
@@ -3,14 +3,15 @@ import api from '../../api/client';
 import Shimmer from '../../components/Shimmer';
 import { OrderCard } from '../../components/base';
 import fallbackImage from '../../assets/no-image.svg';
+import { type Status } from '../../components/ui/StatusChip';
 import styles from './ReceivedOrders.module.scss';
 
 interface Order {
   _id: string;
   user: { name: string; phone?: string };
-  product: { name: string };
+  product: { name: string; price: number; image?: string };
   quantity: number;
-  status: string;
+  status: Status;
   createdAt: string;
 }
 
@@ -75,7 +76,18 @@ const ReceivedOrders = () => {
         list.map((i) => (
           <OrderCard
             key={i._id}
-            order={i}
+            items={[
+              {
+                id: i._id,
+                title: i.product.name,
+                image: i.product.image || fallbackImage,
+              },
+            ]}
+            shop={i.user.name}
+            date={i.createdAt}
+            status={i.status}
+            quantity={i.quantity}
+            total={i.product.price * i.quantity}
             onAccept={i.status === 'pending' ? () => act(i._id, 'accept') : undefined}
             onReject={i.status === 'pending' ? () => act(i._id, 'reject') : undefined}
           />


### PR DESCRIPTION
## Summary
- add cancel capability to generic OrderCard component
- group "My Orders" by month with sticky headers
- add status/date/shop/price filters that sync with URL and render as removable chips

## Testing
- `npm run lint`
- `npm run build` *(fails: 'ReactNode' type-only import and other typing issues in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_689e2e851244833299f8105be32be0ef