### PR TITLE
refactor: replace interest with orders

### DIFF
--- a/client/src/pages/VoiceOrder/VoiceOrder.tsx
+++ b/client/src/pages/VoiceOrder/VoiceOrder.tsx
@@ -103,10 +103,6 @@ const VoiceOrder = () => {
         shopId: item.shop._id,
         source: 'voice-order',
       });
-      await api.post('/orders/interest', {
-        shopId: item.shop._id,
-        productId: item.product._id,
-      });
       alert('Order placed');
     } catch {
       alert('Failed to place order');

--- a/server/controllers/verifiedUserController.js
+++ b/server/controllers/verifiedUserController.js
@@ -46,30 +46,6 @@ exports.getAllVerifiedUsers = async (req, res) => {
   }
 };
 
-exports.markInterest = async (req, res) => {
-  try {
-    const verifiedId = req.params.id;
-    const userId = req.user._id;
-
-    const verified = await VerifiedUser.findById(verifiedId);
-    if (!verified)
-      return res.status(404).json({ error: "Verified user not found" });
-
-    const alreadyConnected = verified.connections.some(
-      (c) => c.user.toString() === userId.toString()
-    );
-
-    if (!alreadyConnected) {
-      verified.connections.push({ user: userId, status: "pending" });
-      await verified.save();
-    }
-
-    res.json({ message: "Interest marked successfully" });
-  } catch (err) {
-    res.status(500).json({ error: "Failed to mark interest" });
-  }
-};
-
 exports.getMyRequests = async (req, res) => {
   try {
     const verified = await VerifiedUser.findOne({ user: req.user._id });

--- a/server/routes/verifiedUserRoutes.js
+++ b/server/routes/verifiedUserRoutes.js
@@ -5,7 +5,6 @@ const protectAdmin = require("../middleware/adminAuth");
 const {
   applyForVerification,
   getAllVerifiedUsers,
-  markInterest,
   getAcceptedProviders,
   getVerificationRequests,
   acceptVerificationRequest,
@@ -14,7 +13,6 @@ const {
 
 router.post("/apply", protect, applyForVerification);
 router.get("/all", protect, getAllVerifiedUsers);
-router.post("/interest/:id", protect, markInterest);
 router.get("/requests", protectAdmin, getVerificationRequests);
 router.post("/accept/:userId", protectAdmin, acceptVerificationRequest);
 router.post("/reject/:userId", protectAdmin, rejectVerificationRequest);


### PR DESCRIPTION
## Summary
- drop deprecated interest endpoint usage in voice ordering
- remove interest controller and route
- confirm axios client uses `VITE_API_URL`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `node server.js` *(fails: MongoDB connection error: The `uri` parameter to `openUri()` must be a string)*

------
https://chatgpt.com/codex/tasks/task_e_689ecb4208e083329e3af461e69c1c16