### PR TITLE
Add language and notification settings with persistence

### DIFF
--- a/client/src/pages/Settings/Settings.module.scss
+++ b/client/src/pages/Settings/Settings.module.scss
@@ -6,6 +6,10 @@
   margin-top: 1rem;
 }
 
+.section {
+  margin-top: 1rem;
+}
+
 .description {
   margin-top: 0.25rem;
   font-size: var(--font-size-sm);
@@ -42,6 +46,26 @@
 .themeOption input:focus-visible + .swatch {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
+}
+
+.select {
+  margin-top: var(--space-3);
+}
+
+.select:focus-visible,
+.optionRow input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.prefItem {
+  margin-top: var(--space-3);
+}
+
+.optionRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .swatch {

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { ModalSheet } from '../../components/base';
 import { clearUser } from '../../store/slices/userSlice';
+import { setLanguage, setNotificationPrefs } from '../../store/slices/settingsSlice';
+import type { RootState } from '../../store';
 import { useTheme, type Theme } from '../../theme/ThemeProvider';
 import styles from './Settings.module.scss';
 
@@ -12,6 +14,7 @@ const Settings = () => {
   const navigate = useNavigate();
   const { theme, setTheme, availableThemes } = useTheme();
   const [sheetOpen, setSheetOpen] = useState(false);
+  const settings = useSelector((state: RootState) => state.settings);
 
   const handleSelectTheme = (option: Theme) => {
     setTheme(option);
@@ -24,6 +27,43 @@ const Settings = () => {
     dispatch(clearUser());
     navigate('/login');
   };
+
+  const handleLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const lang = e.target.value;
+    localStorage.setItem('manacity_lang', lang);
+    dispatch(setLanguage(lang));
+  };
+
+  const handleToggle = (
+    key: keyof typeof settings.notifications,
+    value: boolean,
+  ) => {
+    const updated = { ...settings.notifications, [key]: value };
+    localStorage.setItem('manacity_prefs', JSON.stringify(updated));
+    dispatch(setNotificationPrefs({ [key]: value }));
+  };
+
+  const notificationOptions: {
+    key: keyof typeof settings.notifications;
+    label: string;
+    description: string;
+  }[] = [
+    {
+      key: 'orderUpdates',
+      label: 'Order updates',
+      description: 'Get updates about the status of your orders.',
+    },
+    {
+      key: 'offersPromos',
+      label: 'Offers & promos',
+      description: 'Receive special offers and promotions.',
+    },
+    {
+      key: 'systemMessages',
+      label: 'System messages',
+      description: 'Be notified about important system changes.',
+    },
+  ];
 
   return (
     <motion.div
@@ -69,6 +109,36 @@ const Settings = () => {
             </label>
           ))}
         </div>
+      </fieldset>
+      <fieldset className={styles.section}>
+        <legend>Language</legend>
+        <p className={styles.description}>Select your preferred language.</p>
+        <select
+          id="language"
+          className={styles.select}
+          value={settings.language}
+          onChange={handleLanguageChange}
+        >
+          <option value="EN">English</option>
+          <option value="ES">Spanish</option>
+        </select>
+      </fieldset>
+      <fieldset className={styles.section}>
+        <legend>Notifications</legend>
+        {notificationOptions.map((opt) => (
+          <div key={opt.key} className={styles.prefItem}>
+            <div className={styles.optionRow}>
+              <label htmlFor={opt.key}>{opt.label}</label>
+              <input
+                id={opt.key}
+                type="checkbox"
+                checked={settings.notifications[opt.key]}
+                onChange={(e) => handleToggle(opt.key, e.target.checked)}
+              />
+            </div>
+            <p className={styles.description}>{opt.description}</p>
+          </div>
+        ))}
       </fieldset>
       <ModalSheet open={sheetOpen} onClose={() => setSheetOpen(false)}>
         <div className={styles.themeOptions}>

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -2,14 +2,16 @@ import { configureStore } from '@reduxjs/toolkit';
 import userReducer from './slices/userSlice';
 import cartReducer from './slices/cartSlice';
 import productReducer from './slices/productSlice';
+import settingsReducer from './slices/settingsSlice';
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
-    cart: cartReducer,
-    products: productReducer,
-  },
-});
+      cart: cartReducer,
+      products: productReducer,
+      settings: settingsReducer,
+    },
+  });
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/client/src/store/slices/settingsSlice.ts
+++ b/client/src/store/slices/settingsSlice.ts
@@ -1,0 +1,64 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export interface NotificationPrefs {
+  orderUpdates: boolean;
+  offersPromos: boolean;
+  systemMessages: boolean;
+}
+
+export interface SettingsState {
+  language: string;
+  notifications: NotificationPrefs;
+}
+
+const defaultNotifications: NotificationPrefs = {
+  orderUpdates: true,
+  offersPromos: true,
+  systemMessages: true,
+};
+
+const getInitialLanguage = (): string => {
+  if (typeof localStorage !== 'undefined') {
+    const stored = localStorage.getItem('manacity_lang');
+    if (stored) return stored;
+    localStorage.setItem('manacity_lang', 'EN');
+  }
+  return 'EN';
+};
+
+const getInitialNotifications = (): NotificationPrefs => {
+  if (typeof localStorage !== 'undefined') {
+    const stored = localStorage.getItem('manacity_prefs');
+    if (stored) {
+      try {
+        return { ...defaultNotifications, ...JSON.parse(stored) };
+      } catch {
+        // ignore parse errors and fall back to defaults
+      }
+    } else {
+      localStorage.setItem('manacity_prefs', JSON.stringify(defaultNotifications));
+    }
+  }
+  return defaultNotifications;
+};
+
+const initialState: SettingsState = {
+  language: getInitialLanguage(),
+  notifications: getInitialNotifications(),
+};
+
+const settingsSlice = createSlice({
+  name: 'settings',
+  initialState,
+  reducers: {
+    setLanguage(state, action: PayloadAction<string>) {
+      state.language = action.payload;
+    },
+    setNotificationPrefs(state, action: PayloadAction<Partial<NotificationPrefs>>) {
+      state.notifications = { ...state.notifications, ...action.payload };
+    },
+  },
+});
+
+export const { setLanguage, setNotificationPrefs } = settingsSlice.actions;
+export default settingsSlice.reducer;


### PR DESCRIPTION
## Summary
- add settings slice to persist language and notification preferences
- expose language dropdown and notification toggles in settings page
- style and focus states for accessible controls

## Testing
- `npm --prefix client run lint`
- `cd client && npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689f027fd3e483328a4dc67a913908d0