### PR TITLE
refactor: apply theme tokens across UI

### DIFF
--- a/client/src/components/Shimmer.scss
+++ b/client/src/components/Shimmer.scss
@@ -6,7 +6,7 @@
 .shimmer {
   position: relative;
   overflow: hidden;
-  background-color: #f0f0f0;
+  background-color: var(--color-surface);
 }
 
 .shimmer::after {

--- a/client/src/components/base/CartSummary.module.scss
+++ b/client/src/components/base/CartSummary.module.scss
@@ -8,9 +8,9 @@
   flex-direction: column;
   gap: 0.5rem;
   padding: 1rem;
-  background: #fff;
+  background: var(--color-card);
   border-radius: 8px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-sm);
 }
 
 .row {
@@ -27,7 +27,7 @@
 }
 
 .checkout {
-  @include button-style(var(--color-primary), #fff);
+  @include button-style(var(--color-primary), var(--color-on-primary));
   width: 100%;
   margin-top: 0.5rem;
 }
@@ -38,11 +38,11 @@
   input {
     flex: 1;
     padding: 0.5rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--color-border);
     border-radius: 4px;
   }
   button {
-    @include button-style(var(--color-primary), #fff);
+    @include button-style(var(--color-primary), var(--color-on-primary));
     padding: 0.5rem 1rem;
   }
 }

