### PR TITLE
feat: add business request workflow

### DIFF
--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -19,13 +19,17 @@ export const fetchUsers = async () => {
   return res.data;
 };
 
-export const fetchPendingShops = async () => {
-  const res = await adminApi.get('/shops/pending');
+export const fetchBusinessRequests = async () => {
+  const res = await adminApi.get('/shops/requests');
   return res.data;
 };
 
 export const approveShop = async (id: string) => {
   await adminApi.put(`/shops/approve/${id}`);
+};
+
+export const rejectShop = async (id: string) => {
+  await adminApi.put(`/shops/reject/${id}`);
 };
 
 export const fetchVerificationRequests = async () => {

--- a/client/src/api/profile.ts
+++ b/client/src/api/profile.ts
@@ -18,6 +18,7 @@ export interface BusinessRequest {
   category: string;
   location: string;
   address: string;
+  description?: string;
 }
 
 export interface VerifyRequest {
@@ -42,6 +43,11 @@ export const requestVerification = async (data: VerifyRequest) => {
 
 export const requestBusiness = async (data: BusinessRequest) => {
   await api.post('/shops', data);
+};
+
+export const getMyBusinessRequest = async () => {
+  const res = await api.get('/shops/my');
+  return res.data;
 };
 
 export const getMyProducts = async () => {

--- a/client/src/pages/AdminPanel/AdminPanel.tsx
+++ b/client/src/pages/AdminPanel/AdminPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { fetchPendingShops, approveShop } from '../../api/admin';
+import { fetchBusinessRequests, approveShop, rejectShop } from '../../api/admin';
 import './AdminPanel.scss';
 
 interface Shop {
@@ -18,7 +18,7 @@ const AdminPanel = () => {
   useEffect(() => {
     (async () => {
       try {
-        const data = await fetchPendingShops();
+        const data = await fetchBusinessRequests();
         setShops(data);
       } catch {
         setShops([]);
@@ -32,6 +32,18 @@ const AdminPanel = () => {
     try {
       setActionId(id);
       await approveShop(id);
+      setShops((prev) => prev.filter((s) => s._id !== id));
+    } catch {
+      // ignore
+    } finally {
+      setActionId('');
+    }
+  };
+
+  const handleReject = async (id: string) => {
+    try {
+      setActionId(id);
+      await rejectShop(id);
       setShops((prev) => prev.filter((s) => s._id !== id));
     } catch {
       // ignore
@@ -57,6 +69,12 @@ const AdminPanel = () => {
                 disabled={actionId === shop._id}
               >
                 {actionId === shop._id ? 'Approving...' : 'Approve'}
+              </button>
+              <button
+                onClick={() => handleReject(shop._id)}
+                disabled={actionId === shop._id}
+              >
+                {actionId === shop._id ? 'Processing...' : 'Reject'}
               </button>
             </li>
           ))}

--- a/client/src/pages/Profile/Profile.module.scss
+++ b/client/src/pages/Profile/Profile.module.scss
@@ -197,3 +197,70 @@
   font-size: 0.9rem;
   color: #666;
 }
+
+.statusIndicator {
+  font-weight: 600;
+  margin: 0.5rem 0;
+  &.approved {
+    color: #22c55e;
+  }
+  &.pending {
+    color: #fbbf24;
+  }
+  &.rejected {
+    color: #ef4444;
+  }
+}
+
+.businessForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+
+  h3 {
+    margin-bottom: 0.5rem;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.9rem;
+    font-weight: 600;
+
+    input,
+    textarea {
+      width: 100%;
+      padding: 0.6rem;
+      margin-top: 0.3rem;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      font-size: 1rem;
+
+      &:focus {
+        border-color: $primary-color;
+        outline: none;
+      }
+    }
+  }
+
+  .modalActions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+
+    button {
+      @include button-style($primary-color, #fff);
+      padding: 0.5rem 1rem;
+
+      &:first-child {
+        background: #eee;
+        color: #333;
+
+        &:hover {
+          background: #ddd;
+        }
+      }
+    }
+  }
+}

--- a/server/models/Shop.js
+++ b/server/models/Shop.js
@@ -11,7 +11,7 @@ const shopSchema = new mongoose.Schema(
     category: { type: String, required: true }, // e.g., grocery, clothing
     status: {
       type: String,
-      enum: ["pending", "approved"],
+      enum: ["pending", "approved", "rejected"],
       default: "pending",
     },
     location: { type: String, required: true },

--- a/server/routes/shopRoutes.js
+++ b/server/routes/shopRoutes.js
@@ -8,16 +8,20 @@ const {
   getShopById,
   getProductsByShop,
   getPendingShops,
+  getMyShop,
   approveShop,
+  rejectShop,
   getMyProducts,
 } = require("../controllers/shopController");
 
 router.post("/", protect, createShop);
-router.get("/pending", adminAuth, getPendingShops);
+router.get("/requests", adminAuth, getPendingShops);
 router.put("/approve/:id", adminAuth, approveShop);
+router.put("/reject/:id", adminAuth, rejectShop);
+router.get("/my", protect, getMyShop);
 router.get("/", getAllShops);
+router.get("/my-products", protect, getMyProducts);
 router.get("/:id", getShopById);
 router.get("/:id/products", getProductsByShop);
-router.get("/my-products", protect, getMyProducts);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- enable users to request business accounts via profile modal and track request status
- allow admins to approve or reject business requests in admin panel
- add server support for listing, approving, rejecting and notifying business requests

## Testing
- ✅ `npm run lint`
- ⚠️ `npm test` (no tests specified)

------
https://chatgpt.com/codex/tasks/task_e_689eda910f388332b2887b75d04650c7