### PR TITLE
Implement notifications page with filters and read tracking

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,6 +24,7 @@ import OrderNow from './pages/OrderNow/OrderNow';
 import ManageProducts from './pages/ManageProducts/ManageProducts';
 import ReceivedOrders from './pages/ReceivedOrders/ReceivedOrders';
 import MyOrders from './pages/MyOrders/MyOrders';
+import Notifications from './pages/Notifications/Notifications';
 import TabLayout from './layouts/TabLayout';
 import AdminLogin from './pages/AdminLogin/AdminLogin';
 import AdminDashboard from './pages/AdminDashboard';
@@ -71,12 +72,13 @@ function App() {
             <Route path="/special-shop" element={<SpecialShop />} />
             <Route path="/voice-order" element={<VoiceOrder />} />
             <Route path="/order-now" element={<OrderNow />} />
-          <Route path="/profile" element={<Profile />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/manage-products" element={<ManageProducts />} />
-          <Route path="/orders/received" element={<ReceivedOrders />} />
-          <Route path="/orders/my" element={<MyOrders />} />
-        </Route>
+            <Route path="/notifications" element={<Notifications />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/manage-products" element={<ManageProducts />} />
+            <Route path="/orders/received" element={<ReceivedOrders />} />
+            <Route path="/orders/my" element={<MyOrders />} />
+          </Route>
           <Route path="/shops/:id" element={<ShopDetails />} />
           <Route path="/product/:id" element={<ProductDetails />} />
           <Route path="/events/:id" element={<EventDetails />} />

--- a/client/src/api/notifications.ts
+++ b/client/src/api/notifications.ts
@@ -1,0 +1,21 @@
+import api from './client';
+
+export interface Notification {
+  _id: string;
+  title: string;
+  message: string;
+  image?: string;
+  link?: string;
+  type: string;
+  createdAt: string;
+  isRead?: boolean;
+}
+
+export const fetchNotifications = async (): Promise<Notification[]> => {
+  const res = await api.get('/notifications');
+  return res.data;
+};
+
+export const markNotificationRead = async (id: string) => {
+  await api.post(`/notifications/view/${id}`);
+};

--- a/client/src/layouts/TabLayout.scss
+++ b/client/src/layouts/TabLayout.scss
@@ -223,6 +223,20 @@
         cursor: pointer;
       }
 
+      .sidebar-notifications {
+        background: $primary-color;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        width: 100%;
+        height: 42px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 1.2rem;
+        cursor: pointer;
+      }
+
       .sidebar-settings {
         background: $primary-color;
         color: #fff;

--- a/client/src/layouts/TabLayout.tsx
+++ b/client/src/layouts/TabLayout.tsx
@@ -11,6 +11,7 @@ import {
   AiOutlineCalendar,
   AiOutlineUser,
   AiOutlineSetting,
+  AiOutlineBell,
 } from "react-icons/ai";
 import { FaShoppingCart, FaMicrophone } from "react-icons/fa";
 import "./TabLayout.scss";
@@ -60,6 +61,12 @@ const TabLayout = () => {
             </button>
           )}
           <button
+            className="notif-btn"
+            onClick={() => navigate('/notifications')}
+          >
+            <AiOutlineBell />
+          </button>
+          <button
             className="profile-btn"
             onClick={() => navigate('/profile')}
           >
@@ -106,6 +113,12 @@ const TabLayout = () => {
             <span className="count">{cartItems.length}</span>
           </button>
         )}
+        <button
+          className="sidebar-notifications"
+          onClick={() => navigate('/notifications')}
+        >
+          <AiOutlineBell />
+        </button>
         <button
           className="sidebar-profile"
           onClick={() => navigate('/profile')}

--- a/client/src/pages/Notifications/Notifications.scss
+++ b/client/src/pages/Notifications/Notifications.scss
@@ -1,0 +1,92 @@
+.notifications-page {
+  padding: 1rem;
+
+  .notif-filters {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+
+    button {
+      padding: 0.4rem 0.8rem;
+      border-radius: 4px;
+      background: #eee;
+      border: none;
+      cursor: pointer;
+
+      &.active {
+        background: #333;
+        color: #fff;
+      }
+    }
+  }
+
+  .notif-group {
+    margin-bottom: 1.5rem;
+
+    .group-date {
+      margin-bottom: 0.5rem;
+      font-weight: 600;
+    }
+  }
+
+  .notif-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: #fff;
+    border-radius: 8px;
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+
+    &.read {
+      opacity: 0.6;
+    }
+
+    img {
+      width: 40px;
+      height: 40px;
+      object-fit: cover;
+      border-radius: 50%;
+    }
+
+    .info {
+      flex: 1;
+
+      h5 {
+        margin: 0 0 4px;
+        font-size: 0.95rem;
+      }
+
+      p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: #555;
+      }
+    }
+
+    .mark-btn {
+      display: none;
+      background: transparent;
+      border: none;
+      color: #0077ff;
+      cursor: pointer;
+    }
+  }
+
+  .empty-state {
+    text-align: center;
+    margin-top: 2rem;
+    color: #666;
+  }
+}
+
+@media (min-width: 600px) {
+  .notifications-page {
+    .notif-item {
+      .mark-btn {
+        display: inline-block;
+      }
+    }
+  }
+}

