### PR TITLE
style: apply blue theme to core components

### DIFF
--- a/client/src/components/base/OrderCard.module.scss
+++ b/client/src/components/base/OrderCard.module.scss
@@ -1,5 +1,6 @@
 .card {
-  background: var(--color-card);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
   border-radius: var(--radius-md);
   padding: var(--spacing-sm);

--- a/client/src/components/base/ProductCard.module.scss
+++ b/client/src/components/base/ProductCard.module.scss
@@ -1,5 +1,6 @@
 .card {
-  background: var(--color-card);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
@@ -7,9 +8,10 @@
   flex-direction: column;
   position: relative;
   cursor: pointer;
-  transition: box-shadow var(--transition-medium);
+  transition: transform var(--transition-medium), box-shadow var(--transition-medium);
 
   &:hover {
+    transform: translateY(-2px);
     box-shadow: var(--shadow-md);
   }
 }
@@ -30,8 +32,8 @@
     position: absolute;
     left: var(--spacing-sm);
     top: var(--spacing-sm);
-    background: var(--color-primary);
-    color: var(--color-on-primary);
+    background: var(--blue-600);
+    color: var(--white);
     border-radius: var(--radius-sm);
     padding: 2px 6px;
     font-size: var(--font-size-sm);

--- a/client/src/components/base/ProfileHeader.module.scss
+++ b/client/src/components/base/ProfileHeader.module.scss
@@ -3,7 +3,8 @@
   align-items: center;
   gap: var(--spacing-md);
   padding: var(--spacing-md) var(--spacing-sm);
-  background: var(--color-card);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
 }
@@ -27,8 +28,8 @@
 }
 
 .role {
-  background: var(--color-primary);
-  color: var(--color-on-primary);
+  background: var(--blue-100);
+  color: var(--blue-700);
   padding: 0 var(--spacing-xs);
   border-radius: var(--radius-sm);
   font-size: 0.75rem;
@@ -54,9 +55,26 @@
 }
 
 .actions button {
-  background: var(--color-card);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-primary);
   border-radius: var(--radius-md);
   padding: 0.25rem 0.75rem;
   cursor: pointer;
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+}
+
+.actions button + button {
+  background: var(--blue-100);
+  color: var(--blue-700);
+  border-color: var(--blue-100);
+}
+
+.nameRow h3 {
+  color: var(--gray-900);
+  margin: 0;
 }

--- a/client/src/components/ui/ProductCard.module.scss
+++ b/client/src/components/ui/ProductCard.module.scss
@@ -1,5 +1,6 @@
 .card {
-  background: var(--color-card);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
@@ -37,8 +38,8 @@
     position: absolute;
     left: var(--spacing-sm);
     top: var(--spacing-sm);
-    background: var(--color-primary);
-    color: var(--color-on-primary);
+    background: var(--blue-600);
+    color: var(--white);
     border-radius: var(--radius-sm);
     padding: 2px 6px;
     font-size: var(--font-size-sm);

--- a/client/src/components/ui/SectionHeader.module.scss
+++ b/client/src/components/ui/SectionHeader.module.scss
@@ -8,11 +8,13 @@
 .title {
   font-size: var(--font-size-lg);
   font-weight: 600;
+  border-left: 4px solid var(--blue-600);
+  padding-left: var(--space-2);
 }
 
 .link {
   font-size: var(--font-size-sm);
-  color: var(--color-primary);
+  color: var(--blue-600);
 }
 
 @media (min-width: 768px) {

--- a/client/src/components/ui/StatusChip.module.scss
+++ b/client/src/components/ui/StatusChip.module.scss
@@ -8,19 +8,19 @@
 }
 
 .pending {
-  background: var(--color-primary);
-  color: var(--color-on-primary);
+  background: var(--blue-100);
+  color: var(--blue-700);
 }
 
 .accepted {
-  background: var(--color-success);
-  color: var(--color-on-primary);
+  background: var(--blue-600);
+  color: var(--white);
 }
 
 .rejected,
 .cancelled {
   background: var(--color-danger);
-  color: var(--color-on-primary);
+  color: var(--white);
 }
 
 .completed {


### PR DESCRIPTION
## Summary
- style ProductCard surfaces with borders, blue discount badges, and hover lift
- align OrderCard and status chips with blue theme tokens
- polish ProfileHeader and section headers with blue accents

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a01bd8acf88332a58d14cf604f1be0