### PR TITLE
fix: preload persisted theme to avoid FOUC

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,6 +6,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Orbitron:wght@600&display=swap" rel="stylesheet" />
     <title>Manacity</title>
+    <script>
+      (function () {
+        try {
+          const theme = localStorage.getItem('manacity_theme') || 'light';
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch {
+          // ignore access issues
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- preload persisted theme before app render to prevent flash of unstyled content

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a02292956083329d5ff5a123d6dd10