### PR TITLE
feat: add business product management with live updates

### DIFF
--- a/client/src/pages/ShopDetails/ShopDetails.tsx
+++ b/client/src/pages/ShopDetails/ShopDetails.tsx
@@ -47,6 +47,16 @@ const ShopDetails = () => {
       }
     };
     load();
+    const refresh = async () => {
+      try {
+        const prodRes = await api.get(`/shops/${id}/products`);
+        setProducts(Array.isArray(prodRes.data) ? prodRes.data : []);
+      } catch {
+        // ignore
+      }
+    };
+    window.addEventListener('productsUpdated', refresh);
+    return () => window.removeEventListener('productsUpdated', refresh);
   }, [id]);
 
   const filtered = useMemo(() => {

--- a/client/src/store/slices/productSlice.ts
+++ b/client/src/store/slices/productSlice.ts
@@ -8,6 +8,9 @@ export interface Product {
   price: number;
   category: string;
   image?: string;
+  images?: string[];
+  mrp?: number;
+  discount?: number;
   stock: number;
   shop: string;
 }

--- a/server/controllers/shopController.js
+++ b/server/controllers/shopController.js
@@ -4,6 +4,21 @@ const User = require("../models/User");
 const Notification = require("../models/Notification");
 const { promoteToBusiness } = require("./userController");
 
+const normalizeProduct = (p) => ({
+  id: p._id.toString(),
+  _id: p._id.toString(),
+  name: p.name,
+  price: p.price,
+  mrp: p.mrp,
+  discount: p.mrp ? Math.round(((p.mrp - p.price) / p.mrp) * 100) : 0,
+  stock: p.stock,
+  images: p.images,
+  image: p.images?.[0] || '',
+  category: p.category,
+  shopId: p.shop.toString(),
+  shop: p.shop.toString(),
+});
+
 exports.createShop = async (req, res) => {
   try {
     const { name, category, location, address, image, banner, description } = req.body;
@@ -54,7 +69,7 @@ exports.getShopById = async (req, res) => {
 exports.getProductsByShop = async (req, res) => {
   try {
     const products = await Product.find({ shop: req.params.id });
-    res.json(products);
+    res.json(products.map(normalizeProduct));
   } catch (err) {
     res.status(500).json({ error: "Failed to fetch products" });
   }
@@ -127,7 +142,7 @@ exports.rejectShop = async (req, res) => {
 exports.getMyProducts = async (req, res) => {
   try {
     const products = await Product.find({ createdBy: req.user._id });
-    res.status(200).json(products);
+    res.status(200).json(products.map(normalizeProduct));
   } catch (err) {
     res.status(500).json({ message: "Server error fetching products." });
   }

--- a/server/models/Product.js
+++ b/server/models/Product.js
@@ -11,8 +11,9 @@ const productSchema = new mongoose.Schema(
     name: { type: String, required: true },
     description: { type: String, default: "" },
     price: { type: Number, required: true },
+    mrp: { type: Number, required: true },
     category: { type: String, default: "general" },
-    image: { type: String, default: "" },
+    images: { type: [String], default: [] },
     stock: { type: Number, default: 0 },
   },
   { timestamps: true }


### PR DESCRIPTION
## Summary
- extend product model with mrp and image gallery
- normalize product responses with ownership checks
- add business product manager with validation, toast feedback, and live shop refresh

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ee1d6b988833297c82d918d5ced28