### PR TITLE
feat: introduce blue light theme and default

### DIFF
--- a/client/src/styles/_base.scss
+++ b/client/src/styles/_base.scss
@@ -14,6 +14,7 @@ h5,
 h6 {
   font-weight: 700;
   line-height: 1.2;
+  color: var(--color-primary);
 }
 
 .card {

--- a/client/src/styles/_reset.scss
+++ b/client/src/styles/_reset.scss
@@ -69,3 +69,9 @@ button {
   font: inherit;
   color: inherit;
 }
+
+/* Focus states */
+:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}

--- a/client/src/styles/_theme.scss
+++ b/client/src/styles/_theme.scss
@@ -6,6 +6,28 @@
  */
 
 :root {
+  /* Blue scale */
+  --blue-900: #0B3C8A;
+  --blue-800: #1149A6;
+  --blue-700: #1657C2;
+  --blue-600: #1B63D9;
+  --blue-500: #2A75E8;
+  --blue-400: #5B95F0;
+  --blue-300: #8AB2F6;
+  --blue-200: #BDD1FA;
+  --blue-100: #E7F0FE;
+  --blue-050: #F3F8FF;
+
+  /* Neutrals */
+  --gray-900: #111827;
+  --gray-700: #374151;
+  --gray-600: #4B5563;
+  --gray-500: #6B7280;
+  --gray-300: #D1D5DB;
+  --gray-200: #E5E7EB;
+  --gray-100: #F3F4F6;
+  --white: #FFFFFF;
+
   /* Typography scale */
   --font-family-sans: 'Inter', 'DM Sans', sans-serif;
   --font-size-xs: 0.75rem;
@@ -15,12 +37,12 @@
   --font-size-xl: 1.5rem;
 
   /* Radii */
-  --radius-sm: 6px;
-  --radius-md: 10px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
   --radius-lg: 16px;
 
   /* Shadows */
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05), 0 1px 3px rgba(0, 0, 0, 0.1);
   --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.15);
 
@@ -29,53 +51,60 @@
   --space-2: 8px;
   --space-3: 12px;
   --space-4: 16px;
-  --space-5: 20px;
-  --space-6: 24px;
-  --space-7: 28px;
-  --space-8: 32px;
+  --space-5: 24px;
+  --space-6: 32px;
 
   /* Legacy spacing aliases */
   --spacing-xs: var(--space-1);
   --spacing-sm: var(--space-2);
   --spacing-md: var(--space-4);
-  --spacing-lg: var(--space-6);
-  --spacing-xl: var(--space-8);
+  --spacing-lg: var(--space-5);
+  --spacing-xl: var(--space-6);
 
-  /* Default (light) colours */
-  --color-bg: #ffffff;
-  --color-surface: #f5f5f7;
-  --color-text: #1f2937;
-  --color-primary: #ff3e6c;
-  --color-primary-hover: #ff6b81;
-  --color-success: #22c55e;
-  --color-danger: #ef4444;
-  --color-muted: #6b7280;
+  /* Default (Blue Light) colours */
+  --color-bg: var(--white);
+  --color-surface: var(--white);
+  --color-surface-alt: var(--blue-050);
+  --color-text: var(--gray-900);
+  --color-muted: var(--gray-600);
+  --color-primary: var(--blue-600);
+  --color-primary-hover: var(--blue-700);
+  --color-primary-contrast: var(--white);
+  --color-on-primary: var(--color-primary-contrast);
+  --color-border: var(--blue-100);
+  --color-focus-ring: var(--blue-500);
+  --color-success: #16A34A;
+  --color-warning: #D97706;
+  --color-danger: #DC2626;
+  --color-info: var(--blue-600);
   --color-text-secondary: var(--color-muted);
-  --color-border: var(--color-muted);
-  --color-on-primary: #ffffff;
   --overlay-bg: rgba(0, 0, 0, 0.4);
 
   /* Legacy colour aliases */
   --color-card: var(--color-surface);
-  --color-warning: #f59e0b;
-  --color-info: #3b82f6;
 }
 