--- a/client/src/components/base/FacetFilterBar.module.scss
+++ b/client/src/components/base/FacetFilterBar.module.scss
@@ -28,7 +28,7 @@
 
 .active {
   background: var(--color-primary);
-  color: #fff;
+  color: var(--color-on-primary);
 }
 
 .desktopFilters {
@@ -57,7 +57,7 @@
   border: none;
   border-radius: var(--radius-sm);
   background: var(--color-primary);
-  color: #fff;
+  color: var(--color-on-primary);
   cursor: pointer;
 
   &:focus-visible {

--- a/client/src/components/base/ModalSheet.module.scss
+++ b/client/src/components/base/ModalSheet.module.scss
@@ -1,7 +1,7 @@
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0,0,0,0.4);
+  background: var(--overlay-bg);
   display: flex;
   justify-content: center;
   align-items: flex-end;

--- a/client/src/components/base/OrderCard.module.scss
+++ b/client/src/components/base/OrderCard.module.scss
@@ -49,7 +49,7 @@
     border-radius: var(--radius-sm);
     cursor: pointer;
     background: var(--color-primary);
-    color: #fff;
+    color: var(--color-on-primary);
 
     &:focus-visible {
       outline: 2px solid var(--color-primary);

--- a/client/src/components/base/OrderLineItem.module.scss
+++ b/client/src/components/base/OrderLineItem.module.scss
@@ -6,9 +6,9 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem;
-  background: #fff;
+  background: var(--color-card);
   border-radius: 8px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-sm);
 
   img {
     width: 64px;
@@ -38,6 +38,6 @@
 }
 
 .remove {
-  @include button-style(red, #fff);
+  @include button-style(var(--color-danger), var(--color-on-primary));
   padding: 0.3rem 0.6rem;
 }

--- a/client/src/components/base/ProductCard.module.scss
+++ b/client/src/components/base/ProductCard.module.scss
@@ -31,7 +31,7 @@
     left: var(--spacing-sm);
     top: var(--spacing-sm);
     background: var(--color-primary);
-    color: #fff;
+    color: var(--color-on-primary);
     border-radius: var(--radius-sm);
     padding: 2px 6px;
     font-size: var(--font-size-sm);
@@ -66,7 +66,7 @@
   border: none;
   border-radius: var(--radius-sm);
   background: var(--color-primary);
-  color: #fff;
+  color: var(--color-on-primary);
   cursor: pointer;
   transition: background var(--transition-fast);
 

--- a/client/src/components/base/ProfileHeader.module.scss
+++ b/client/src/components/base/ProfileHeader.module.scss
@@ -28,7 +28,7 @@
 
 .role {
   background: var(--color-primary);
-  color: #fff;
+  color: var(--color-on-primary);
   padding: 0 var(--spacing-xs);
   border-radius: var(--radius-sm);
   font-size: 0.75rem;

--- a/client/src/components/toast.ts
+++ b/client/src/components/toast.ts
@@ -9,11 +9,11 @@ const showToast = (message: string, type: ToastType = 'success') => {
     bottom: 1rem;
     left: 50%;
     transform: translateX(-50%);
-    background: ${type === 'success' ? '#16a34a' : '#dc2626'};
-    color: #fff;
+    background: ${type === 'success' ? 'var(--color-success)' : 'var(--color-danger)'};
+    color: var(--color-on-primary);
     padding: 0.75rem 1rem;
     border-radius: 4px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-md);
     z-index: 9999;
     opacity: 0;
     transition: opacity 0.3s ease;

--- a/client/src/components/ui/HorizontalCarousel.module.scss
+++ b/client/src/components/ui/HorizontalCarousel.module.scss
@@ -32,7 +32,8 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  background: rgba(255, 255, 255, 0.8);
+  background: var(--color-bg);
+  opacity: 0.8;
   border: none;
   cursor: pointer;
   padding: 0.25rem;

--- a/client/src/components/ui/ProductCard.module.scss
+++ b/client/src/components/ui/ProductCard.module.scss
@@ -38,7 +38,7 @@
     left: var(--spacing-sm);
     top: var(--spacing-sm);
     background: var(--color-primary);
-    color: #fff;
+    color: var(--color-on-primary);
     border-radius: var(--radius-sm);
     padding: 2px 6px;
     font-size: var(--font-size-sm);
@@ -80,7 +80,7 @@
     border-radius: var(--radius-sm);
     cursor: pointer;
     background: var(--color-primary);
-    color: #fff;
+    color: var(--color-on-primary);
     transition: background var(--transition-fast);
 
     &:hover {

--- a/client/src/components/ui/StatusChip.module.scss
+++ b/client/src/components/ui/StatusChip.module.scss
@@ -9,23 +9,23 @@
 
 .pending {
   background: var(--color-primary);
-  color: #fff;
+  color: var(--color-on-primary);
 }
 
 .accepted {
   background: var(--color-success);
-  color: #fff;
+  color: var(--color-on-primary);
 }
 
 .rejected,
 .cancelled {
   background: var(--color-danger);
-  color: #fff;
+  color: var(--color-on-primary);
 }
 
 .completed {
   background: var(--color-info);
-  color: #fff;
+  color: var(--color-on-primary);
 }
 
 @media (min-width: 768px) {

--- a/client/src/pages/Cart/Cart.module.scss
+++ b/client/src/pages/Cart/Cart.module.scss
@@ -12,7 +12,7 @@
 
   .empty {
     text-align: center;
-    color: #666;
+    color: var(--color-muted);
     margin-top: 2rem;
   }
 

--- a/client/src/pages/Home/Home.scss
+++ b/client/src/pages/Home/Home.scss
@@ -17,7 +17,7 @@
     overflow: hidden;
     cursor: pointer;
     margin-bottom: 2rem;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-lg);
 
     img {
       width: 100%;
@@ -37,8 +37,8 @@
       position: absolute;
       bottom: 1rem;
       left: 1rem;
-      color: white;
-      text-shadow: 1px 1px 5px black;
+      color: var(--color-on-primary);
+      text-shadow: 1px 1px 5px var(--color-text);
 
       h3 {
         font-size: 1.5rem;
@@ -64,11 +64,11 @@
     margin-bottom: 2rem;
 
     .card {
-      background: #fff;
+      background: var(--color-card);
       border-radius: 1rem;
       overflow: hidden;
       cursor: pointer;
-      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.07);
+      box-shadow: var(--shadow-md);
       transition: 0.3s;
       width: 100%;
 
@@ -92,7 +92,7 @@
 
         p {
           font-size: 0.9rem;
-          color: #666;
+          color: var(--color-muted);
         }
       }
     }

--- a/client/src/pages/LandingPage/LandingPage.scss
+++ b/client/src/pages/LandingPage/LandingPage.scss
@@ -32,7 +32,7 @@
     h1 {
       font-size: 2.4rem;
       font-weight: 700;
-      color: #222;
+      color: var(--color-text);
 
       span {
         color: $primary-color;
@@ -45,7 +45,7 @@
 
     p {
       font-size: 1.1rem;
-      color: #555;
+      color: var(--color-muted);
       margin: 1rem 0 2rem;
       max-width: 600px;
     }
@@ -70,7 +70,7 @@
 
         &.primary {
           background: $primary-color;
-          color: #fff;
+          color: var(--color-on-primary);
           border: none;
 
           &:hover {
@@ -79,13 +79,13 @@
         }
 
         &.secondary {
-          background: #fff;
+          background: var(--color-bg);
           color: $primary-color;
           border: 2px solid $primary-color;
 
           &:hover {
             background: $primary-color;
-            color: #fff;
+            color: var(--color-on-primary);
           }
         }
       }
@@ -120,7 +120,7 @@
       }
 
       p {
-        color: #555;
+        color: var(--color-muted);
         font-size: 0.95rem;
       }
     }
@@ -131,7 +131,7 @@
     justify-content: space-around;
     align-items: center;
     padding: 1.5rem 2rem;
-    background: #f9f9f9;
+    background: var(--color-surface);
     text-align: center;
     flex-wrap: wrap;
     gap: 1rem;

--- a/client/src/pages/MyOrders/MyOrders.module.scss
+++ b/client/src/pages/MyOrders/MyOrders.module.scss
@@ -22,7 +22,7 @@
     padding: 0.4rem 0.8rem;
     border: none;
     border-radius: 999px;
-    background: #f2f2f2;
+    background: var(--color-surface);
     font-size: 0.85rem;
     cursor: pointer;
   }
@@ -32,14 +32,14 @@
   margin-bottom: 1rem;
 }
 
-.month {
-  position: sticky;
-  top: 0;
-  background: #fff;
-  padding: 0.25rem 0;
-  font-weight: bold;
-  z-index: 1;
-}
+  .month {
+    position: sticky;
+    top: 0;
+    background: var(--color-bg);
+    padding: 0.25rem 0;
+    font-weight: bold;
+    z-index: 1;
+  }
 
 .empty {
   text-align: center;
@@ -57,5 +57,5 @@
 
 .browse {
   margin-top: 1rem;
-  @include button-style($primary-color, #fff);
+  @include button-style($primary-color, var(--color-on-primary));
 }

--- a/client/src/pages/Notifications/Notifications.scss
+++ b/client/src/pages/Notifications/Notifications.scss
@@ -9,13 +9,13 @@
     button {
       padding: 0.4rem 0.8rem;
       border-radius: 4px;
-      background: #eee;
+      background: var(--color-surface);
       border: none;
       cursor: pointer;
 
       &.active {
-        background: #333;
-        color: #fff;
+        background: var(--color-text);
+        color: var(--color-on-primary);
       }
     }
   }
@@ -33,11 +33,11 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    background: #fff;
+    background: var(--color-card);
     border-radius: 8px;
     padding: 0.5rem;
     margin-bottom: 0.5rem;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    box-shadow: var(--shadow-sm);
 
     &.read {
       opacity: 0.6;
@@ -61,7 +61,7 @@
       p {
         margin: 0;
         font-size: 0.85rem;
-        color: #555;
+        color: var(--color-muted);
       }
     }
 
@@ -69,7 +69,7 @@
       display: none;
       background: transparent;
       border: none;
-      color: #0077ff;
+      color: var(--color-info);
       cursor: pointer;
     }
   }
@@ -77,7 +77,7 @@
   .empty-state {
     text-align: center;
     margin-top: 2rem;
-    color: #666;
+    color: var(--color-muted);
   }
 }
 

