### PR TITLE
feat: add dedicated settings page with logout

### DIFF
--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import { ProfileHeader, Tabs, OrderCard } from '../../components/base';
 import ProductCard from '../../components/ui/ProductCard';
 import type { RootState } from '../../store';
 import { sampleShops } from '../../data/sampleData';
-import { clearUser, setUser } from '../../store/slices/userSlice';
+import { setUser } from '../../store/slices/userSlice';
 import ModalSheet from '../../components/base/ModalSheet';
 import {
   requestBusiness,
@@ -18,9 +17,8 @@ import styles from './Profile.module.scss';
 
 const Profile = () => {
   const user = useSelector((state: RootState) => state.user as any);
-  const { theme, setTheme } = useTheme();
+  const { theme } = useTheme();
   const dispatch = useDispatch();
-  const navigate = useNavigate();
 
   const [activeTab, setActiveTab] = useState('overview');
   const [businessOpen, setBusinessOpen] = useState(false);
@@ -105,36 +103,6 @@ const Profile = () => {
     tabs.push({ key: 'reviews', label: 'Reviews', content: <p>No reviews yet.</p> });
   }
 
-  tabs.push({
-    key: 'settings',
-    label: 'Settings',
-    content: (
-      <div className={styles.settings}>
-        <div className={styles.themes}>
-          <button type="button" onClick={() => setTheme('colorful')}>
-            Colorful
-          </button>
-          <button type="button" onClick={() => setTheme('light')}>
-            Light
-          </button>
-          <button type="button" onClick={() => setTheme('dark')}>
-            Dark
-          </button>
-        </div>
-        <button
-          type="button"
-          className={styles.logout}
-          onClick={() => {
-            dispatch(clearUser());
-            navigate('/login');
-          }}
-        >
-          Logout
-        </button>
-        <p className={styles.prefs}>Preferences coming soon.</p>
-      </div>
-    ),
-  });
 
   return (
     <div className={`${styles.profile} ${styles[theme]}`}>
@@ -151,7 +119,6 @@ const Profile = () => {
           ...(user.role !== 'business' && shopStatus !== 'pending'
             ? [{ label: 'Request Business', onClick: () => setBusinessOpen(true) }]
             : []),
-          { label: 'Settings', onClick: () => setActiveTab('settings') },
         ]}
       />
       {shopStatus && (

--- a/client/src/pages/Settings/Settings.module.scss
+++ b/client/src/pages/Settings/Settings.module.scss
@@ -1,0 +1,18 @@
+.settings {
+  padding: 1rem;
+}
+
+.dangerZone {
+  margin-top: 2rem;
+  border-top: 1px solid #e53e3e;
+  padding-top: 1rem;
+}
+
+.logout {
+  background: #e53e3e;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/client/src/pages/Settings/Settings.scss
+++ b/client/src/pages/Settings/Settings.scss
@@ -1,6 +1,0 @@
-.settings {
-  padding: 1rem;
-  h2 {
-    margin-bottom: 0.5rem;
-  }
-}

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -1,15 +1,35 @@
 import { motion } from 'framer-motion';
-import './Settings.scss';
+import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { clearUser } from '../../store/slices/userSlice';
+import styles from './Settings.module.scss';
 
-const Settings = () => (
-  <motion.div
-    className="settings"
-    initial={{ opacity: 0, y: 30 }}
-    animate={{ opacity: 1, y: 0 }}
-  >
-    <h2>Settings</h2>
-    <p>Manage your app preferences here.</p>
-  </motion.div>
-);
+const Settings = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    dispatch(clearUser());
+    navigate('/login');
+  };
+
+  return (
+    <motion.div
+      className={styles.settings}
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <h2>Settings</h2>
+      <div className={styles.dangerZone}>
+        <h3>Danger Zone</h3>
+        <button type="button" className={styles.logout} onClick={handleLogout}>
+          Logout
+        </button>
+      </div>
+    </motion.div>
+  );
+};
 
 export default Settings;


### PR DESCRIPTION
## Summary
- create settings page with a danger zone logout that clears auth and redirects
- switch settings styles to module scss
- simplify profile by removing settings tab and logout action

## Testing
- `npm run lint`
- `npm run build` *(fails: ReactNode type-only import and Events typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ef5405fb88332beb17829ffda2459