### PR TITLE
style: refine toolbar visuals

### DIFF
--- a/client/src/components/ui/Toolbar.module.scss
+++ b/client/src/components/ui/Toolbar.module.scss
@@ -6,23 +6,81 @@
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2);
-  background: var(--color-bg);
+  background: var(--white);
   box-shadow: var(--shadow-sm);
 }
 
 .title {
   font-size: var(--font-size-lg);
   font-weight: 600;
+  color: var(--gray-900);
 }
 
 .search {
   flex: 1;
 }
 
+.search input {
+  width: 100%;
+  border-radius: var(--radius-sm);
+}
+
+.search input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--blue-500);
+}
+
 .actions {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+}
+
+.actions button {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--blue-600);
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.actions button:hover {
+  background: var(--blue-050);
+}
+
+.actions button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--blue-500);
+}
+
+.actions button.active,
+.actions button[aria-current='true'] {
+  background: var(--blue-050);
+}
+
+.actions :global(.badge) {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: var(--blue-600);
+  color: var(--white);
+  min-width: 18px;
+  min-height: 18px;
+  padding: 0 4px;
+  border-radius: 12px;
+  font-size: var(--font-size-xs);
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- Make toolbar background always white with shadow-sm for a crisp header
- Add blue-focused interactions for actions and search, including global badge styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a018ffee008332b00e8e87e62e9f32