--- a/client/src/pages/ProductDetails/ProductDetails.scss
+++ b/client/src/pages/ProductDetails/ProductDetails.scss
@@ -32,7 +32,7 @@
       }
 
       img.active {
-        border-color: #27ae60;
+        border-color: var(--color-success);
       }
     }
   }
@@ -53,7 +53,7 @@
 
     details {
       margin-bottom: 0.75rem;
-      border: 1px solid #ddd;
+      border: 1px solid var(--color-border);
       border-radius: 8px;
       padding: 0.5rem 1rem;
 
@@ -64,7 +64,7 @@
 
       p {
         margin-top: 0.5rem;
-        color: #333;
+        color: var(--color-text);
       }
     }
   }
@@ -82,13 +82,13 @@
     gap: 1rem;
     align-items: center;
     padding: 0.75rem 1rem;
-    background: #fff;
-    box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
+    background: var(--color-card);
+    box-shadow: var(--shadow-md);
 
     .add-cart-btn {
       flex: 1;
-      background-color: #27ae60;
-      color: #fff;
+      background-color: var(--color-success);
+      color: var(--color-on-primary);
       padding: 0.75rem;
       font-weight: 600;
       border: none;
@@ -97,7 +97,7 @@
       transition: background 0.2s ease;
 
       &:hover {
-        background-color: #1e874b;
+        opacity: 0.9;
       }
     }
   }

