### PR TITLE
feat: improve admin events accessibility

### DIFF
--- a/client/src/hooks/useFocusTrap.ts
+++ b/client/src/hooks/useFocusTrap.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+
+/**
+ * Trap focus within the referenced element when active.
+ * Restores focus to previously active element on cleanup.
+ */
+export const useFocusTrap = <T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  active: boolean,
+  onClose?: () => void
+) => {
+  useEffect(() => {
+    if (!active || !ref.current) return;
+
+    const node = ref.current;
+    const focusable = node.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose?.();
+        return;
+      }
+      if (e.key !== 'Tab' || focusable.length === 0) return;
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    first?.focus();
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', handleKey);
+
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+      document.body.style.overflow = '';
+      previouslyFocused?.focus();
+    };
+  }, [ref, active, onClose]);
+};
+
+export default useFocusTrap;

--- a/client/src/pages/AdminEvents/AdminEvents.scss
+++ b/client/src/pages/AdminEvents/AdminEvents.scss
@@ -21,6 +21,35 @@
   text-align: left;
 }
 
+.status-chip {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.status-upcoming {
+  background: #2563eb;
+}
+
+.status-ongoing {
+  background: #16a34a;
+}
+
+.status-past {
+  background: #6b7280;
+}
+
+/* Keep header visible while scrolling */
+.events-table thead th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 1;
+}
+
 .actions button {
   margin-right: 0.25rem;
 }
@@ -56,4 +85,44 @@
   gap: 0.5rem;
   justify-content: flex-end;
   margin-top: 1rem;
+}
+
+/* Mobile card view */
+@media (max-width: 768px) {
+  .events-table,
+  .events-table thead,
+  .events-table tbody,
+  .events-table th,
+  .events-table td,
+  .events-table tr {
+    display: block;
+  }
+
+  .events-table thead {
+    display: none;
+  }
+
+  .events-table tr {
+    margin-bottom: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  }
+
+  .events-table td {
+    border: none;
+    border-bottom: 1px solid #eee;
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .events-table td::before {
+    content: attr(data-label);
+    font-weight: bold;
+  }
+
+  .events-table td:last-child {
+    border-bottom: none;
+  }
 }

--- a/client/src/pages/AdminEvents/AdminEvents.tsx
+++ b/client/src/pages/AdminEvents/AdminEvents.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   fetchEvents,
   createEvent as apiCreateEvent,
@@ -9,6 +9,7 @@ import {
 import Loader from '../../components/Loader';
 import toast from '../../components/toast';
 import './AdminEvents.scss';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface EventItem {
   _id: string;
@@ -47,6 +48,11 @@ const AdminEvents = () => {
   const [edit, setEdit] = useState<EventItem | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
   const [saving, setSaving] = useState(false);
+
+  const createRef = useRef<HTMLFormElement>(null);
+  const editRef = useRef<HTMLFormElement>(null);
+  useFocusTrap<HTMLFormElement>(createRef, createOpen, () => setCreateOpen(false));
+  useFocusTrap<HTMLFormElement>(editRef, !!edit, () => setEdit(null));
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -166,15 +172,24 @@ const AdminEvents = () => {
           <tbody>
             {events.map((ev) => (
               <tr key={ev._id}>
-                <td>{ev.title}</td>
-                <td>{new Date(ev.startAt).toLocaleString()}</td>
-                <td>{new Date(ev.endAt).toLocaleString()}</td>
-                <td>{ev.status}</td>
-                <td>{ev.capacity}</td>
-                <td>{ev.registered}</td>
-                <td className="actions">
-                  <button onClick={() => openEdit(ev)}>Edit</button>
-                  <button onClick={() => handleDelete(ev._id)}>Delete</button>
+                <td data-label="Title">{ev.title}</td>
+                <td data-label="Start">{new Date(ev.startAt).toLocaleString()}</td>
+                <td data-label="End">{new Date(ev.endAt).toLocaleString()}</td>
+                <td data-label="Status">
+                  <span className={`status-chip status-${ev.status}`}>{ev.status}</span>
+                </td>
+                <td data-label="Capacity">{ev.capacity}</td>
+                <td data-label="Registered">{ev.registered}</td>
+                <td className="actions" data-label="Actions">
+                  <button aria-label={`Edit ${ev.title}`} onClick={() => openEdit(ev)}>
+                    Edit
+                  </button>
+                  <button
+                    aria-label={`Delete ${ev.title}`}
+                    onClick={() => handleDelete(ev._id)}
+                  >
+                    Delete
+                  </button>
                 </td>
               </tr>
             ))}
@@ -197,8 +212,12 @@ const AdminEvents = () => {
       </div>
 
       {createOpen && (
-        <div className="modal">
-          <form className="modal-content" onSubmit={handleCreate}>
+        <div className="modal" role="dialog" aria-modal="true">
+          <form
+            ref={createRef}
+            className="modal-content"
+            onSubmit={handleCreate}
+          >
             <h3>Create Event</h3>
             <label>
               Title
@@ -250,8 +269,12 @@ const AdminEvents = () => {
       )}
 
       {edit && (
-        <div className="modal">
-          <form className="modal-content" onSubmit={handleUpdate}>
+        <div className="modal" role="dialog" aria-modal="true">
+          <form
+            ref={editRef}
+            className="modal-content"
+            onSubmit={handleUpdate}
+          >
             <h3>Edit Event</h3>
             <label>
               Title


### PR DESCRIPTION
## Summary
- add reusable focus-trap hook for modals
- make admin events table responsive with sticky header and status chips
- add aria labels to event actions

## Testing
- `npm run lint`
- `npm run build` *(fails: ReactNode type-only import and typing issues elsewhere)*

------
https://chatgpt.com/codex/tasks/task_e_68a007880c288332acabae636a4d2827