### PR TITLE
feat(admin): manage verification requests

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -69,7 +69,9 @@ function App() {
           <Route element={<AdminLayout />}>
             <Route index element={<AdminDashboard />} />
             <Route path="shops" element={<AdminPanel />} />
-            <Route path="requests" element={<VerificationRequests />} />
+            <Route path="requests">
+              <Route path="verification" element={<VerificationRequests />} />
+            </Route>
           </Route>
         </Route>
         <Route element={<ProtectedRoute />}>

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -35,8 +35,16 @@ export const rejectShop = async (id: string) => {
   await adminApi.put(`/shops/reject/${id}`);
 };
 
-export const fetchVerificationRequests = async () => {
-  const res = await adminApi.get('/verified/requests');
+export interface VerificationRequestParams {
+  page?: number;
+  status?: string;
+  profession?: string;
+}
+
+export const fetchVerificationRequests = async (
+  params: VerificationRequestParams = {},
+) => {
+  const res = await adminApi.get('/verified/requests', { params });
   return res.data;
 };
 

--- a/client/src/layouts/AdminLayout.tsx
+++ b/client/src/layouts/AdminLayout.tsx
@@ -8,7 +8,7 @@ const AdminLayout = () => {
         <nav>
           <ul>
             <li><Link to="/admin">Dashboard</Link></li>
-            <li><Link to="/admin/requests">Requests</Link></li>
+            <li><Link to="/admin/requests/verification">Requests</Link></li>
             <li><Link to="/admin/shops">Shops</Link></li>
             <li><span>Products</span></li>
             <li><span>Events</span></li>

--- a/client/src/pages/VerificationRequests/VerificationRequests.scss
+++ b/client/src/pages/VerificationRequests/VerificationRequests.scss
@@ -1,21 +1,29 @@
 .verification-requests {
   padding: 2rem;
 
-  ul {
-    list-style: none;
-    padding: 0;
+  .filters {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
 
-    li {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 0.5rem 0;
-      border-bottom: 1px solid #ddd;
+  table {
+    width: 100%;
+    border-collapse: collapse;
 
-      .actions {
-        display: flex;
-        gap: 0.5rem;
-      }
+    th,
+    td {
+      padding: 0.5rem;
+      border: 1px solid #ddd;
+      text-align: left;
     }
   }
+
+  .pagination {
+    margin-top: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
 }
+

--- a/client/src/pages/VerificationRequests/VerificationRequests.tsx
+++ b/client/src/pages/VerificationRequests/VerificationRequests.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   fetchVerificationRequests,
   acceptVerification,
   rejectVerification,
 } from '../../api/admin';
+import toast from '../../components/toast';
 import './VerificationRequests.scss';
 
 interface Request {
@@ -12,46 +14,93 @@ interface Request {
     _id: string;
     name: string;
     phone: string;
-    profession: string;
-    bio: string;
   };
-  portfolio?: string[];
+  profession: string;
+  bio: string;
+  status: string;
   createdAt: string;
+}
+
+interface RequestResponse {
+  requests: Request[];
+  total: number;
+  page: number;
+  pages: number;
 }
 
 const VerificationRequests = () => {
   const [requests, setRequests] = useState<Request[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [pages, setPages] = useState(1);
   const [actionId, setActionId] = useState('');
+  const [professionInput, setProfessionInput] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const status = searchParams.get('status') || '';
+  const profession = searchParams.get('profession') || '';
 
   useEffect(() => {
-    (async () => {
+    setProfessionInput(profession);
+  }, [profession]);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
       try {
-        const data = await fetchVerificationRequests();
-        setRequests(data);
+        const data: RequestResponse = await fetchVerificationRequests({
+          page,
+          status,
+          profession,
+        });
+        setRequests(data.requests);
+        setPages(data.pages);
       } catch {
         setRequests([]);
+        setPages(1);
       } finally {
         setLoading(false);
       }
-    })();
-  }, []);
+    };
+    load();
+  }, [page, status, profession]);
 
-  const handleAccept = async (id: string) => {
-    try {
-      setActionId(id);
-      await acceptVerification(id);
-      setRequests((prev) => prev.filter((r) => r.user._id !== id));
-    } finally {
-      setActionId('');
-    }
+  const updateParam = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (value) params.set(key, value);
+    else params.delete(key);
+    params.set('page', '1');
+    setSearchParams(params);
   };
 
-  const handleReject = async (id: string) => {
+  const changePage = (newPage: number) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('page', String(newPage));
+    setSearchParams(params);
+  };
+
+  const handleAction = async (
+    id: string,
+    newStatus: 'approved' | 'rejected',
+  ) => {
+    const prev = [...requests];
+    let updated = requests.map((r) =>
+      r.user._id === id ? { ...r, status: newStatus } : r,
+    );
+    if (status && status !== newStatus) {
+      updated = updated.filter((r) => r.user._id !== id);
+    }
+    setRequests(updated);
+    setActionId(id);
     try {
-      setActionId(id);
-      await rejectVerification(id);
-      setRequests((prev) => prev.filter((r) => r.user._id !== id));
+      if (newStatus === 'approved') await acceptVerification(id);
+      else await rejectVerification(id);
+      toast(
+        `Request ${newStatus === 'approved' ? 'approved' : 'rejected'}`,
+      );
+    } catch {
+      setRequests(prev);
+      toast('Failed to update request', 'error');
     } finally {
       setActionId('');
     }
@@ -60,40 +109,84 @@ const VerificationRequests = () => {
   return (
     <div className="verification-requests">
       <h1>Verification Requests</h1>
+      <div className="filters">
+        <select
+          value={status}
+          onChange={(e) => updateParam('status', e.target.value)}
+        >
+          <option value="">All Statuses</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+        </select>
+        <input
+          type="text"
+          placeholder="Profession"
+          value={professionInput}
+          onChange={(e) => setProfessionInput(e.target.value)}
+          onBlur={() => updateParam('profession', professionInput)}
+        />
+      </div>
       {loading ? (
         <p>Loading...</p>
       ) : (
-        <ul>
-          {requests.map((req) => (
-            <li key={req._id}>
-              <div>
-                <strong>{req.user.name}</strong> - {req.user.phone}
-                <div>{req.user.profession}</div>
-                <div>{req.user.bio}</div>
-                {req.portfolio && req.portfolio.length > 0 && (
-                  <div>
-                    {req.portfolio.map((link) => (
-                      <a key={link} href={link} target="_blank" rel="noreferrer">
-                        {link}
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </div>
-              <div className="actions">
-                <button onClick={() => handleAccept(req.user._id)} disabled={actionId === req.user._id}>
-                  {actionId === req.user._id ? '...' : 'Accept'}
-                </button>
-                <button onClick={() => handleReject(req.user._id)} disabled={actionId === req.user._id}>
-                  Reject
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Phone</th>
+              <th>Profession</th>
+              <th>Bio</th>
+              <th>Requested At</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {requests.map((req) => (
+              <tr key={req._id}>
+                <td>{req.user.name}</td>
+                <td>{req.user.phone}</td>
+                <td>{req.profession}</td>
+                <td>{req.bio}</td>
+                <td>{new Date(req.createdAt).toLocaleDateString()}</td>
+                <td>{req.status}</td>
+                <td>
+                  <button
+                    onClick={() => handleAction(req.user._id, 'approved')}
+                    disabled={actionId === req.user._id}
+                  >
+                    Accept
+                  </button>
+                  <button
+                    onClick={() => handleAction(req.user._id, 'rejected')}
+                    disabled={actionId === req.user._id}
+                  >
+                    Reject
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
+      <div className="pagination">
+        <button disabled={page <= 1} onClick={() => changePage(page - 1)}>
+          Prev
+        </button>
+        <span>
+          {page} / {pages}
+        </span>
+        <button
+          disabled={page >= pages}
+          onClick={() => changePage(page + 1)}
+        >
+          Next
+        </button>
+      </div>
     </div>
   );
 };
 
 export default VerificationRequests;
+


### PR DESCRIPTION
## Summary
- paginate & filter verification requests in API
- add admin UI to accept or reject verification requests with optimisitic updates
- route admin sidebar to verification requests page

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f0e5639e88332b7db4d58bb6f5778