### PR TITLE
feat: add admin user management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,6 +33,7 @@ import AdminProducts from './pages/AdminProducts';
 import AdminEvents from './pages/AdminEvents';
 import VerificationRequests from './pages/VerificationRequests';
 import BusinessRequests from './pages/BusinessRequests';
+import AdminUsers from './pages/AdminUsers';
 import AdminProtectedRoute from './components/AdminProtectedRoute';
 import AdminLayout from './layouts/AdminLayout';
 import { setUser } from './store/slices/userSlice';
@@ -74,6 +75,7 @@ function App() {
             <Route path="shops" element={<AdminShops />} />
             <Route path="products" element={<AdminProducts />} />
             <Route path="events" element={<AdminEvents />} />
+            <Route path="users" element={<AdminUsers />} />
             <Route path="requests">
               <Route path="business" element={<BusinessRequests />} />
               <Route path="verification" element={<VerificationRequests />} />

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -17,9 +17,30 @@ export const adminLogin = async ({ identifier, password }: AdminCreds) => {
   return token;
 };
 
-export const fetchUsers = async () => {
-  const res = await adminApi.get('/admin/users');
-  return res.data;
+export interface UserQueryParams {
+  role?: string;
+  verified?: boolean;
+  query?: string;
+  page?: number;
+  pageSize?: number;
+  sort?: string;
+}
+
+export const fetchUsers = async (params: UserQueryParams = {}) => {
+  const res = await adminApi.get('/users', { params });
+  return res.data as { items: any[]; total: number };
+};
+
+export const updateUserRole = async (id: string, role: string) => {
+  await adminApi.put(`/users/${id}/role`, { role });
+};
+
+export const updateUserStatus = async (id: string, active: boolean) => {
+  await adminApi.put(`/users/${id}/status`, { active });
+};
+
+export const deleteUser = async (id: string) => {
+  await adminApi.delete(`/users/${id}`);
 };
 
 export interface BusinessRequestParams {

--- a/client/src/layouts/AdminLayout.tsx
+++ b/client/src/layouts/AdminLayout.tsx
@@ -13,7 +13,7 @@ const AdminLayout = () => {
             <li><Link to="/admin/shops">Shops</Link></li>
             <li><Link to="/admin/products">Products</Link></li>
             <li><span>Events</span></li>
-            <li><span>Users</span></li>
+            <li><Link to="/admin/users">Users</Link></li>
             <li><span>Analytics</span></li>
           </ul>
         </nav>

--- a/client/src/pages/AdminUsers/AdminUsers.scss
+++ b/client/src/pages/AdminUsers/AdminUsers.scss
@@ -1,0 +1,37 @@
+.admin-users {
+  padding: 1rem;
+}
+
+.admin-users .filters {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.users-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.users-table th,
+.users-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.actions button {
+  margin-right: 0.25rem;
+}
+
+.pagination {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+button.danger {
+  color: #fff;
+  background: #d33;
+}

--- a/client/src/pages/AdminUsers/AdminUsers.tsx
+++ b/client/src/pages/AdminUsers/AdminUsers.tsx
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  fetchUsers,
+  updateUserRole,
+  updateUserStatus,
+  deleteUser as apiDeleteUser,
+  type UserQueryParams,
+} from '../../api/admin';
+import Loader from '../../components/Loader';
+import toast from '../../components/toast';
+import './AdminUsers.scss';
+
+interface User {
+  _id: string;
+  name: string;
+  phone: string;
+  role: string;
+  isVerified: boolean;
+  isActive: boolean;
+  ordersCount: number;
+  createdAt: string;
+}
+
+const AdminUsers = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState('');
+  const [role, setRole] = useState('');
+  const [verified, setVerified] = useState('');
+  const [sort, setSort] = useState('-createdAt');
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const pageSize = 10;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params: UserQueryParams = {
+        query: query || undefined,
+        role: role || undefined,
+        verified: verified ? verified === 'true' : undefined,
+        sort,
+        page,
+        pageSize,
+      };
+      const data = await fetchUsers(params);
+      setUsers(data.items as User[]);
+      setTotal(data.total);
+    } catch {
+      toast('Failed to load users', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [query, role, verified, sort, page]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleRoleChange = async (id: string, newRole: string) => {
+    const prev = [...users];
+    setUsers((list) =>
+      list.map((u) =>
+        u._id === id
+          ? { ...u, role: newRole, isVerified: newRole === 'verified' || u.isVerified }
+          : u,
+      ),
+    );
+    try {
+      await updateUserRole(id, newRole);
+    } catch {
+      setUsers(prev);
+      toast('Failed to update role', 'error');
+    }
+  };
+
+  const handleToggleActive = async (user: User) => {
+    if (!confirm(user.isActive ? 'Deactivate user?' : 'Reactivate user?')) return;
+    const prev = [...users];
+    setUsers((list) =>
+      list.map((u) =>
+        u._id === user._id ? { ...u, isActive: !user.isActive } : u,
+      ),
+    );
+    try {
+      await updateUserStatus(user._id, !user.isActive);
+    } catch {
+      setUsers(prev);
+      toast('Failed to update status', 'error');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete user?')) return;
+    const prev = [...users];
+    setUsers((list) => list.filter((u) => u._id !== id));
+    try {
+      await apiDeleteUser(id);
+    } catch {
+      setUsers(prev);
+      toast('Failed to delete user', 'error');
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  return (
+    <div className="admin-users">
+      <h2>Users</h2>
+      <div className="filters">
+        <input
+          placeholder="Search name or phone"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setPage(1);
+          }}
+        />
+        <select
+          value={role}
+          onChange={(e) => {
+            setRole(e.target.value);
+            setPage(1);
+          }}
+        >
+          <option value="">All Roles</option>
+          <option value="customer">Customer</option>
+          <option value="verified">Verified</option>
+          <option value="business">Business</option>
+          <option value="admin">Admin</option>
+        </select>
+        <select
+          value={verified}
+          onChange={(e) => {
+            setVerified(e.target.value);
+            setPage(1);
+          }}
+        >
+          <option value="">All Users</option>
+          <option value="true">Verified</option>
+          <option value="false">Unverified</option>
+        </select>
+        <select value={sort} onChange={(e) => setSort(e.target.value)}>
+          <option value="-createdAt">Newest</option>
+          <option value="createdAt">Oldest</option>
+        </select>
+      </div>
+      {loading ? (
+        <Loader />
+      ) : (
+        <table className="users-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Phone</th>
+              <th>Role</th>
+              <th>Verified</th>
+              <th>Orders</th>
+              <th>Created</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u._id}>
+                <td>{u.name}</td>
+                <td>{u.phone}</td>
+                <td>
+                  <select
+                    value={u.role}
+                    onChange={(e) => handleRoleChange(u._id, e.target.value)}
+                  >
+                    <option value="customer">Customer</option>
+                    <option value="verified">Verified</option>
+                    <option value="business">Business</option>
+                    <option value="admin">Admin</option>
+                  </select>
+                </td>
+                <td>{u.isVerified ? 'Yes' : 'No'}</td>
+                <td>{u.ordersCount}</td>
+                <td>{new Date(u.createdAt).toLocaleDateString()}</td>
+                <td className="actions">
+                  <button onClick={() => handleToggleActive(u)}>
+                    {u.isActive ? 'Deactivate' : 'Reactivate'}
+                  </button>
+                  <button
+                    className="danger"
+                    onClick={() => handleDelete(u._id)}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <nav className="pagination" aria-label="Pagination">
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page <= 1}
+        >
+          Prev
+        </button>
+        <span>
+          {page} / {totalPages}
+        </span>
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page >= totalPages}
+        >
+          Next
+        </button>
+      </nav>
+    </div>
+  );
+};
+
+export default AdminUsers;

--- a/client/src/pages/AdminUsers/index.ts
+++ b/client/src/pages/AdminUsers/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AdminUsers';

--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -1,18 +1,124 @@
 const User = require('../models/User');
 const Order = require('../models/Order');
 
-exports.getAllUsers = async (req, res) => {
+exports.getUsers = async (req, res) => {
   try {
-    const users = await User.find().select('-password');
-    res.json(users);
+    const {
+      role,
+      query,
+      verified,
+      page = 1,
+      pageSize = 10,
+      sort = '-createdAt',
+    } = req.query;
+
+    const filter = {};
+    if (role) filter.role = role;
+    if (verified !== undefined) filter.isVerified = verified === 'true';
+    if (query) {
+      filter.$or = [
+        { name: { $regex: query, $options: 'i' } },
+        { phone: { $regex: query, $options: 'i' } },
+      ];
+    }
+
+    const skip = (Number(page) - 1) * Number(pageSize);
+    const sortObj = {};
+    if (sort) {
+      if (sort.startsWith('-')) {
+        sortObj[sort.slice(1)] = -1;
+      } else {
+        sortObj[sort] = 1;
+      }
+    }
+
+    const pipeline = [
+      { $match: filter },
+      {
+        $lookup: {
+          from: 'orders',
+          localField: '_id',
+          foreignField: 'user',
+          as: 'orders',
+        },
+      },
+      { $addFields: { ordersCount: { $size: '$orders' } } },
+      { $project: { password: 0, orders: 0 } },
+      { $sort: sortObj },
+      { $skip: skip },
+      { $limit: Number(pageSize) },
+    ];
+
+    const [items, total] = await Promise.all([
+      User.aggregate(pipeline).exec(),
+      User.countDocuments(filter),
+    ]);
+
+    res.json({ items, total });
   } catch (err) {
     res.status(500).json({ error: 'Failed to fetch users' });
   }
 };
 
+exports.updateUserRole = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { role } = req.body;
+    const user = await User.findById(id);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    if (user.role === 'admin' && role !== 'admin') {
+      const adminCount = await User.countDocuments({ role: 'admin' });
+      if (adminCount <= 1) {
+        return res.status(400).json({ error: 'Cannot demote last admin' });
+      }
+    }
+
+    user.role = role;
+    if (role === 'verified') user.isVerified = true;
+    await user.save();
+    res.json({ message: 'Role updated' });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update role' });
+  }
+};
+
+exports.updateUserStatus = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { active } = req.body;
+    const user = await User.findById(id);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    if (user.role === 'admin' && active === false) {
+      const adminCount = await User.countDocuments({ role: 'admin' });
+      if (adminCount <= 1) {
+        return res.status(400).json({ error: 'Cannot deactivate last admin' });
+      }
+    }
+
+    user.isActive = active;
+    await user.save();
+    res.json({ message: 'Status updated' });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update status' });
+  }
+};
+
 exports.deleteUser = async (req, res) => {
   try {
-    await User.findByIdAndDelete(req.params.id);
+    const { id } = req.params;
+    const user = await User.findById(id);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    if (user.role === 'admin') {
+      const adminCount = await User.countDocuments({ role: 'admin' });
+      if (adminCount <= 1) {
+        return res.status(400).json({ error: 'Cannot delete last admin' });
+      }
+    }
+
+    await user.deleteOne();
     res.json({ message: 'User deleted' });
   } catch (err) {
     res.status(500).json({ error: 'Failed to delete user' });

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -9,10 +9,11 @@ const userSchema = new mongoose.Schema(
     address: { type: String, default: "" },
     role: {
       type: String,
-      enum: ["customer", "business"],
+      enum: ["customer", "verified", "business", "admin"],
       default: "customer",
     },
     isVerified: { type: Boolean, default: false },
+    isActive: { type: Boolean, default: true },
     verificationStatus: {
       type: String,
       enum: ["pending", "verified", "rejected"],

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const {
-  getAllUsers,
+  getUsers,
+  updateUserRole,
+  updateUserStatus,
   deleteUser,
   verifyUser,
   getAllOrders,
@@ -10,8 +12,10 @@ const isAdmin = require('../middleware/isAdmin');
 
 const router = express.Router();
 
-router.get('/users', protect, isAdmin, getAllUsers);
-router.delete('/user/:id', protect, isAdmin, deleteUser);
+router.get('/users', protect, isAdmin, getUsers);
+router.put('/users/:id/role', protect, isAdmin, updateUserRole);
+router.put('/users/:id/status', protect, isAdmin, updateUserStatus);
+router.delete('/users/:id', protect, isAdmin, deleteUser);
 router.put('/user/:id/verify', protect, isAdmin, verifyUser);
 router.get('/orders', protect, isAdmin, getAllOrders);
 

--- a/server/routes/adminUserRoutes.js
+++ b/server/routes/adminUserRoutes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const {
+  getUsers,
+  updateUserRole,
+  updateUserStatus,
+  deleteUser,
+} = require('../controllers/adminController');
+const protect = require('../middleware/authMiddleware');
+const isAdmin = require('../middleware/isAdmin');
+
+const router = express.Router();
+
+router.get('/', protect, isAdmin, getUsers);
+router.put('/:id/role', protect, isAdmin, updateUserRole);
+router.put('/:id/status', protect, isAdmin, updateUserStatus);
+router.delete('/:id', protect, isAdmin, deleteUser);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -15,6 +15,7 @@ const notificationRoutes = require("./routes/notificationRoutes");
 const orderRoutes = require("./routes/orderRoutes");
 const adminRoutes = require("./routes/adminRoutes");
 const productRoutes = require("./routes/productRoutes");
+const adminUserRoutes = require("./routes/adminUserRoutes");
 
 const app = express();
 app.use(cors());
@@ -32,6 +33,7 @@ app.use("/api/notifications", notificationRoutes);
 app.use("/api/orders", orderRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/products", productRoutes);
+app.use("/api/users", adminUserRoutes);
 
 mongoose
   .connect(process.env.MONGO_URI)


### PR DESCRIPTION
## Summary
- add admin users page with role, verification and status controls
- expose paginated user API with role filters and safe admin demotion checks
- link users page into admin navigation and routes

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f17cc5e6c833296d29fa00000f05a