--- a/client/src/pages/Profile/Profile.module.scss
+++ b/client/src/pages/Profile/Profile.module.scss
@@ -13,13 +13,13 @@
   }
 
   &.light {
-    background: #f7f7f7;
-    color: #111;
+    background: var(--color-bg);
+    color: var(--color-text);
   }
 
   &.dark {
-    background: #111;
-    color: #f7f7f7;
+    background: var(--color-bg);
+    color: var(--color-text);
   }
 
   .userCard {
@@ -54,7 +54,7 @@
 
     .editBtn {
       margin-top: 0.5rem;
-      @include button-style($primary-color, #fff);
+      @include button-style($primary-color, var(--color-on-primary));
     }
 
     .status {
@@ -62,13 +62,13 @@
       margin-top: 0.5rem;
 
       &.verified {
-        color: #22c55e;
+        color: var(--color-success);
       }
       &.pending {
-        color: #fbbf24;
+        color: var(--color-warning);
       }
       &.rejected {
-        color: #ef4444;
+        color: var(--color-danger);
       }
     }
   }
@@ -104,7 +104,7 @@
   .modal {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.45);
+    background: var(--overlay-bg);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -135,7 +135,7 @@
             width: 100%;
             padding: 0.6rem;
             margin-top: 0.3rem;
-            border: 1px solid #ccc;
+            border: 1px solid var(--color-border);
             border-radius: 8px;
             font-size: 1rem;
 
@@ -152,15 +152,15 @@
           gap: 1rem;
 
           button {
-            @include button-style($primary-color, #fff);
+            @include button-style($primary-color, var(--color-on-primary));
             padding: 0.5rem 1rem;
 
             &.cancel {
-              background: #eee;
-              color: #333;
+              background: var(--color-surface);
+              color: var(--color-text);
 
               &:hover {
-                background: #ddd;
+                background: var(--color-muted);
               }
             }
           }
@@ -195,20 +195,20 @@
 
 .prefs {
   font-size: 0.9rem;
-  color: #666;
+  color: var(--color-muted);
 }
 
 .statusIndicator {
   font-weight: 600;
   margin: 0.5rem 0;
   &.approved {
-    color: #22c55e;
+    color: var(--color-success);
   }
   &.pending {
-    color: #fbbf24;
+    color: var(--color-warning);
   }
   &.rejected {
-    color: #ef4444;
+    color: var(--color-danger);
   }
 }
 
@@ -233,7 +233,7 @@
       width: 100%;
       padding: 0.6rem;
       margin-top: 0.3rem;
-      border: 1px solid #ccc;
+      border: 1px solid var(--color-border);
       border-radius: 8px;
       font-size: 1rem;
 
@@ -250,15 +250,15 @@
     gap: 1rem;
 
     button {
-      @include button-style($primary-color, #fff);
+      @include button-style($primary-color, var(--color-on-primary));
       padding: 0.5rem 1rem;
 
       &:first-child {
-        background: #eee;
-        color: #333;
+        background: var(--color-surface);
+        color: var(--color-text);
 
         &:hover {
-          background: #ddd;
+          background: var(--color-muted);
         }
       }
     }

--- a/client/src/pages/ReceivedOrders/ReceivedOrders.module.scss
+++ b/client/src/pages/ReceivedOrders/ReceivedOrders.module.scss
@@ -22,7 +22,7 @@
     padding: 0.4rem 0.8rem;
     border: none;
     border-radius: 999px;
-    background: #f2f2f2;
+    background: var(--color-surface);
     font-size: 0.85rem;
     cursor: pointer;
   }

--- a/client/src/pages/Settings/Settings.module.scss
+++ b/client/src/pages/Settings/Settings.module.scss
@@ -107,13 +107,13 @@
 
 .dangerZone {
   margin-top: 2rem;
-  border-top: 1px solid #e53e3e;
+  border-top: 1px solid var(--color-danger);
   padding-top: 1rem;
 }
 
 .logout {
-  background: #e53e3e;
-  color: #fff;
+  background: var(--color-danger);
+  color: var(--color-on-primary);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;

--- a/client/src/pages/ShopDetails/ShopDetails.tsx
+++ b/client/src/pages/ShopDetails/ShopDetails.tsx
@@ -109,7 +109,7 @@ const ShopDetails = () => {
             <h2>{shop.name}</h2>
             {shop.rating && (
               <div className="rating">
-                <AiFillStar color="var(--color-warning, #fbbf24)" />
+                <AiFillStar color="var(--color-warning)" />
                 <span>{shop.rating.toFixed(1)}</span>
               </div>
             )}

--- a/client/src/pages/Shops/Shops.module.scss
+++ b/client/src/pages/Shops/Shops.module.scss
@@ -9,19 +9,19 @@
     position: sticky;
     top: 0;
     z-index: 10;
-    background: #fff;
+    background: var(--color-card);
     padding-bottom: 0.75rem;
     margin-bottom: 0.75rem;
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--color-border);
   }
 
   .searchBar input,
   .searchBar select {
     padding: 0.5rem 0.75rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--color-border);
     border-radius: 6px;
     flex: 1;
     min-width: 140px;
@@ -44,8 +44,8 @@
     button {
       flex-shrink: 0;
       padding: 0.4rem 0.9rem;
-      border: 1px solid #ccc;
-      background: #fff;
+      border: 1px solid var(--color-border);
+      background: var(--color-bg);
       border-radius: 999px;
       cursor: pointer;
       white-space: nowrap;
@@ -53,7 +53,7 @@
 
       &.active {
         background: $primary-color;
-        color: #fff;
+        color: var(--color-on-primary);
         border-color: $primary-color;
       }
     }
@@ -70,10 +70,10 @@
   }
 
   .card {
-    background: #fff;
+    background: var(--color-card);
     border-radius: 12px;
     overflow: hidden;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: var(--shadow-sm);
     cursor: pointer;
     transition: transform 0.2s ease;
 
@@ -95,7 +95,7 @@
       }
       p {
         margin: 0;
-        color: #666;
+        color: var(--color-muted);
       }
       .badge {
         display: inline-block;
@@ -104,12 +104,12 @@
         border-radius: 4px;
         font-size: 0.75rem;
         &.open {
-          background: #d4edda;
-          color: #155724;
+          background: var(--color-success);
+          color: var(--color-on-primary);
         }
         &.closed {
-          background: #f8d7da;
-          color: #721c24;
+          background: var(--color-danger);
+          color: var(--color-on-primary);
         }
       }
     }

