### PR TITLE
feat: add admin login and protected layout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,7 +31,9 @@ import AdminDashboard from './pages/AdminDashboard';
 import AdminPanel from './pages/AdminPanel';
 import VerificationRequests from './pages/VerificationRequests';
 import AdminProtectedRoute from './components/AdminProtectedRoute';
+import AdminLayout from './layouts/AdminLayout';
 import { setUser } from './store/slices/userSlice';
+import { setAdminToken } from './store/slices/adminSlice';
 import type { AppDispatch } from './store';
 import UiPreview from './pages/UiPreview';
 
@@ -47,6 +49,11 @@ function App() {
         // ignore parsing errors
       }
     }
+
+    const adminToken = localStorage.getItem('manacity_admin_token');
+    if (adminToken) {
+      dispatch(setAdminToken(adminToken));
+    }
   }, [dispatch]);
 
   return (
@@ -55,13 +62,15 @@ function App() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
-        <Route path="/admin-login" element={<AdminLogin />} />
+        <Route path="/admin/login" element={<AdminLogin />} />
         <Route path="/preview" element={<UiPreview />} />
         {/* <Route path="/verify-otp" element={<OtpPage />} /> */}
-        <Route element={<AdminProtectedRoute />}>
-          <Route path="/admin-dashboard" element={<AdminDashboard />} />
-          <Route path="/admin-panel" element={<AdminPanel />} />
-          <Route path="/admin/verification-requests" element={<VerificationRequests />} />
+        <Route path="/admin" element={<AdminProtectedRoute />}>
+          <Route element={<AdminLayout />}>
+            <Route index element={<AdminDashboard />} />
+            <Route path="shops" element={<AdminPanel />} />
+            <Route path="requests" element={<VerificationRequests />} />
+          </Route>
         </Route>
         <Route element={<ProtectedRoute />}>
           <Route element={<TabLayout />}>

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -1,15 +1,18 @@
 import adminApi from './adminClient';
 
 export interface AdminCreds {
-  email: string;
+  identifier: string;
   password: string;
 }
 
-export const adminLogin = async (creds: AdminCreds) => {
-  const res = await adminApi.post('/auth/admin-login', creds);
+export const adminLogin = async ({ identifier, password }: AdminCreds) => {
+  const res = await adminApi.post('/auth/admin-login', {
+    email: identifier,
+    password,
+  });
   const { token } = res.data;
   if (token) {
-    localStorage.setItem('adminToken', token);
+    localStorage.setItem('manacity_admin_token', token);
   }
   return token;
 };

--- a/client/src/api/adminClient.ts
+++ b/client/src/api/adminClient.ts
@@ -5,7 +5,7 @@ const adminApi = axios.create({
 });
 
 adminApi.interceptors.request.use((config) => {
-  const token = localStorage.getItem('adminToken');
+  const token = localStorage.getItem('manacity_admin_token');
   if (token) {
     config.headers = config.headers || {};
     config.headers.Authorization = `Bearer ${token}`;

--- a/client/src/components/AdminProtectedRoute.tsx
+++ b/client/src/components/AdminProtectedRoute.tsx
@@ -1,9 +1,13 @@
 import { Navigate, Outlet } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../store';
 
 const AdminProtectedRoute = () => {
-  const token = localStorage.getItem('adminToken');
+  const token =
+    useSelector((state: RootState) => state.admin.token) ||
+    localStorage.getItem('manacity_admin_token');
   if (!token) {
-    return <Navigate to="/admin-login" replace />;
+    return <Navigate to="/admin/login" replace />;
   }
   return <Outlet />;
 };

--- a/client/src/layouts/AdminLayout.scss
+++ b/client/src/layouts/AdminLayout.scss
@@ -1,0 +1,46 @@
+.admin-layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.admin-sidebar {
+  width: 220px;
+  background: #f5f5f5;
+  padding: 1rem;
+}
+
+.admin-sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.admin-sidebar li {
+  margin-bottom: 0.5rem;
+}
+
+.admin-sidebar a,
+.admin-sidebar span {
+  color: #333;
+  text-decoration: none;
+}
+
+.admin-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.admin-topbar {
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+}
+
+.admin-main {
+  flex: 1;
+  padding: 1rem;
+  background: #fafafa;
+}

--- a/client/src/layouts/AdminLayout.tsx
+++ b/client/src/layouts/AdminLayout.tsx
@@ -1,0 +1,33 @@
+import { Link, Outlet } from 'react-router-dom';
+import './AdminLayout.scss';
+
+const AdminLayout = () => {
+  return (
+    <div className="admin-layout">
+      <aside className="admin-sidebar">
+        <nav>
+          <ul>
+            <li><Link to="/admin">Dashboard</Link></li>
+            <li><Link to="/admin/requests">Requests</Link></li>
+            <li><Link to="/admin/shops">Shops</Link></li>
+            <li><span>Products</span></li>
+            <li><span>Events</span></li>
+            <li><span>Users</span></li>
+            <li><span>Analytics</span></li>
+          </ul>
+        </nav>
+      </aside>
+      <div className="admin-content">
+        <header className="admin-topbar">
+          <input type="text" placeholder="Search..." />
+          <div className="quick-actions">Quick Actions</div>
+        </header>
+        <main className="admin-main">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/client/src/pages/AdminLogin/AdminLogin.tsx
+++ b/client/src/pages/AdminLogin/AdminLogin.tsx
@@ -1,13 +1,17 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import { useDispatch } from 'react-redux';
 import { adminLogin } from '../../api/admin';
+import { setAdminToken } from '../../store/slices/adminSlice';
+import type { AppDispatch } from '../../store';
 import Loader from '../../components/Loader';
 import './AdminLogin.scss';
 
 const AdminLogin = () => {
   const navigate = useNavigate();
-  const [form, setForm] = useState({ email: '', password: '' });
+  const dispatch = useDispatch<AppDispatch>();
+  const [form, setForm] = useState({ identifier: '', password: '' });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -20,8 +24,11 @@ const AdminLogin = () => {
     setError('');
     try {
       setLoading(true);
-      await adminLogin(form);
-      navigate('/admin-dashboard');
+      const token = await adminLogin(form);
+      if (token) {
+        dispatch(setAdminToken(token));
+        navigate('/admin');
+      }
     } catch (err: any) {
       const message = err.response?.data?.error || 'Login failed';
       setError(message);
@@ -34,7 +41,14 @@ const AdminLogin = () => {
     <div className="admin-login-page">
       <motion.form onSubmit={handleSubmit} className="admin-form" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
         <h2>Admin Login</h2>
-        <input name="email" placeholder="Email" type="email" value={form.email} onChange={handleChange} required />
+        <input
+          name="identifier"
+          placeholder="Phone or Email"
+          type="text"
+          value={form.identifier}
+          onChange={handleChange}
+          required
+        />
         <input name="password" placeholder="Password" type="password" value={form.password} onChange={handleChange} required />
         {error && <div className="error">{error}</div>}
         <motion.button type="submit" whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }} disabled={loading}>

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -3,15 +3,17 @@ import userReducer from './slices/userSlice';
 import cartReducer from './slices/cartSlice';
 import productReducer from './slices/productSlice';
 import settingsReducer from './slices/settingsSlice';
+import adminReducer from './slices/adminSlice';
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
-      cart: cartReducer,
-      products: productReducer,
-      settings: settingsReducer,
-    },
-  });
+    cart: cartReducer,
+    products: productReducer,
+    settings: settingsReducer,
+    admin: adminReducer,
+  },
+});
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/client/src/store/slices/adminSlice.ts
+++ b/client/src/store/slices/adminSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+interface AdminState {
+  token: string | null;
+}
+
+const initialState: AdminState = {
+  token: null,
+};
+
+const adminSlice = createSlice({
+  name: 'admin',
+  initialState,
+  reducers: {
+    setAdminToken(state, action: PayloadAction<string>) {
+      state.token = action.payload;
+    },
+    clearAdminToken(state) {
+      state.token = null;
+    },
+  },
+});
+
+export const { setAdminToken, clearAdminToken } = adminSlice.actions;
+export default adminSlice.reducer;


### PR DESCRIPTION
## Summary
- add Redux slice to track admin authentication token
- create /admin/login page and protect /admin/* routes
- introduce admin dashboard shell with top bar and sidebar navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f0aeb14e88332a56dbf9685d0c603