### PR TITLE
feat: polish received orders with filters and actions

### DIFF
--- a/client/src/pages/ReceivedOrders/ReceivedOrders.module.scss
+++ b/client/src/pages/ReceivedOrders/ReceivedOrders.module.scss
@@ -7,8 +7,25 @@
 
 .filters {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin-bottom: 1rem;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+
+  .chip {
+    padding: 0.4rem 0.8rem;
+    border: none;
+    border-radius: 999px;
+    background: #f2f2f2;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
 }
 
 .empty {
@@ -22,58 +39,6 @@
 }
 
 .card {
-  border: 1px solid #ddd;
-  padding: 0.75rem;
   margin-bottom: 0.75rem;
-  border-radius: 6px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s;
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-
-  &:hover {
-    transform: translateY(-2px);
-  }
-
-  .info {
-    flex: 1;
-
-    .field {
-      display: flex;
-      align-items: center;
-      gap: 0.25rem;
-      margin: 0;
-      font-size: 0.85rem;
-    }
-  }
-
-  .status {
-    padding: 0.25rem 0.5rem;
-    font-size: 0.75rem;
-    border-radius: 4px;
-    text-transform: capitalize;
-    font-weight: bold;
-    &.pending { background: #e5e7eb; color: #555; }
-    &.accepted { background: #d1fae5; color: #065f46; }
-    &.rejected { background: #fee2e2; color: #991b1b; }
-    &.cancelled { background: #ffedd5; color: #9a3412; }
-  }
-
-  .actions {
-    display: flex;
-    gap: 0.5rem;
-
-    .accept { @include button-style($primary-color, #fff); padding: 0.25rem 0.5rem; }
-    .reject { @include button-style(red, #fff); padding: 0.25rem 0.5rem; }
-  }
-
-  .call {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    color: green;
-    text-decoration: none;
-    font-weight: bold;
-  }
 }
+

--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -88,7 +88,9 @@ exports.getReceivedOrders = async (req, res) => {
 
 exports.acceptOrder = async (req, res) => {
   try {
-    const order = await Order.findById(req.params.id);
+    const order = await Order.findById(req.params.id)
+      .populate('user', 'name phone')
+      .populate('product', 'name category price image');
     if (!order) return res.status(404).json({ error: 'Order not found' });
     if (order.business.toString() !== req.user._id.toString())
       return res.status(403).json({ error: 'Not authorized' });
@@ -102,7 +104,9 @@ exports.acceptOrder = async (req, res) => {
 
 exports.rejectOrder = async (req, res) => {
   try {
-    const order = await Order.findById(req.params.id);
+    const order = await Order.findById(req.params.id)
+      .populate('user', 'name')
+      .populate('product', 'name category price image');
     if (!order) return res.status(404).json({ error: 'Order not found' });
     if (order.business.toString() !== req.user._id.toString())
       return res.status(403).json({ error: 'Not authorized' });


### PR DESCRIPTION
## Summary
- polish Received Orders page with status/category/price filters and chip controls
- add optimistic accept/reject actions and reveal call button when order is accepted
- populate accept/reject responses with user and product details on the server

## Testing
- `npm run lint`
- `npm run build` *(fails: ReactNode type imports and other existing TS errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e31b279b88332bee75085567f6eb4