### PR TITLE
feat(admin): add event management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ import AdminLogin from './pages/AdminLogin/AdminLogin';
 import AdminDashboard from './pages/AdminDashboard';
 import AdminShops from './pages/AdminShops';
 import AdminProducts from './pages/AdminProducts';
+import AdminEvents from './pages/AdminEvents';
 import VerificationRequests from './pages/VerificationRequests';
 import BusinessRequests from './pages/BusinessRequests';
 import AdminProtectedRoute from './components/AdminProtectedRoute';
@@ -72,6 +73,7 @@ function App() {
             <Route index element={<AdminDashboard />} />
             <Route path="shops" element={<AdminShops />} />
             <Route path="products" element={<AdminProducts />} />
+            <Route path="events" element={<AdminEvents />} />
             <Route path="requests">
               <Route path="business" element={<BusinessRequests />} />
               <Route path="verification" element={<VerificationRequests />} />

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -126,3 +126,37 @@ export const updateProduct = async (
 export const deleteProduct = async (id: string) => {
   await adminApi.delete(`/products/${id}`);
 };
+
+export interface EventQueryParams {
+  status?: string;
+  page?: number;
+  pageSize?: number;
+  sort?: string;
+}
+
+export const fetchEvents = async (params: EventQueryParams = {}) => {
+  const res = await adminApi.get('/events', { params });
+  return res.data as { items: any[]; total: number };
+};
+
+export const createEvent = async (data: {
+  title: string;
+  startAt: string;
+  endAt: string;
+  capacity: number;
+}) => {
+  const res = await adminApi.post('/events', data);
+  return res.data;
+};
+
+export const updateEvent = async (
+  id: string,
+  data: Partial<{ title: string; startAt: string; endAt: string; capacity: number }>,
+) => {
+  const res = await adminApi.put(`/events/${id}`, data);
+  return res.data;
+};
+
+export const deleteEvent = async (id: string) => {
+  await adminApi.delete(`/events/${id}`);
+};

--- a/client/src/pages/AdminEvents/AdminEvents.scss
+++ b/client/src/pages/AdminEvents/AdminEvents.scss
@@ -1,0 +1,59 @@
+.admin-events {
+  padding: 1rem;
+}
+
+.admin-events .filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.events-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.events-table th,
+.events-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.actions button {
+  margin-right: 0.25rem;
+}
+
+.pagination {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  min-width: 300px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}

--- a/client/src/pages/AdminEvents/AdminEvents.tsx
+++ b/client/src/pages/AdminEvents/AdminEvents.tsx
@@ -1,0 +1,308 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  fetchEvents,
+  createEvent as apiCreateEvent,
+  updateEvent as apiUpdateEvent,
+  deleteEvent as apiDeleteEvent,
+  type EventQueryParams,
+} from '../../api/admin';
+import Loader from '../../components/Loader';
+import toast from '../../components/toast';
+import './AdminEvents.scss';
+
+interface EventItem {
+  _id: string;
+  title: string;
+  startAt: string;
+  endAt: string;
+  status: string;
+  capacity: number;
+  registered: number;
+}
+
+interface FormState {
+  title: string;
+  startAt: string;
+  endAt: string;
+  capacity: number;
+}
+
+const emptyForm: FormState = {
+  title: '',
+  startAt: '',
+  endAt: '',
+  capacity: 0,
+};
+
+const AdminEvents = () => {
+  const [events, setEvents] = useState<EventItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState('');
+  const [sort, setSort] = useState('-startAt');
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const pageSize = 10;
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [edit, setEdit] = useState<EventItem | null>(null);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params: EventQueryParams = {
+        status: status || undefined,
+        sort,
+        page,
+        pageSize,
+      };
+      const data = await fetchEvents(params);
+      setEvents(data.items as EventItem[]);
+      setTotal(data.total);
+    } catch {
+      toast('Failed to load events', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [status, sort, page, pageSize]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (new Date(form.startAt) >= new Date(form.endAt)) {
+      toast('startAt must be before endAt', 'error');
+      return;
+    }
+    setSaving(true);
+    try {
+      const created = await apiCreateEvent(form);
+      setEvents((prev) => [created, ...prev]);
+      setCreateOpen(false);
+      setForm(emptyForm);
+    } catch {
+      toast('Failed to create event', 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openEdit = (ev: EventItem) => {
+    setEdit(ev);
+    setForm({
+      title: ev.title,
+      startAt: ev.startAt.slice(0, 16),
+      endAt: ev.endAt.slice(0, 16),
+      capacity: ev.capacity,
+    });
+  };
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!edit) return;
+    if (new Date(form.startAt) >= new Date(form.endAt)) {
+      toast('startAt must be before endAt', 'error');
+      return;
+    }
+    setSaving(true);
+    try {
+      const updated = await apiUpdateEvent(edit._id, form);
+      setEvents((prev) => prev.map((ev) => (ev._id === edit._id ? updated : ev)));
+      setEdit(null);
+    } catch {
+      toast('Failed to update event', 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('Delete this event?')) return;
+    try {
+      await apiDeleteEvent(id);
+      setEvents((prev) => prev.filter((ev) => ev._id !== id));
+      setTotal((t) => t - 1);
+    } catch {
+      toast('Failed to delete event', 'error');
+    }
+  };
+
+  return (
+    <div className="admin-events">
+      <h2>Events</h2>
+      <div className="filters">
+        <select value={status} onChange={(e) => setStatus(e.target.value)}>
+          <option value="">All</option>
+          <option value="upcoming">Upcoming</option>
+          <option value="ongoing">Ongoing</option>
+          <option value="past">Past</option>
+        </select>
+        <select value={sort} onChange={(e) => setSort(e.target.value)}>
+          <option value="-startAt">Newest</option>
+          <option value="startAt">Oldest</option>
+        </select>
+        <button onClick={() => setCreateOpen(true)}>Add Event</button>
+      </div>
+      {loading ? (
+        <Loader />
+      ) : (
+        <table className="events-table">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Start</th>
+              <th>End</th>
+              <th>Status</th>
+              <th>Capacity</th>
+              <th>Registered</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((ev) => (
+              <tr key={ev._id}>
+                <td>{ev.title}</td>
+                <td>{new Date(ev.startAt).toLocaleString()}</td>
+                <td>{new Date(ev.endAt).toLocaleString()}</td>
+                <td>{ev.status}</td>
+                <td>{ev.capacity}</td>
+                <td>{ev.registered}</td>
+                <td className="actions">
+                  <button onClick={() => openEdit(ev)}>Edit</button>
+                  <button onClick={() => handleDelete(ev._id)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <div className="pagination">
+        <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+          Prev
+        </button>
+        <span>
+          {page}/{totalPages}
+        </span>
+        <button
+          disabled={page >= totalPages}
+          onClick={() => setPage((p) => p + 1)}
+        >
+          Next
+        </button>
+      </div>
+
+      {createOpen && (
+        <div className="modal">
+          <form className="modal-content" onSubmit={handleCreate}>
+            <h3>Create Event</h3>
+            <label>
+              Title
+              <input
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+              />
+            </label>
+            <label>
+              Start
+              <input
+                type="datetime-local"
+                value={form.startAt}
+                onChange={(e) => setForm({ ...form, startAt: e.target.value })}
+              />
+            </label>
+            <label>
+              End
+              <input
+                type="datetime-local"
+                value={form.endAt}
+                onChange={(e) => setForm({ ...form, endAt: e.target.value })}
+              />
+            </label>
+            <label>
+              Capacity
+              <input
+                type="number"
+                value={form.capacity}
+                onChange={(e) =>
+                  setForm({ ...form, capacity: Number(e.target.value) })
+                }
+              />
+            </label>
+            <div className="modal-actions">
+              <button type="submit" disabled={saving}>
+                {saving ? 'Saving...' : 'Create'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setCreateOpen(false)}
+                disabled={saving}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {edit && (
+        <div className="modal">
+          <form className="modal-content" onSubmit={handleUpdate}>
+            <h3>Edit Event</h3>
+            <label>
+              Title
+              <input
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+              />
+            </label>
+            <label>
+              Start
+              <input
+                type="datetime-local"
+                value={form.startAt}
+                onChange={(e) => setForm({ ...form, startAt: e.target.value })}
+              />
+            </label>
+            <label>
+              End
+              <input
+                type="datetime-local"
+                value={form.endAt}
+                onChange={(e) => setForm({ ...form, endAt: e.target.value })}
+              />
+            </label>
+            <label>
+              Capacity
+              <input
+                type="number"
+                value={form.capacity}
+                onChange={(e) =>
+                  setForm({ ...form, capacity: Number(e.target.value) })
+                }
+              />
+            </label>
+            <div className="modal-actions">
+              <button type="submit" disabled={saving}>
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setEdit(null)}
+                disabled={saving}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminEvents;

--- a/client/src/pages/AdminEvents/index.ts
+++ b/client/src/pages/AdminEvents/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AdminEvents';

--- a/server/routes/eventRoutes.js
+++ b/server/routes/eventRoutes.js
@@ -5,12 +5,16 @@ const {
   createEvent,
   getAllEvents,
   getEventById,
+  updateEvent,
+  deleteEvent,
   registerForEvent,
 } = require("../controllers/eventController");
 
 router.post("/", createEvent); // Admin only (later add admin middleware)
 router.get("/", getAllEvents);
 router.get("/:id", getEventById);
+router.put("/:id", updateEvent); // Admin only
+router.delete("/:id", deleteEvent); // Admin only
 router.post("/:id/register", protect, registerForEvent);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add event schema with start/end times and capacity tracking
- expose full CRUD operations for events and admin API helpers
- build admin Events page with create, edit, delete and filtering

## Testing
- `npm run lint`
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: TS errors in unrelated modules)


------
https://chatgpt.com/codex/tasks/task_e_689f160eea788332a33901b6e970c4a3