### PR TITLE
feat: add admin shop management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,7 +28,7 @@ import Notifications from './pages/Notifications/Notifications';
 import TabLayout from './layouts/TabLayout';
 import AdminLogin from './pages/AdminLogin/AdminLogin';
 import AdminDashboard from './pages/AdminDashboard';
-import AdminPanel from './pages/AdminPanel';
+import AdminShops from './pages/AdminShops';
 import VerificationRequests from './pages/VerificationRequests';
 import BusinessRequests from './pages/BusinessRequests';
 import AdminProtectedRoute from './components/AdminProtectedRoute';
@@ -69,7 +69,7 @@ function App() {
         <Route path="/admin" element={<AdminProtectedRoute />}>
           <Route element={<AdminLayout />}>
             <Route index element={<AdminDashboard />} />
-            <Route path="shops" element={<AdminPanel />} />
+            <Route path="shops" element={<AdminShops />} />
             <Route path="requests">
               <Route path="business" element={<BusinessRequests />} />
               <Route path="verification" element={<VerificationRequests />} />

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -63,3 +63,29 @@ export const acceptVerification = async (id: string) => {
 export const rejectVerification = async (id: string) => {
   await adminApi.post(`/verified/reject/${id}`);
 };
+
+export interface ShopQueryParams {
+  query?: string;
+  status?: string;
+  category?: string;
+  page?: number;
+  pageSize?: number;
+  sort?: string;
+}
+
+export const fetchShops = async (params: ShopQueryParams = {}) => {
+  const res = await adminApi.get('/shops', { params });
+  return res.data;
+};
+
+export const updateShop = async (
+  id: string,
+  data: Partial<{ name: string; category: string; location: string; status: string }>,
+) => {
+  const res = await adminApi.put(`/shops/${id}`, data);
+  return res.data;
+};
+
+export const deleteShop = async (id: string) => {
+  await adminApi.delete(`/shops/${id}`);
+};

--- a/client/src/pages/AdminShops/AdminShops.scss
+++ b/client/src/pages/AdminShops/AdminShops.scss
@@ -1,0 +1,58 @@
+.admin-shops {
+  padding: 1rem;
+}
+
+.admin-shops .filters {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.shops-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.shops-table th,
+.shops-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.actions button {
+  margin-right: 0.25rem;
+}
+
+.pagination {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  min-width: 300px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}

--- a/client/src/pages/AdminShops/AdminShops.tsx
+++ b/client/src/pages/AdminShops/AdminShops.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  fetchShops,
+  updateShop as apiUpdateShop,
+  deleteShop as apiDeleteShop,
+  type ShopQueryParams,
+} from '../../api/admin';
+import Loader from '../../components/Loader';
+import toast from '../../components/toast';
+import './AdminShops.scss';
+
+interface Shop {
+  _id: string;
+  name: string;
+  owner: string;
+  category: string;
+  location: string;
+  status: 'active' | 'pending' | 'suspended';
+  productsCount: number;
+  createdAt: string;
+}
+
+const AdminShops = () => {
+  const [shops, setShops] = useState<Shop[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState('');
+  const [category, setCategory] = useState('');
+  const [sort, setSort] = useState('-createdAt');
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const pageSize = 10;
+
+  const [edit, setEdit] = useState<Shop | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params: ShopQueryParams = {
+        query,
+        status: status || undefined,
+        category: category || undefined,
+        sort,
+        page,
+        pageSize,
+      };
+      const data = await fetchShops(params);
+      setShops(data.items);
+      setTotal(data.total);
+    } catch {
+      toast('Failed to load shops', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [query, status, category, sort, page, pageSize]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!edit) return;
+    try {
+      setSaving(true);
+      await apiUpdateShop(edit._id, {
+        name: edit.name,
+        category: edit.category,
+        location: edit.location,
+      });
+      toast('Shop updated');
+      setEdit(null);
+      load();
+    } catch {
+      toast('Failed to update shop', 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleStatus = async (shop: Shop) => {
+    try {
+      const newStatus = shop.status === 'active' ? 'suspended' : 'active';
+      await apiUpdateShop(shop._id, { status: newStatus });
+      setShops((prev) =>
+        prev.map((s) => (s._id === shop._id ? { ...s, status: newStatus } : s)),
+      );
+    } catch {
+      toast('Failed to update status', 'error');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete shop?')) return;
+    try {
+      await apiDeleteShop(id);
+      setShops((prev) => prev.filter((s) => s._id !== id));
+      toast('Shop deleted');
+      load();
+    } catch {
+      toast('Failed to delete shop', 'error');
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  return (
+    <div className="admin-shops">
+      <h2>Shops</h2>
+      <div className="filters">
+        <input
+          placeholder="Search by name or owner"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setPage(1);
+          }}
+        />
+        <input
+          placeholder="Category"
+          value={category}
+          onChange={(e) => {
+            setCategory(e.target.value);
+            setPage(1);
+          }}
+        />
+        <select
+          value={status}
+          onChange={(e) => {
+            setStatus(e.target.value);
+            setPage(1);
+          }}
+        >
+          <option value="">All Statuses</option>
+          <option value="active">Active</option>
+          <option value="pending">Pending</option>
+          <option value="suspended">Suspended</option>
+        </select>
+        <select value={sort} onChange={(e) => setSort(e.target.value)}>
+          <option value="-createdAt">Newest</option>
+          <option value="createdAt">Oldest</option>
+        </select>
+      </div>
+      {loading ? (
+        <Loader />
+      ) : (
+        <table className="shops-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Owner</th>
+              <th>Category</th>
+              <th>Location</th>
+              <th>Status</th>
+              <th>Products</th>
+              <th>Created</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {shops.map((s) => (
+              <tr key={s._id}>
+                <td>{s.name}</td>
+                <td>{s.owner}</td>
+                <td>{s.category}</td>
+                <td>{s.location}</td>
+                <td>{s.status}</td>
+                <td>{s.productsCount}</td>
+                <td>{new Date(s.createdAt).toLocaleDateString()}</td>
+                <td className="actions">
+                  <button onClick={() => setEdit(s)}>Edit</button>
+                  <button onClick={() => handleToggleStatus(s)}>
+                    {s.status === 'active' ? 'Suspend' : 'Activate'}
+                  </button>
+                  <button onClick={() => handleDelete(s._id)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <div className="pagination">
+        <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+          Prev
+        </button>
+        <span>
+          {page}/{totalPages}
+        </span>
+        <button
+          disabled={page >= totalPages}
+          onClick={() => setPage((p) => p + 1)}
+        >
+          Next
+        </button>
+      </div>
+      {edit && (
+        <div className="modal">
+          <form className="modal-content" onSubmit={handleSave}>
+            <h3>Edit Shop</h3>
+            <label>
+              Name
+              <input
+                value={edit.name}
+                onChange={(e) => setEdit({ ...edit, name: e.target.value })}
+              />
+            </label>
+            <label>
+              Category
+              <input
+                value={edit.category}
+                onChange={(e) => setEdit({ ...edit, category: e.target.value })}
+              />
+            </label>
+            <label>
+              Location
+              <input
+                value={edit.location}
+                onChange={(e) => setEdit({ ...edit, location: e.target.value })}
+              />
+            </label>
+            <div className="modal-actions">
+              <button type="submit" disabled={saving}>
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setEdit(null)}
+                disabled={saving}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminShops;

--- a/client/src/pages/AdminShops/index.ts
+++ b/client/src/pages/AdminShops/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AdminShops';

--- a/server/routes/shopRoutes.js
+++ b/server/routes/shopRoutes.js
@@ -12,6 +12,8 @@ const {
   approveShop,
   rejectShop,
   getMyProducts,
+  updateShop,
+  deleteShop,
 } = require("../controllers/shopController");
 
 router.post("/", protect, createShop);
@@ -20,8 +22,10 @@ router.post("/approve/:id", protect, isAdmin, approveShop);
 router.post("/reject/:id", protect, isAdmin, rejectShop);
 router.get("/my", protect, getMyShop);
 router.get("/", getAllShops);
+router.put("/:id", protect, isAdmin, updateShop);
+router.delete("/:id", protect, isAdmin, deleteShop);
 router.get("/my-products", protect, getMyProducts);
-router.get("/:id", getShopById);
 router.get("/:id/products", getProductsByShop);
+router.get("/:id", getShopById);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add admin shops page with search, filters, sorting and pagination
- support shop editing, status toggling and deletion via new API calls
- extend server shop routes for listing, updating and deleting shops

## Testing
- `npm run lint`
- `npm run build` *(fails: ReactNode type-only import and other TS errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f1137c70083328d213484a27b8b75