### PR TITLE
feat(admin): add generic DataTable component

### DIFF
--- a/client/src/components/admin/DataTable.module.scss
+++ b/client/src/components/admin/DataTable.module.scss
@@ -1,0 +1,121 @@
+.wrapper {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: var(--space-2) var(--space-3);
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  thead th {
+    background: var(--color-surface);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+}
+
+.sortButton {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.filtersRow {
+  th {
+    padding: var(--space-1) var(--space-2);
+  }
+
+  input {
+    width: 100%;
+    padding: var(--space-1);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg);
+    color: var(--color-text);
+  }
+}
+
+.empty {
+  text-align: center;
+  padding: var(--space-4);
+  color: var(--color-muted);
+}
+
+.pagination {
+  margin-top: var(--space-3);
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-2);
+
+  button {
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg);
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+@media (max-width: 640px) {
+  .table,
+  .table thead,
+  .table tbody,
+  .table th,
+  .table td,
+  .table tr {
+    display: block;
+  }
+
+  .table thead {
+    display: none;
+  }
+
+  .row {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    margin-bottom: var(--space-3);
+  }
+
+  .cell {
+    display: flex;
+    justify-content: space-between;
+    padding: var(--space-2);
+    border-bottom: 1px solid var(--color-border);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &::before {
+      content: attr(data-label);
+      font-weight: 600;
+      margin-right: var(--space-2);
+    }
+  }
+
+  .filtersRow {
+    display: none;
+  }
+}

--- a/client/src/components/admin/DataTable.tsx
+++ b/client/src/components/admin/DataTable.tsx
@@ -1,0 +1,220 @@
+import { useState, type ReactNode } from 'react';
+import Shimmer from '../Shimmer';
+import styles from './DataTable.module.scss';
+
+export type ColumnKey<T> = keyof T & string;
+
+export interface Column<T> {
+  key: ColumnKey<T>;
+  label: string;
+  sortable?: boolean;
+  render?: (row: T) => ReactNode;
+}
+
+export interface FilterConfig {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export interface DataTableProps<T extends Record<string, any>> {
+  columns: Column<T>[];
+  rows: T[];
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  onSort?: (key: ColumnKey<T>, direction: 'asc' | 'desc') => void;
+  filters?: Record<ColumnKey<T>, FilterConfig>;
+  loading?: boolean;
+  selectable?: boolean;
+  selected?: string[];
+  onSelectionChange?: (ids: string[]) => void;
+  rowKey?: (row: T, index: number) => string;
+}
+
+function DataTable<T extends Record<string, any>>({
+  columns,
+  rows,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onSort,
+  filters,
+  loading = false,
+  selectable = false,
+  selected = [],
+  onSelectionChange,
+  rowKey,
+}: DataTableProps<T>) {
+  const [sortKey, setSortKey] = useState<ColumnKey<T> | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+
+  const getRowId = (row: T, idx: number) =>
+    rowKey ? rowKey(row, idx) : (row as any).id ?? (row as any)._id ?? String(idx);
+
+  const selectedSet = new Set(selected);
+
+  const handleSort = (key: ColumnKey<T>) => {
+    let dir: 'asc' | 'desc' = 'asc';
+    if (sortKey === key && sortDir === 'asc') {
+      dir = 'desc';
+    }
+    setSortKey(key);
+    setSortDir(dir);
+    onSort?.(key, dir);
+  };
+
+  const toggleAll = (checked: boolean) => {
+    if (!onSelectionChange) return;
+    if (checked) {
+      onSelectionChange(rows.map((r, i) => getRowId(r, i)));
+    } else {
+      onSelectionChange([]);
+    }
+  };
+
+  const toggleRow = (id: string, checked: boolean) => {
+    if (!onSelectionChange) return;
+    const next = new Set(selectedSet);
+    if (checked) {
+      next.add(id);
+    } else {
+      next.delete(id);
+    }
+    onSelectionChange(Array.from(next));
+  };
+
+  const renderBody = () => {
+    if (loading) {
+      return Array.from({ length: Math.max(pageSize, 3) }, (_, i) => (
+        <tr key={i} className={styles.row}>
+          <td colSpan={columns.length + (selectable ? 1 : 0)}>
+            <Shimmer height="20px" />
+          </td>
+        </tr>
+      ));
+    }
+
+    if (!rows.length) {
+      return (
+        <tr className={styles.row}>
+          <td
+            colSpan={columns.length + (selectable ? 1 : 0)}
+            className={styles.empty}
+          >
+            No records
+          </td>
+        </tr>
+      );
+    }
+
+    return rows.map((row, rowIndex) => {
+      const id = getRowId(row, rowIndex);
+      return (
+        <tr key={id} className={styles.row}>
+          {selectable && (
+            <td className={styles.cell} data-label="Select">
+              <input
+                type="checkbox"
+                aria-label="Select row"
+                checked={selectedSet.has(id)}
+                onChange={(e) => toggleRow(id, e.target.checked)}
+              />
+            </td>
+          )}
+          {columns.map((col) => (
+            <td
+              key={col.key}
+              className={styles.cell}
+              data-label={col.label}
+            >
+              {col.render ? col.render(row) : (row as any)[col.key]}
+            </td>
+          ))}
+        </tr>
+      );
+    });
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            {selectable && (
+              <th>
+                <input
+                  type="checkbox"
+                  aria-label="Select all"
+                  checked={rows.length > 0 && selectedSet.size === rows.length}
+                  onChange={(e) => toggleAll(e.target.checked)}
+                />
+              </th>
+            )}
+            {columns.map((col) => (
+              <th key={col.key} scope="col">
+                {col.sortable ? (
+                  <button
+                    type="button"
+                    className={styles.sortButton}
+                    onClick={() => handleSort(col.key)}
+                  >
+                    {col.label}
+                    {sortKey === col.key && (
+                      <span>{sortDir === 'asc' ? '▲' : '▼'}</span>
+                    )}
+                  </button>
+                ) : (
+                  col.label
+                )}
+              </th>
+            ))}
+          </tr>
+          {filters && (
+            <tr className={styles.filtersRow}>
+              {selectable && <th />}
+              {columns.map((col) => (
+                <th key={col.key}>
+                  {filters[col.key] ? (
+                    <input
+                      type="text"
+                      value={filters[col.key].value}
+                      placeholder={filters[col.key].placeholder}
+                      onChange={(e) => filters[col.key].onChange(e.target.value)}
+                    />
+                  ) : null}
+                </th>
+              ))}
+            </tr>
+          )}
+        </thead>
+        <tbody>{renderBody()}</tbody>
+      </table>
+      <nav className={styles.pagination} aria-label="Pagination">
+        <button
+          type="button"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page <= 1}
+        >
+          Prev
+        </button>
+        <span>
+          {page} / {pageCount}
+        </span>
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={page >= pageCount}
+        >
+          Next
+        </button>
+      </nav>
+    </div>
+  );
+}
+
+export default DataTable;


### PR DESCRIPTION
## Summary
- add reusable DataTable with sorting, filtering, pagination and optional bulk select
- style table for responsive card layout and sticky header

## Testing
- `npm run lint`
- `npm run build` *(fails: ReactNode import and type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689f0c9fce2c8332b9c9110a423950e2