-/* Light theme (explicit) */
+/* Blue Light theme (explicit) */
 [data-theme='light'] {
-  --color-bg: #ffffff;
-  --color-surface: #f5f5f7;
-  --color-text: #1f2937;
-  --color-primary: #ff3e6c;
-  --color-primary-hover: #ff6b81;
-  --color-success: #22c55e;
-  --color-danger: #ef4444;
-  --color-muted: #6b7280;
+  --color-bg: var(--white);
+  --color-surface: var(--white);
+  --color-surface-alt: var(--blue-050);
+  --color-text: var(--gray-900);
+  --color-muted: var(--gray-600);
+  --color-primary: var(--blue-600);
+  --color-primary-hover: var(--blue-700);
+  --color-primary-contrast: var(--white);
+  --color-on-primary: var(--color-primary-contrast);
+  --color-border: var(--blue-100);
+  --color-focus-ring: var(--blue-500);
+  --color-success: #16A34A;
+  --color-warning: #D97706;
+  --color-danger: #DC2626;
+  --color-info: var(--blue-600);
+  --color-text-secondary: var(--color-muted);
 
   /* Legacy colour aliases */
   --color-card: var(--color-surface);
-  --color-warning: #f59e0b;
-  --color-info: #3b82f6;
   --overlay-bg: rgba(0, 0, 0, 0.4);
 }
 
@@ -83,36 +112,48 @@
 [data-theme='dark'] {
   --color-bg: #18181b;
   --color-surface: #27272a;
+  --color-surface-alt: #1f1f23;
   --color-text: #f5f5f5;
+  --color-muted: #9ca3af;
   --color-primary: #ff3e6c;
   --color-primary-hover: #ff6b81;
-  --color-success: #22c55e;
-  --color-danger: #ef4444;
-  --color-muted: #9ca3af;
+  --color-primary-contrast: #ffffff;
+  --color-on-primary: var(--color-primary-contrast);
+  --color-border: #3f3f46;
+  --color-focus-ring: var(--blue-500);
+  --color-success: #16A34A;
+  --color-warning: #D97706;
+  --color-danger: #DC2626;
+  --color-info: var(--blue-600);
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.6);
   --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.7);
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.8);
 
   --color-card: var(--color-surface);
-  --color-warning: #f59e0b;
-  --color-info: #3b82f6;
   --overlay-bg: rgba(0, 0, 0, 0.6);
+  --color-text-secondary: var(--color-muted);
 }
 
 /* Colourful theme with brand accents */
 [data-theme='colorful'] {
   --color-bg: #fff8e1;
   --color-surface: #ffffff;
+  --color-surface-alt: #fff4e6;
   --color-text: #222222;
+  --color-muted: #6b7280;
   --color-primary: #ff9800;
   --color-primary-hover: #ffb74d;
-  --color-success: #22c55e;
-  --color-danger: #ef4444;
-  --color-muted: #6b7280;
+  --color-primary-contrast: #ffffff;
+  --color-on-primary: var(--color-primary-contrast);
+  --color-border: var(--gray-200);
+  --color-focus-ring: var(--blue-500);
+  --color-success: #16A34A;
+  --color-warning: #D97706;
+  --color-danger: #DC2626;
+  --color-info: var(--blue-600);
 
   --color-card: var(--color-surface);
-  --color-warning: #f59e0b;
-  --color-info: #3b82f6;
   --overlay-bg: rgba(0, 0, 0, 0.4);
+  --color-text-secondary: var(--color-muted);
 }
 

--- a/client/src/theme/ThemeProvider.tsx
+++ b/client/src/theme/ThemeProvider.tsx
@@ -21,8 +21,7 @@ const ThemeProvider = ({ children }: { children: ReactNode }) => {
     if (stored && availableThemes.includes(stored)) {
       setTheme(stored);
     } else {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      setTheme(prefersDark ? 'dark' : 'light');
+      setTheme('light');
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- add blue palette tokens and blue light theme defaults
- set blue light as default theme
- add global focus ring and heading colors

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a0122c25a883328963ba0a0cb1109b