### PR TITLE
refactor: replace hardcoded colors with tokens

### DIFF
--- a/client/src/components/base/CartSummary.module.scss
+++ b/client/src/components/base/CartSummary.module.scss
@@ -8,7 +8,8 @@
   flex-direction: column;
   gap: 0.5rem;
   padding: 1rem;
-  background: var(--color-card);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: var(--shadow-sm);
 }
@@ -17,6 +18,7 @@
   display: flex;
   justify-content: space-between;
   font-size: 0.95rem;
+  color: var(--color-text);
 }
 
 .total {
@@ -24,6 +26,7 @@
   justify-content: space-between;
   font-weight: bold;
   margin-top: 0.5rem;
+  color: var(--color-text);
 }
 
 .checkout {
@@ -44,5 +47,8 @@
   button {
     @include button-style(var(--color-primary), var(--color-on-primary));
     padding: 0.5rem 1rem;
+  }
+  a {
+    color: var(--color-primary);
   }
 }

--- a/client/src/components/base/OrderCard.module.scss
+++ b/client/src/components/base/OrderCard.module.scss
@@ -7,6 +7,12 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover,
+.card:focus-within {
+  box-shadow: var(--shadow-md);
 }
 
 .thumbs {

--- a/client/src/pages/EventDetails/EventDetails.scss
+++ b/client/src/pages/EventDetails/EventDetails.scss
@@ -1,3 +1,5 @@
+@import "../../styles/mixins";
+
 .event-details {
   padding: 1.5rem;
 
@@ -18,25 +20,25 @@
     }
 
     .meta {
-      color: #777;
+      color: var(--color-text-secondary);
       margin-bottom: 1rem;
     }
 
     .countdown {
       font-weight: bold;
-      color: #0070f3;
+      color: var(--color-primary);
       margin-bottom: 1rem;
     }
 
     .description {
-      color: #333;
+      color: var(--color-text);
       line-height: 1.5;
       margin-bottom: 1rem;
     }
 
     .admin-note {
-      background: #fef8e7;
-      border-left: 4px solid #f0c36d;
+      background: var(--color-surface-alt);
+      border-left: 4px solid var(--color-warning);
       padding: 0.8rem;
       margin-bottom: 1.5rem;
       border-radius: 6px;
@@ -52,14 +54,11 @@
     }
 
     .register-btn {
-      background-color: #0070f3;
-      color: white;
+      @include button-style(var(--color-primary), var(--color-on-primary));
       padding: 0.7rem 1.5rem;
       font-weight: 600;
-      border: none;
       border-radius: 8px;
-      cursor: pointer;
-      transition: all 0.2s ease;
+      transition: background 0.2s ease;
 
       &:disabled {
         opacity: 0.6;
@@ -67,14 +66,14 @@
       }
 
       &:hover {
-        background-color: #005ad4;
+        background-color: var(--color-primary-hover);
       }
     }
 
     .message {
       margin-top: 0.8rem;
       font-weight: bold;
-      color: #155724;
+      color: var(--color-success);
     }
 
     .leaderboard {
@@ -87,15 +86,15 @@
         th,
         td {
           padding: 0.4rem;
-          border-bottom: 1px solid #e0e0e0;
+          border-bottom: 1px solid var(--color-border);
         }
 
         th {
-          background: #f8f8f8;
+          background: var(--color-surface-alt);
         }
 
         .winner {
-          background: #fff8e1;
+          background: var(--color-surface-alt);
         }
       }
     }

--- a/client/src/pages/Events/Events.scss
+++ b/client/src/pages/Events/Events.scss
@@ -1,3 +1,5 @@
+@import "../../styles/mixins";
+
 .events {
   padding: 2rem;
 
@@ -13,15 +15,17 @@
 
     .tab {
       padding: 0.4rem 0.9rem;
-      border: none;
+      border: 1px solid var(--color-border);
       border-radius: 16px;
-      background: #f0f0f0;
+      background: var(--color-surface-alt);
       cursor: pointer;
       font-weight: 500;
+      color: var(--color-text);
 
       &.active {
-        background: #0070f3;
-        color: #fff;
+        background: var(--color-primary);
+        color: var(--color-on-primary);
+        border-color: var(--color-primary);
       }
     }
   }
@@ -33,13 +37,18 @@
   }
 
   .event-card {
-    background: white;
+    background: var(--color-surface);
     border-radius: 12px;
     padding: 1rem;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: var(--shadow-sm);
     cursor: pointer;
-    transition: transform 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
     text-align: center;
+
+    &:hover {
+      transform: translateY(-4px);
+      box-shadow: var(--shadow-md);
+    }
 
     img {
       width: 100%;
@@ -52,32 +61,24 @@
     h3 {
       margin: 0.5rem 0 0.2rem;
       font-size: 1.1rem;
+      color: var(--color-primary);
     }
 
     .date,
     .location {
       margin: 0.2rem 0;
-      color: #666;
+      color: var(--color-text-secondary);
       font-size: 0.9rem;
     }
 
     .register-btn {
       margin-top: 0.5rem;
       padding: 0.4rem 0.8rem;
-      background: #0070f3;
-      color: #fff;
-      border: none;
-      border-radius: 6px;
-      cursor: pointer;
+      @include button-style(var(--color-primary), var(--color-on-primary));
       font-weight: 600;
-
       &:hover {
-        background: #005ad4;
+        background: var(--color-primary-hover);
       }
-    }
-
-    &:hover {
-      transform: translateY(-4px);
     }
   }
 }

