### PR TITLE
feat: add business request approvals and filters

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ import AdminLogin from './pages/AdminLogin/AdminLogin';
 import AdminDashboard from './pages/AdminDashboard';
 import AdminPanel from './pages/AdminPanel';
 import VerificationRequests from './pages/VerificationRequests';
+import BusinessRequests from './pages/BusinessRequests';
 import AdminProtectedRoute from './components/AdminProtectedRoute';
 import AdminLayout from './layouts/AdminLayout';
 import { setUser } from './store/slices/userSlice';
@@ -70,6 +71,7 @@ function App() {
             <Route index element={<AdminDashboard />} />
             <Route path="shops" element={<AdminPanel />} />
             <Route path="requests">
+              <Route path="business" element={<BusinessRequests />} />
               <Route path="verification" element={<VerificationRequests />} />
             </Route>
           </Route>

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -22,17 +22,25 @@ export const fetchUsers = async () => {
   return res.data;
 };
 
-export const fetchBusinessRequests = async () => {
-  const res = await adminApi.get('/shops/requests');
+export interface BusinessRequestParams {
+  status?: string;
+  category?: string;
+  location?: string;
+}
+
+export const fetchBusinessRequests = async (
+  params: BusinessRequestParams = {},
+) => {
+  const res = await adminApi.get('/shops/requests', { params });
   return res.data;
 };
 
 export const approveShop = async (id: string) => {
-  await adminApi.put(`/shops/approve/${id}`);
+  await adminApi.post(`/shops/approve/${id}`);
 };
 
 export const rejectShop = async (id: string) => {
-  await adminApi.put(`/shops/reject/${id}`);
+  await adminApi.post(`/shops/reject/${id}`);
 };
 
 export interface VerificationRequestParams {

--- a/client/src/layouts/AdminLayout.tsx
+++ b/client/src/layouts/AdminLayout.tsx
@@ -8,7 +8,8 @@ const AdminLayout = () => {
         <nav>
           <ul>
             <li><Link to="/admin">Dashboard</Link></li>
-            <li><Link to="/admin/requests/verification">Requests</Link></li>
+            <li><Link to="/admin/requests/business">Business Requests</Link></li>
+            <li><Link to="/admin/requests/verification">Verification Requests</Link></li>
             <li><Link to="/admin/shops">Shops</Link></li>
             <li><span>Products</span></li>
             <li><span>Events</span></li>

--- a/client/src/pages/AdminPanel/AdminPanel.tsx
+++ b/client/src/pages/AdminPanel/AdminPanel.tsx
@@ -18,7 +18,7 @@ const AdminPanel = () => {
   useEffect(() => {
     (async () => {
       try {
-        const data = await fetchBusinessRequests();
+        const data = await fetchBusinessRequests({ status: 'pending' });
         setShops(data);
       } catch {
         setShops([]);

--- a/client/src/pages/BusinessRequests/BusinessRequests.scss
+++ b/client/src/pages/BusinessRequests/BusinessRequests.scss
@@ -1,0 +1,21 @@
+.business-requests {
+  padding: 2rem;
+
+  .filters {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+
+    th,
+    td {
+      padding: 0.5rem;
+      border: 1px solid #ddd;
+      text-align: left;
+    }
+  }
+}

--- a/client/src/pages/BusinessRequests/BusinessRequests.tsx
+++ b/client/src/pages/BusinessRequests/BusinessRequests.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  fetchBusinessRequests,
+  approveShop,
+  rejectShop,
+  type BusinessRequestParams,
+} from '../../api/admin';
+import toast from '../../components/toast';
+import './BusinessRequests.scss';
+
+interface ShopRequest {
+  _id: string;
+  name: string;
+  category: string;
+  location: string;
+  address: string;
+  status: string;
+  createdAt: string;
+  owner: {
+    _id: string;
+    name: string;
+    phone: string;
+  };
+}
+
+const BusinessRequests = () => {
+  const [requests, setRequests] = useState<ShopRequest[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [actionId, setActionId] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const status = searchParams.get('status') || '';
+  const category = searchParams.get('category') || '';
+  const location = searchParams.get('location') || '';
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const params: BusinessRequestParams = {};
+        if (status) params.status = status;
+        if (category) params.category = category;
+        if (location) params.location = location;
+        const data: ShopRequest[] = await fetchBusinessRequests(params);
+        setRequests(data);
+      } catch {
+        setRequests([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [status, category, location]);
+
+  const updateParam = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (value) params.set(key, value);
+    else params.delete(key);
+    setSearchParams(params);
+  };
+
+  const handleAction = async (
+    id: string,
+    newStatus: 'approved' | 'rejected',
+  ) => {
+    const prev = [...requests];
+    let updated = requests.map((r) =>
+      r._id === id ? { ...r, status: newStatus } : r,
+    );
+    if (status && status !== newStatus) {
+      updated = updated.filter((r) => r._id !== id);
+    }
+    setRequests(updated);
+    setActionId(id);
+    try {
+      if (newStatus === 'approved') await approveShop(id);
+      else await rejectShop(id);
+      toast(
+        `Request ${newStatus === 'approved' ? 'approved' : 'rejected'}`,
+      );
+    } catch {
+      setRequests(prev);
+      toast('Failed to update request', 'error');
+    } finally {
+      setActionId('');
+    }
+  };
+
+  return (
+    <div className="business-requests">
+      <h1>Business Requests</h1>
+      <div className="filters">
+        <select
+          value={status}
+          onChange={(e) => updateParam('status', e.target.value)}
+        >
+          <option value="">All Statuses</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+        </select>
+        <input
+          type="text"
+          placeholder="Category"
+          value={category}
+          onChange={(e) => updateParam('category', e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => updateParam('location', e.target.value)}
+        />
+      </div>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Shop Name</th>
+              <th>Category</th>
+              <th>Location</th>
+              <th>Address</th>
+              <th>Requested At</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {requests.map((req) => (
+              <tr key={req._id}>
+                <td>{req.owner?.name}</td>
+                <td>{req.name}</td>
+                <td>{req.category}</td>
+                <td>{req.location}</td>
+                <td>{req.address}</td>
+                <td>{new Date(req.createdAt).toLocaleDateString()}</td>
+                <td>{req.status}</td>
+                <td>
+                  <button
+                    onClick={() => handleAction(req._id, 'approved')}
+                    disabled={actionId === req._id}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => handleAction(req._id, 'rejected')}
+                    disabled={actionId === req._id}
+                  >
+                    Reject
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default BusinessRequests;
+

--- a/client/src/pages/BusinessRequests/index.ts
+++ b/client/src/pages/BusinessRequests/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BusinessRequests';

--- a/server/controllers/shopController.js
+++ b/server/controllers/shopController.js
@@ -77,13 +77,16 @@ exports.getProductsByShop = async (req, res) => {
 
 exports.getPendingShops = async (req, res) => {
   try {
-    const shops = await Shop.find({ status: "pending" }).populate(
-      "owner",
-      "name phone"
-    );
+    const { status, category, location } = req.query;
+    const filters = {};
+    if (status) filters.status = status;
+    if (category) filters.category = category;
+    if (location) filters.location = location;
+
+    const shops = await Shop.find(filters).populate("owner", "name phone");
     res.json(shops);
   } catch (err) {
-    res.status(500).json({ error: "Failed to fetch pending shops" });
+    res.status(500).json({ error: "Failed to fetch shop requests" });
   }
 };
 

--- a/server/routes/shopRoutes.js
+++ b/server/routes/shopRoutes.js
@@ -16,8 +16,8 @@ const {
 
 router.post("/", protect, createShop);
 router.get("/requests", protect, isAdmin, getPendingShops);
-router.put("/approve/:id", protect, isAdmin, approveShop);
-router.put("/reject/:id", protect, isAdmin, rejectShop);
+router.post("/approve/:id", protect, isAdmin, approveShop);
+router.post("/reject/:id", protect, isAdmin, rejectShop);
 router.get("/my", protect, getMyShop);
 router.get("/", getAllShops);
 router.get("/my-products", protect, getMyProducts);


### PR DESCRIPTION
## Summary
- allow admins to approve or reject shop requests with POST routes
- add Business Requests page with status, category and location filters
- wire admin navigation and API client to manage shop requests

## Testing
- `cd client && npm run lint`
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f0fce494883328d1333bb01dbafc0