--- a/client/src/styles/_theme.scss
+++ b/client/src/styles/_theme.scss
@@ -50,6 +50,10 @@
   --color-success: #22c55e;
   --color-danger: #ef4444;
   --color-muted: #6b7280;
+  --color-text-secondary: var(--color-muted);
+  --color-border: var(--color-muted);
+  --color-on-primary: #ffffff;
+  --overlay-bg: rgba(0, 0, 0, 0.4);
 
   /* Legacy colour aliases */
   --color-card: var(--color-surface);
@@ -72,6 +76,7 @@
   --color-card: var(--color-surface);
   --color-warning: #f59e0b;
   --color-info: #3b82f6;
+  --overlay-bg: rgba(0, 0, 0, 0.4);
 }
 
 /* Dark theme */
@@ -91,6 +96,7 @@
   --color-card: var(--color-surface);
   --color-warning: #f59e0b;
   --color-info: #3b82f6;
+  --overlay-bg: rgba(0, 0, 0, 0.6);
 }
 
 /* Colourful theme with brand accents */
@@ -107,5 +113,6 @@
   --color-card: var(--color-surface);
   --color-warning: #f59e0b;
   --color-info: #3b82f6;
+  --overlay-bg: rgba(0, 0, 0, 0.4);
 }
 

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -1,7 +1,7 @@
 $primary-color: var(--color-primary);
 $primary-color-hover: var(--color-primary-hover);
-$gradient-start: #FF3E6C;
-$gradient-middle: #FF6B81;
-$gradient-end: #FF3E6C;
+$gradient-start: var(--color-primary);
+$gradient-middle: var(--color-primary-hover);
+$gradient-end: var(--color-primary);
 $font-header: var(--font-family-sans);
 $font-body: var(--font-family-sans);


### PR DESCRIPTION
## Summary
- map theme variables for accents, borders and overlays
- refactor shared components to consume CSS vars
- replace page module color literals with theme tokens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f04ab19788332999d0b1bcfd2856f