--- a/client/src/pages/Notifications/Notifications.tsx
+++ b/client/src/pages/Notifications/Notifications.tsx
@@ -1,0 +1,136 @@
+import './Notifications.scss';
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import {
+  fetchNotifications,
+  markNotificationRead,
+  type Notification,
+} from '../../api/notifications';
+import Shimmer from '../../components/Shimmer';
+
+const filterLabels: Record<string, string> = {
+  all: 'All',
+  orders: 'Orders',
+  admin: 'Admin',
+  offers: 'Offers',
+  system: 'System',
+};
+
+const filters = Object.keys(filterLabels);
+
+const Notifications = () => {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [activeFilter, setActiveFilter] = useState('all');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const touchStart = useRef(0);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const urlFilter = searchParams.get('type');
+    if (urlFilter && filters.includes(urlFilter)) setActiveFilter(urlFilter);
+  }, [searchParams]);
+
+  useEffect(() => {
+    fetchNotifications()
+      .then((data) => setNotifications(data))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleMarkRead = async (id: string) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n._id === id ? { ...n, isRead: true } : n)),
+    );
+    try {
+      await markNotificationRead(id);
+    } catch {
+      // revert on failure
+      setNotifications((prev) =>
+        prev.map((n) => (n._id === id ? { ...n, isRead: false } : n)),
+      );
+    }
+  };
+
+  const filtered = notifications.filter(
+    (n) => activeFilter === 'all' || n.type === activeFilter,
+  );
+
+  const groups = filtered.reduce<Record<string, Notification[]>>((acc, n) => {
+    const date = new Date(n.createdAt).toDateString();
+    if (!acc[date]) acc[date] = [];
+    acc[date].push(n);
+    return acc;
+  }, {});
+
+  return (
+    <div className="notifications-page">
+      <div className="notif-filters">
+        {filters.map((f) => (
+          <button
+            key={f}
+            className={activeFilter === f ? 'active' : ''}
+            onClick={() => {
+              setActiveFilter(f);
+              if (f === 'all') setSearchParams({});
+              else setSearchParams({ type: f });
+            }}
+          >
+            {filterLabels[f]}
+          </button>
+        ))}
+      </div>
+      {loading ? (
+        <div className="notif-skeletons">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="notif-item">
+              <Shimmer width={40} height={40} className="rounded" />
+              <div className="info">
+                <Shimmer style={{ height: 14, width: '60%', marginBottom: 6 }} />
+                <Shimmer style={{ height: 12, width: '80%' }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : Object.keys(groups).length === 0 ? (
+        <div className="empty-state">No notifications</div>
+      ) : (
+        Object.entries(groups).map(([date, items]) => (
+          <div key={date} className="notif-group">
+            <h4 className="group-date">{date}</h4>
+            {items.map((n) => (
+              <div
+                key={n._id}
+                className={`notif-item ${n.isRead ? 'read' : ''}`}
+                onTouchStart={(e) => (touchStart.current = e.touches[0].clientX)}
+                onTouchEnd={(e) => {
+                  const diff = touchStart.current - e.changedTouches[0].clientX;
+                  if (diff > 50) handleMarkRead(n._id);
+                }}
+              >
+                {n.image && (
+                  <img
+                    src={n.image}
+                    alt=""
+                    onClick={() => n.link && navigate(n.link)}
+                  />
+                )}
+                <div className="info" onClick={() => n.link && navigate(n.link)}>
+                  <h5>{n.title}</h5>
+                  <p>{n.message}</p>
+                </div>
+                <button
+                  className="mark-btn"
+                  onClick={() => handleMarkRead(n._id)}
+                >
+                  Mark read
+                </button>
+              </div>
+            ))}
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default Notifications;

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -34,10 +34,12 @@ exports.getUserNotifications = async (req, res) => {
       ],
     }).sort({ createdAt: -1 });
 
-    // Exclude viewed ones
-    const filtered = notifs.filter((n) => !n.viewedBy.includes(userId));
+    const mapped = notifs.map((n) => ({
+      ...n.toObject(),
+      isRead: n.viewedBy.includes(userId),
+    }));
 
-    res.json(filtered);
+    res.json(mapped);
   } catch (err) {
     res.status(500).json({ error: "Failed to fetch notifications" });
   }

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -8,8 +8,8 @@ const notificationSchema = new mongoose.Schema(
     link: { type: String },
     type: {
       type: String,
-      enum: ["general", "event", "shop", "order"],
-      default: "general",
+      enum: ["order", "admin", "offer", "system"],
+      default: "system",
     },
     user: { type: mongoose.Schema.Types.ObjectId, ref: "User", default: null }, // null = global
     viewedBy: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],


### PR DESCRIPTION
## Summary
- add notifications API client and new `/notifications` page with date grouping, category filters, skeletons, and swipe/desktop read actions
- expose notifications via header button and route; server returns read status and supports new notification types

## Testing
- `cd client && npm run lint`
- `cd client && npm test` *(fails: Missing script "test")*
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689ee4529ab08332a739390f5b859b3e