### PR TITLE
feat: add admin analytics dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,6 +34,7 @@ import AdminEvents from './pages/AdminEvents';
 import VerificationRequests from './pages/VerificationRequests';
 import BusinessRequests from './pages/BusinessRequests';
 import AdminUsers from './pages/AdminUsers';
+import AdminAnalytics from './pages/AdminAnalytics';
 import AdminProtectedRoute from './components/AdminProtectedRoute';
 import AdminLayout from './layouts/AdminLayout';
 import { setUser } from './store/slices/userSlice';
@@ -76,6 +77,7 @@ function App() {
             <Route path="products" element={<AdminProducts />} />
             <Route path="events" element={<AdminEvents />} />
             <Route path="users" element={<AdminUsers />} />
+            <Route path="analytics" element={<AdminAnalytics />} />
             <Route path="requests">
               <Route path="business" element={<BusinessRequests />} />
               <Route path="verification" element={<VerificationRequests />} />

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -17,6 +17,39 @@ export const adminLogin = async ({ identifier, password }: AdminCreds) => {
   return token;
 };
 
+export interface MetricsSummary {
+  users: number;
+  shops: number;
+  gmv: number;
+  ordersToday: number;
+  orders7d: number;
+  orders30d: number;
+  activeEvents: number;
+  conversions: number;
+  topShops?: Array<{ id: string; name: string; orders: number }>;
+  topProducts?: Array<{ id: string; name: string; orders: number }>;
+}
+
+export interface SeriesPoint {
+  date: string;
+  value: number;
+}
+
+export const fetchMetrics = async () => {
+  const res = await adminApi.get('/metrics');
+  return res.data as MetricsSummary;
+};
+
+export const fetchMetricSeries = async (
+  metric: 'orders' | 'signups' | 'gmv',
+  period: string,
+) => {
+  const res = await adminApi.get('/metrics/timeseries', {
+    params: { metric, period },
+  });
+  return res.data as SeriesPoint[];
+};
+
 export interface UserQueryParams {
   role?: string;
   verified?: boolean;

--- a/client/src/components/SimpleChart.tsx
+++ b/client/src/components/SimpleChart.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+interface Point {
+  date: string;
+  value: number;
+}
+
+interface Props {
+  data: Point[];
+  height?: number;
+}
+
+const SimpleChart: React.FC<Props> = ({ data, height = 120 }) => {
+  const width = 300; // fixed viewBox width
+  if (!data.length) {
+    return <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} />;
+  }
+  const max = Math.max(...data.map((d) => d.value));
+  const min = Math.min(...data.map((d) => d.value));
+  const range = max - min || 1;
+  const points = data
+    .map((d, i) => {
+      const x = (i / (data.length - 1)) * width;
+      const y = height - ((d.value - min) / range) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`}> 
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        points={points}
+      />
+    </svg>
+  );
+};
+
+export default SimpleChart;

--- a/client/src/layouts/AdminLayout.tsx
+++ b/client/src/layouts/AdminLayout.tsx
@@ -14,7 +14,7 @@ const AdminLayout = () => {
             <li><Link to="/admin/products">Products</Link></li>
             <li><span>Events</span></li>
             <li><Link to="/admin/users">Users</Link></li>
-            <li><span>Analytics</span></li>
+            <li><Link to="/admin/analytics">Analytics</Link></li>
           </ul>
         </nav>
       </aside>

--- a/client/src/pages/AdminAnalytics/AdminAnalytics.scss
+++ b/client/src/pages/AdminAnalytics/AdminAnalytics.scss
@@ -1,0 +1,62 @@
+.admin-analytics {
+  padding: 1rem;
+
+  .analytics-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  .kpis {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .kpi {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 4px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+    h3 {
+      margin: 0 0 0.5rem;
+      font-size: 0.9rem;
+      color: #555;
+    }
+    p {
+      margin: 0;
+      font-size: 1.2rem;
+      font-weight: bold;
+    }
+  }
+
+  .charts {
+    display: grid;
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .chart {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 4px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  }
+
+  .tables {
+    display: grid;
+    gap: 2rem;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    th, td {
+      padding: 0.5rem;
+      text-align: left;
+      border-bottom: 1px solid #eee;
+    }
+  }
+}

--- a/client/src/pages/AdminAnalytics/AdminAnalytics.tsx
+++ b/client/src/pages/AdminAnalytics/AdminAnalytics.tsx
@@ -1,0 +1,112 @@
+import { lazy, Suspense, useEffect, useState } from 'react';
+import { fetchMetrics, fetchMetricSeries, type MetricsSummary, type SeriesPoint } from '../../api/admin';
+import Loader from '../../components/Loader';
+import './AdminAnalytics.scss';
+
+const Chart = lazy(() => import('../../components/SimpleChart'));
+
+const AdminAnalytics = () => {
+  const [metrics, setMetrics] = useState<MetricsSummary | null>(null);
+  const [series, setSeries] = useState<Record<string, SeriesPoint[]>>({});
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const data = await fetchMetrics();
+      setMetrics(data);
+      const [orders, signups, gmv] = await Promise.all([
+        fetchMetricSeries('orders', '30d'),
+        fetchMetricSeries('signups', '30d'),
+        fetchMetricSeries('gmv', '30d'),
+      ]);
+      setSeries({ orders, signups, gmv });
+    } catch {
+      setMetrics(null);
+      setSeries({});
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div className="admin-analytics">
+      <div className="analytics-header">
+        <h1>Analytics</h1>
+        <button type="button" onClick={load} disabled={loading}>
+          {loading ? 'Refreshing...' : 'Refresh'}
+        </button>
+      </div>
+      {loading && !metrics ? <Loader /> : null}
+      {!loading && !metrics ? <p>No data available.</p> : null}
+      {metrics && (
+        <>
+          <section className="kpis">
+            <div className="kpi"><h3>Users</h3><p>{metrics.users}</p></div>
+            <div className="kpi"><h3>Shops</h3><p>{metrics.shops}</p></div>
+            <div className="kpi"><h3>GMV</h3><p>{metrics.gmv}</p></div>
+            <div className="kpi"><h3>Orders Today</h3><p>{metrics.ordersToday}</p></div>
+            <div className="kpi"><h3>Orders 7d</h3><p>{metrics.orders7d}</p></div>
+            <div className="kpi"><h3>Orders 30d</h3><p>{metrics.orders30d}</p></div>
+            <div className="kpi"><h3>Active Events</h3><p>{metrics.activeEvents}</p></div>
+            <div className="kpi"><h3>Conversions</h3><p>{metrics.conversions}</p></div>
+          </section>
+          <section className="charts">
+            <Suspense fallback={<Loader />}>
+              <div className="chart">
+                <h3>Orders</h3>
+                <Chart data={series.orders || []} />
+              </div>
+              <div className="chart">
+                <h3>Signups</h3>
+                <Chart data={series.signups || []} />
+              </div>
+              <div className="chart">
+                <h3>GMV</h3>
+                <Chart data={series.gmv || []} />
+              </div>
+            </Suspense>
+          </section>
+          <section className="tables">
+            <div className="table">
+              <h3>Top Shops</h3>
+              {metrics.topShops && metrics.topShops.length ? (
+                <table>
+                  <thead><tr><th>Shop</th><th>Orders</th></tr></thead>
+                  <tbody>
+                    {metrics.topShops.map((s) => (
+                      <tr key={s.id}><td>{s.name}</td><td>{s.orders}</td></tr>
+                    ))}
+                  </tbody>
+                </table>
+              ) : (
+                <p>No data</p>
+              )}
+            </div>
+            <div className="table">
+              <h3>Top Products</h3>
+              {metrics.topProducts && metrics.topProducts.length ? (
+                <table>
+                  <thead><tr><th>Product</th><th>Orders</th></tr></thead>
+                  <tbody>
+                    {metrics.topProducts.map((p) => (
+                      <tr key={p.id}><td>{p.name}</td><td>{p.orders}</td></tr>
+                    ))}
+                  </tbody>
+                </table>
+              ) : (
+                <p>No data</p>
+              )}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default AdminAnalytics;

--- a/client/src/pages/AdminAnalytics/index.ts
+++ b/client/src/pages/AdminAnalytics/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AdminAnalytics';


### PR DESCRIPTION
## Summary
- add metrics and timeseries helpers for admin API
- introduce simple SVG chart and admin analytics page
- wire analytics page into admin navigation and routes

## Testing
- `npm --prefix client run lint`
- `npm --prefix client run build` *(fails: ReactNode must be imported type-only, existing TS errors in Events and others)*

------
https://chatgpt.com/codex/tasks/task_e_689f1e942258833299d828b6aff515a2