### PR TITLE
feat: add theme selection

### DIFF
--- a/client/src/pages/Settings/Settings.module.scss
+++ b/client/src/pages/Settings/Settings.module.scss
@@ -2,6 +2,77 @@
   padding: 1rem;
 }
 
+.themeSection {
+  margin-top: 1rem;
+}
+
+.description {
+  margin-top: 0.25rem;
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}
+
+.themeOptions {
+  display: flex;
+  gap: 1rem;
+  margin-top: var(--space-3);
+}
+
+.themeOption {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+}
+
+.themeOption input {
+  position: absolute;
+  opacity: 0;
+}
+
+.themeOption input:focus-visible + .swatch {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.swatch {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-sm);
+  position: relative;
+}
+
+.swatchText {
+  font-size: var(--font-size-sm);
+}
+
+.swatchPrimary {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-primary);
+}
+
+.optionLabel {
+  margin-top: 0.25rem;
+  font-size: var(--font-size-sm);
+}
+
+.selected .swatch {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .dangerZone {
   margin-top: 2rem;
   border-top: 1px solid #e53e3e;

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -2,11 +2,13 @@ import { motion } from 'framer-motion';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { clearUser } from '../../store/slices/userSlice';
+import { useTheme } from '../../theme/ThemeProvider';
 import styles from './Settings.module.scss';
 
 const Settings = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const { theme, setTheme, availableThemes } = useTheme();
 
   const handleLogout = () => {
     localStorage.removeItem('token');
@@ -22,6 +24,37 @@ const Settings = () => {
       animate={{ opacity: 1, y: 0 }}
     >
       <h2>Settings</h2>
+      <fieldset className={styles.themeSection}>
+        <legend>Theme</legend>
+        <p className={styles.description}>
+          Themes apply instantly and persist on this device.
+        </p>
+        <div className={styles.themeOptions}>
+          {availableThemes.map((option) => (
+            <label
+              key={option}
+              className={`${styles.themeOption} ${
+                theme === option ? styles.selected : ''
+              }`}
+            >
+              <input
+                type="radio"
+                name="theme"
+                value={option}
+                checked={theme === option}
+                onChange={() => setTheme(option)}
+              />
+              <div className={styles.swatch} data-theme={option}>
+                <span className={styles.swatchText}>Aa</span>
+                <span className={styles.swatchPrimary} />
+              </div>
+              <span className={styles.optionLabel}>
+                {option.charAt(0).toUpperCase() + option.slice(1)}
+              </span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
       <div className={styles.dangerZone}>
         <h3>Danger Zone</h3>
         <button type="button" className={styles.logout} onClick={handleLogout}>


### PR DESCRIPTION
## Summary
- add theme section to settings with Light/Dark/Colorful options
- show live theme swatches and apply selection instantly
- persist chosen theme between sessions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ef7095f608332a47c893f0a3de157