### PR TITLE
Use theme background color for TabLayout

### DIFF
--- a/client/src/layouts/TabLayout.scss
+++ b/client/src/layouts/TabLayout.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
+  background-color: var(--color-bg);
 
   .top-header {
     display: flex;


### PR DESCRIPTION
## Summary
- Remove blue gradient from TabLayout and inherit theme background color

## Testing
- `npm test` (client) *(fails: Missing script "test")*
- `npm run lint` (client)
- `npm test` (server) *(fails: Error: no test specified)*
- `npm run lint` (server) *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a02a58e6308332a22e36a706e409fd