### PR TITLE
feat: add multilingual voice ordering workflow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import Settings from './pages/Settings/Settings';
 import Cart from './pages/Cart/Cart';
 import Events from './pages/Events/Events';
 import VoiceOrder from './pages/VoiceOrder/VoiceOrder';
+import OrderNow from './pages/OrderNow/OrderNow';
 import ManageProducts from './pages/ManageProducts/ManageProducts';
 import ReceivedOrders from './pages/ReceivedOrders/ReceivedOrders';
 import MyOrders from './pages/MyOrders/MyOrders';
@@ -69,6 +70,7 @@ function App() {
             <Route path="/events" element={<Events />} />
             <Route path="/special-shop" element={<SpecialShop />} />
             <Route path="/voice-order" element={<VoiceOrder />} />
+            <Route path="/order-now" element={<OrderNow />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/manage-products" element={<ManageProducts />} />

--- a/client/src/pages/OrderNow/OrderNow.module.scss
+++ b/client/src/pages/OrderNow/OrderNow.module.scss
@@ -1,0 +1,101 @@
+@import "../../styles/variables";
+@import "../../styles/mixins";
+
+.orderNow {
+  padding: 2rem;
+  text-align: center;
+
+  h2 {
+    font-size: 1.6rem;
+    margin-bottom: 1rem;
+  }
+
+  .mic-wrapper {
+    margin: 2rem auto;
+    width: 120px;
+    height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: $primary-color;
+    color: #fff;
+    font-size: 3rem;
+    cursor: pointer;
+  }
+
+  .listening {
+    animation: pulse 1.2s infinite ease-in-out;
+  }
+
+  .transcript {
+    margin-top: 1rem;
+    font-size: 1rem;
+    color: #333;
+    min-height: 1.5rem;
+  }
+
+  .text-input {
+    margin-top: 1rem;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+
+    input {
+      flex: 1;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+    }
+
+    button {
+      padding: 0.5rem 0.75rem;
+      background: $primary-color;
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+  }
+
+  .results {
+    margin-top: 2rem;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+
+  .product-card {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    h4 {
+      margin: 0.5rem 0;
+    }
+
+    p {
+      margin: 0.25rem 0;
+    }
+  }
+
+  .review-btn {
+    margin-top: 1rem;
+    padding: 0.5rem 1rem;
+    background: $primary-color;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+  100% { transform: scale(1); }
+}

--- a/client/src/pages/OrderNow/OrderNow.tsx
+++ b/client/src/pages/OrderNow/OrderNow.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { motion } from 'framer-motion';
+import { FaMicrophone } from 'react-icons/fa';
+import api from '../../api/client';
+import { sampleShops } from '../../data/sampleData';
+import type { RootState } from '../../store';
+import ModalSheet from '../../components/base/ModalSheet';
+import Loader from '../../components/Loader';
+import styles from './OrderNow.module.scss';
+
+interface Product {
+  _id: string;
+  name: string;
+  price: number;
+  image?: string;
+}
+
+interface Shop {
+  _id: string;
+  name: string;
+  products: Product[];
+}
+
+interface MatchedItem {
+  product: Product;
+  shop: Shop;
+  quantity: number;
+}
+
+const OrderNow = () => {
+  const user = useSelector((state: RootState) => state.user as any);
+  const [shops, setShops] = useState<Shop[]>([]);
+  const [transcript, setTranscript] = useState('');
+  const [manual, setManual] = useState('');
+  const [listening, setListening] = useState(false);
+  const [matched, setMatched] = useState<MatchedItem[]>([]);
+  const [language, setLanguage] = useState('en-US');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [placing, setPlacing] = useState(false);
+  const [hasSupport, setHasSupport] = useState(true);
+  const recognitionRef = useRef<any>(null);
+
+  useEffect(() => {
+    api
+      .get('/shops')
+      .then((res) => {
+        if (Array.isArray(res.data) && res.data.length > 0) {
+          setShops(res.data);
+        } else {
+          setShops(sampleShops as unknown as Shop[]);
+        }
+      })
+      .catch(() => setShops(sampleShops as unknown as Shop[]));
+  }, []);
+
+  useEffect(() => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    setHasSupport(!!SpeechRecognition);
+  }, []);
+
+  const toggleListening = () => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (!SpeechRecognition) return;
+
+    if (listening && recognitionRef.current) {
+      recognitionRef.current.stop();
+      return;
+    }
+
+    const recognition = new SpeechRecognition();
+    recognition.lang = language;
+    recognition.interimResults = true;
+    recognition.onresult = (e: any) => {
+      const text = Array.from(e.results)
+        .map((r: any) => r[0].transcript)
+        .join(' ');
+      setTranscript(text);
+    };
+    recognition.onend = () => {
+      setListening(false);
+      if (transcript) processTranscript(transcript);
+    };
+    recognitionRef.current = recognition;
+    recognition.start();
+    setListening(true);
+    setTranscript('');
+    setMatched([]);
+  };
+
+  const processTranscript = (text: string) => {
+    const items: MatchedItem[] = [];
+    const lower = text.toLowerCase();
+    shops.forEach((shop) => {
+      shop.products.forEach((product) => {
+        if (lower.includes(product.name.toLowerCase())) {
+          const regex = new RegExp(`(\\d+)\\s*${product.name.toLowerCase()}`);
+          const match = lower.match(regex);
+          const quantity = match ? parseInt(match[1], 10) : 1;
+          items.push({ product, shop, quantity });
+        }
+      });
+    });
+    setMatched(items);
+  };
+
+  const handleManual = () => {
+    if (manual.trim()) {
+      setTranscript(manual);
+      processTranscript(manual);
+    }
+  };
+
+  const total = matched.reduce(
+    (sum, item) => sum + item.product.price * item.quantity,
+    0
+  );
+
+  const placeOrder = async () => {
+    try {
+      setPlacing(true);
+      await Promise.all(
+        matched.map((m) =>
+          api.post(`/orders/place/${m.product._id}`, {
+            quantity: m.quantity,
+            userId: user?._id,
+            shopId: m.shop._id,
+            source: 'voice-order',
+          })
+        )
+      );
+      alert('Order placed');
+      setMatched([]);
+      setTranscript('');
+      setManual('');
+      setConfirmOpen(false);
+    } catch {
+      alert('Failed to place order');
+    } finally {
+      setPlacing(false);
+    }
+  };
+
+  return (
+    <div className={styles.orderNow}>
+      <h2>Order Now</h2>
+      <p>Say or type your order (e.g., "2 chicken biryani")</p>
+      <select value={language} onChange={(e) => setLanguage(e.target.value)}>
+        <option value="en-US">English</option>
+        <option value="hi-IN">Hindi</option>
+        <option value="te-IN">Telugu</option>
+      </select>
+      {hasSupport && (
+        <motion.div
+          className={`${styles['mic-wrapper']} ${listening ? styles.listening : ''}`}
+          whileTap={{ scale: 0.9 }}
+          onClick={toggleListening}
+        >
+          <FaMicrophone />
+        </motion.div>
+      )}
+      <div className={styles.transcript}>{transcript}</div>
+      {!hasSupport && (
+        <div className={styles['text-input']}>
+          <input
+            type="text"
+            value={manual}
+            onChange={(e) => setManual(e.target.value)}
+            placeholder="Type your order"
+          />
+          <button onClick={handleManual}>Parse</button>
+        </div>
+      )}
+      <div className={styles.results}>
+        {matched.map((m) => (
+          <motion.div
+            key={m.product._id}
+            className={styles['product-card']}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+          >
+            <h4>{m.product.name}</h4>
+            <p>Qty: {m.quantity}</p>
+            <p>₹{m.product.price}</p>
+            <p>{m.shop.name}</p>
+          </motion.div>
+        ))}
+      </div>
+      {matched.length > 0 && (
+        <button className={styles['review-btn']} onClick={() => setConfirmOpen(true)}>
+          Review Order
+        </button>
+      )}
+      <ModalSheet open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <h3>Confirm Order</h3>
+        {matched.map((m) => (
+          <div key={m.product._id} className={styles['product-card']}>
+            <h4>{m.product.name}</h4>
+            <p>Qty: {m.quantity}</p>
+            <p>₹{m.product.price * m.quantity}</p>
+          </div>
+        ))}
+        <p>Total: ₹{total}</p>
+        <button onClick={placeOrder} disabled={placing}>
+          {placing ? <Loader /> : 'Place Order'}
+        </button>
+      </ModalSheet>
+    </div>
+  );
+};
+
+export default OrderNow;


### PR DESCRIPTION
## Summary
- add `/order-now` route with voice ordering flow
- support English, Hindi, and Telugu speech with text fallback
- confirm matched items and place orders via API

## Testing
- `npm run lint`
- `npm run build` *(fails: ReactNode type-only import and type errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_689ed5c675b0833280fdc23f78b6e562