--- a/client/src/pages/MyOrders/MyOrders.module.scss
+++ b/client/src/pages/MyOrders/MyOrders.module.scss
@@ -20,11 +20,28 @@
 
   .chip {
     padding: 0.4rem 0.8rem;
-    border: none;
+    border: 1px solid var(--color-border);
     border-radius: 999px;
     background: var(--color-surface);
     font-size: 0.85rem;
     cursor: pointer;
+    color: var(--color-text);
+    transition: background 0.2s ease;
+
+    &:hover {
+      background: var(--color-surface-alt);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-focus-ring);
+      outline-offset: 2px;
+    }
+
+    &.active {
+      background: var(--color-primary);
+      color: var(--color-on-primary);
+      border-color: var(--color-primary);
+    }
   }
 }
 

--- a/client/src/pages/VerifiedUserDetails/VerifiedUserDetails.scss
+++ b/client/src/pages/VerifiedUserDetails/VerifiedUserDetails.scss
@@ -1,4 +1,5 @@
 @import "../../styles/variables";
+@import "../../styles/mixins";
 .verified-user-details {
   padding: 2rem;
 
@@ -13,24 +14,25 @@
       height: 120px;
       border-radius: 50%;
       object-fit: cover;
-      border: 4px solid #0070f3;
+      border: 4px solid var(--color-primary);
     }
 
     .info {
       text-align: center;
 
       .badge {
-        color: $primary-color;
+        color: var(--color-primary);
         margin-left: 4px;
       }
 
       h2 {
         font-size: 1.8rem;
         margin: 0.2rem 0;
+        color: var(--color-primary);
       }
 
       p {
-        color: #555;
+        color: var(--color-text-secondary);
         margin: 0.2rem 0;
       }
     }
@@ -46,17 +48,15 @@
 
     p {
       line-height: 1.5;
-      color: #444;
+      color: var(--color-text);
     }
   }
 
   .contact-button {
     display: block;
     margin: 2rem auto 0;
-    background-color: #25d366;
-    color: white;
+    @include button-style(var(--color-primary), var(--color-on-primary));
     padding: 0.6rem 1.2rem;
-    border: none;
     border-radius: 8px;
     font-weight: bold;
     text-align: center;
@@ -65,7 +65,7 @@
     transition: background 0.2s ease;
 
     &:hover {
-      background-color: #1ebd57;
+      background-color: var(--color-primary-hover);
     }
   }
 }

--- a/client/src/pages/VerifiedUsers/VerifiedUsers.module.scss
+++ b/client/src/pages/VerifiedUsers/VerifiedUsers.module.scss
@@ -1,4 +1,5 @@
 @import "../../styles/variables";
+@import "../../styles/mixins";
 .verifiedUsers {
   padding: 2rem;
 
@@ -17,7 +18,9 @@
     select {
       padding: 0.4rem 0.6rem;
       border-radius: 6px;
-      border: 1px solid #ddd;
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      color: var(--color-text);
       font-size: 0.9rem;
     }
   }
@@ -29,22 +32,28 @@
   }
 
   .card {
-    background: #fff;
+    background: var(--color-surface);
     border-radius: 12px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    border: 1px solid var(--color-border);
+    box-shadow: var(--shadow-sm);
     padding: 1rem;
     display: flex;
     flex-direction: column;
     position: relative;
     overflow: hidden;
     cursor: pointer;
+    transition: box-shadow 0.2s ease;
+
+    &:hover {
+      box-shadow: var(--shadow-md);
+    }
   }
 
   .badge {
     position: absolute;
     top: 0.5rem;
     right: 0.5rem;
-    color: $primary-color;
+    color: var(--color-primary);
     display: flex;
     align-items: center;
     font-size: 1.1rem;
@@ -64,18 +73,25 @@
     h3 {
       margin: 0.3rem 0;
       font-size: 1.1rem;
+      color: var(--color-primary);
     }
 
     p {
       margin: 0.15rem 0;
-      color: #555;
+      color: var(--color-text-secondary);
       font-size: 0.85rem;
     }
   }
 
   .empty {
     text-align: center;
-    color: #777;
+    color: var(--color-muted);
     margin-top: 2rem;
+
+    button,
+    a {
+      @include button-style($primary-color, var(--color-on-primary));
+      margin-top: 1rem;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- use token-based colors for cart summary with white surface and blue CTA
- add hover/focus feedback and blue accents for order, event, and verified cards
- apply blue chips/status and empty state CTAs using design system tokens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a01e4205b883329c6c7c874d8ae060