### PR TITLE
feat: unify blue theme and toast feedback

### DIFF
--- a/client/src/components/ui/ProductCard.tsx
+++ b/client/src/components/ui/ProductCard.tsx
@@ -6,6 +6,7 @@ import { addToCart } from '../../store/slices/cartSlice';
 import fallbackImage from '../../assets/no-image.svg';
 import WishlistHeart from './WishlistHeart';
 import PriceBlock from './PriceBlock';
+import showToast from './Toast';
 import styles from './ProductCard.module.scss';
 
 export interface Product {
@@ -51,8 +52,9 @@ const ProductCard = ({
           image: product.image,
         })
       );
+      showToast('Added to cart');
     } catch {
-      alert('Failed to add to cart');
+      showToast('Failed to add to cart', 'error');
     }
   };
 
@@ -60,9 +62,9 @@ const ProductCard = ({
     try {
       const qty = parseInt(prompt('Quantity', '1') || '1', 10);
       await api.post(`/orders/place/${product._id}`, { quantity: qty });
-      alert('Order request sent');
+      showToast('Order request sent');
     } catch {
-      alert('Failed to send order');
+      showToast('Failed to send order', 'error');
     }
   };
 

--- a/client/src/components/ui/Toast.tsx
+++ b/client/src/components/ui/Toast.tsx
@@ -1,6 +1,6 @@
-export type ToastType = 'success' | 'error';
+export type ToastType = 'success' | 'error' | 'info';
 
-const showToast = (message: string, type: ToastType = 'success') => {
+const showToast = (message: string, type: ToastType = 'info') => {
   if (typeof document === 'undefined') return;
   const toast = document.createElement('div');
   toast.textContent = message;
@@ -9,10 +9,10 @@ const showToast = (message: string, type: ToastType = 'success') => {
     bottom: 1rem;
     left: 50%;
     transform: translateX(-50%);
-    background: ${type === 'success' ? 'var(--color-success)' : 'var(--color-danger)'};
+    background: ${type === 'success' ? 'var(--color-success)' : type === 'error' ? 'var(--color-danger)' : 'var(--color-info)'};
     color: var(--color-on-primary);
     padding: 0.75rem 1rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     box-shadow: var(--shadow-md);
     z-index: 9999;
     opacity: 0;
@@ -31,4 +31,3 @@ const showToast = (message: string, type: ToastType = 'success') => {
 };
 
 export default showToast;
-

--- a/client/src/pages/AdminEvents/AdminEvents.tsx
+++ b/client/src/pages/AdminEvents/AdminEvents.tsx
@@ -7,7 +7,7 @@ import {
   type EventQueryParams,
 } from '../../api/admin';
 import Loader from '../../components/Loader';
-import toast from '../../components/toast';
+import showToast from '../../components/ui/Toast';
 import './AdminEvents.scss';
 import useFocusTrap from '../../hooks/useFocusTrap';
 
@@ -67,7 +67,7 @@ const AdminEvents = () => {
       setEvents(data.items as EventItem[]);
       setTotal(data.total);
     } catch {
-      toast('Failed to load events', 'error');
+      showToast('Failed to load events', 'error');
     } finally {
       setLoading(false);
     }
@@ -82,7 +82,7 @@ const AdminEvents = () => {
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
     if (new Date(form.startAt) >= new Date(form.endAt)) {
-      toast('startAt must be before endAt', 'error');
+      showToast('startAt must be before endAt', 'error');
       return;
     }
     setSaving(true);
@@ -92,7 +92,7 @@ const AdminEvents = () => {
       setCreateOpen(false);
       setForm(emptyForm);
     } catch {
-      toast('Failed to create event', 'error');
+      showToast('Failed to create event', 'error');
     } finally {
       setSaving(false);
     }
@@ -112,7 +112,7 @@ const AdminEvents = () => {
     e.preventDefault();
     if (!edit) return;
     if (new Date(form.startAt) >= new Date(form.endAt)) {
-      toast('startAt must be before endAt', 'error');
+      showToast('startAt must be before endAt', 'error');
       return;
     }
     setSaving(true);
@@ -121,7 +121,7 @@ const AdminEvents = () => {
       setEvents((prev) => prev.map((ev) => (ev._id === edit._id ? updated : ev)));
       setEdit(null);
     } catch {
-      toast('Failed to update event', 'error');
+      showToast('Failed to update event', 'error');
     } finally {
       setSaving(false);
     }
@@ -134,7 +134,7 @@ const AdminEvents = () => {
       setEvents((prev) => prev.filter((ev) => ev._id !== id));
       setTotal((t) => t - 1);
     } catch {
-      toast('Failed to delete event', 'error');
+      showToast('Failed to delete event', 'error');
     }
   };
 

--- a/client/src/pages/AdminProducts/AdminProducts.tsx
+++ b/client/src/pages/AdminProducts/AdminProducts.tsx
@@ -6,7 +6,7 @@ import {
   type ProductQueryParams,
 } from '../../api/admin';
 import Loader from '../../components/Loader';
-import toast from '../../components/toast';
+import showToast from '../../components/ui/Toast';
 import './AdminProducts.scss';
 
 interface Product {
@@ -69,7 +69,7 @@ const AdminProducts = () => {
       setProducts(data.items as Product[]);
       setTotal(data.total);
     } catch {
-      toast('Failed to load products', 'error');
+      showToast('Failed to load products', 'error');
     } finally {
       setLoading(false);
     }
@@ -125,7 +125,7 @@ const AdminProducts = () => {
       setProducts((prevList) =>
         prevList.map((p) => (p._id === prev._id ? prev : p)),
       );
-      toast('Failed to update product', 'error');
+      showToast('Failed to update product', 'error');
     } finally {
       setSaving(false);
     }
@@ -139,7 +139,7 @@ const AdminProducts = () => {
       await apiDeleteProduct(id);
     } catch {
       setProducts(prev);
-      toast('Failed to delete product', 'error');
+      showToast('Failed to delete product', 'error');
     }
   };
 

--- a/client/src/pages/AdminShops/AdminShops.tsx
+++ b/client/src/pages/AdminShops/AdminShops.tsx
@@ -6,7 +6,7 @@ import {
   type ShopQueryParams,
 } from '../../api/admin';
 import Loader from '../../components/Loader';
-import toast from '../../components/toast';
+import showToast from '../../components/ui/Toast';
 import './AdminShops.scss';
 
 interface Shop {
@@ -49,7 +49,7 @@ const AdminShops = () => {
       setShops(data.items);
       setTotal(data.total);
     } catch {
-      toast('Failed to load shops', 'error');
+      showToast('Failed to load shops', 'error');
     } finally {
       setLoading(false);
     }
@@ -69,11 +69,11 @@ const AdminShops = () => {
         category: edit.category,
         location: edit.location,
       });
-      toast('Shop updated');
+      showToast('Shop updated');
       setEdit(null);
       load();
     } catch {
-      toast('Failed to update shop', 'error');
+      showToast('Failed to update shop', 'error');
     } finally {
       setSaving(false);
     }
@@ -87,7 +87,7 @@ const AdminShops = () => {
         prev.map((s) => (s._id === shop._id ? { ...s, status: newStatus } : s)),
       );
     } catch {
-      toast('Failed to update status', 'error');
+      showToast('Failed to update status', 'error');
     }
   };
 
@@ -96,10 +96,10 @@ const AdminShops = () => {
     try {
       await apiDeleteShop(id);
       setShops((prev) => prev.filter((s) => s._id !== id));
-      toast('Shop deleted');
+      showToast('Shop deleted');
       load();
     } catch {
-      toast('Failed to delete shop', 'error');
+      showToast('Failed to delete shop', 'error');
     }
   };
 

--- a/client/src/pages/AdminUsers/AdminUsers.tsx
+++ b/client/src/pages/AdminUsers/AdminUsers.tsx
@@ -7,7 +7,7 @@ import {
   type UserQueryParams,
 } from '../../api/admin';
 import Loader from '../../components/Loader';
-import toast from '../../components/toast';
+import showToast from '../../components/ui/Toast';
 import './AdminUsers.scss';
 
 interface User {
@@ -47,7 +47,7 @@ const AdminUsers = () => {
       setUsers(data.items as User[]);
       setTotal(data.total);
     } catch {
-      toast('Failed to load users', 'error');
+      showToast('Failed to load users', 'error');
     } finally {
       setLoading(false);
     }
@@ -70,7 +70,7 @@ const AdminUsers = () => {
       await updateUserRole(id, newRole);
     } catch {
       setUsers(prev);
-      toast('Failed to update role', 'error');
+      showToast('Failed to update role', 'error');
     }
   };
 
@@ -86,7 +86,7 @@ const AdminUsers = () => {
       await updateUserStatus(user._id, !user.isActive);
     } catch {
       setUsers(prev);
-      toast('Failed to update status', 'error');
+      showToast('Failed to update status', 'error');
     }
   };
 
@@ -98,7 +98,7 @@ const AdminUsers = () => {
       await apiDeleteUser(id);
     } catch {
       setUsers(prev);
-      toast('Failed to delete user', 'error');
+      showToast('Failed to delete user', 'error');
     }
   };
 

--- a/client/src/pages/BusinessRequests/BusinessRequests.tsx
+++ b/client/src/pages/BusinessRequests/BusinessRequests.tsx
@@ -6,7 +6,7 @@ import {
   rejectShop,
   type BusinessRequestParams,
 } from '../../api/admin';
-import toast from '../../components/toast';
+import showToast from '../../components/ui/Toast';
 import './BusinessRequests.scss';
 
 interface ShopRequest {
@@ -76,12 +76,12 @@ const BusinessRequests = () => {
     try {
       if (newStatus === 'approved') await approveShop(id);
       else await rejectShop(id);
-      toast(
+      showToast(
         `Request ${newStatus === 'approved' ? 'approved' : 'rejected'}`,
       );
     } catch {
       setRequests(prev);
-      toast('Failed to update request', 'error');
+      showToast('Failed to update request', 'error');
     } finally {
       setActionId('');
     }

--- a/client/src/pages/ManageProducts/ManageProducts.tsx
+++ b/client/src/pages/ManageProducts/ManageProducts.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../store/slices/productSlice';
 import Loader from '../../components/Loader';
 import ProductCard from '../../components/ui/ProductCard';
-import toast from '../../components/toast';
+import showToast from '../../components/ui/Toast';
 import styles from './ManageProducts.module.scss';
 
 const emptyForm: Partial<Product> = {
@@ -50,15 +50,15 @@ const ManageProducts = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!form.name || !form.price || form.price <= 0) {
-      toast('Please provide a name and valid price', 'error');
+      showToast('Please provide a name and valid price', 'error');
       return;
     }
     if (!form.mrp || form.mrp <= 0) {
-      toast('Please provide a valid MRP', 'error');
+      showToast('Please provide a valid MRP', 'error');
       return;
     }
     if (form.price > form.mrp) {
-      toast('Price cannot exceed MRP', 'error');
+      showToast('Price cannot exceed MRP', 'error');
       return;
     }
     try {
@@ -69,17 +69,17 @@ const ManageProducts = () => {
       };
       if (editId) {
         await dispatch(updateProduct({ id: editId, data: payload })).unwrap();
-        toast('Product updated');
+        showToast('Product updated');
       } else {
         await dispatch(createProduct(payload)).unwrap();
-        toast('Product added');
+        showToast('Product added');
       }
       setShowModal(false);
       setForm(emptyForm);
       dispatch(fetchMyProducts());
       window.dispatchEvent(new Event('productsUpdated'));
     } catch {
-      toast('Failed to save product', 'error');
+      showToast('Failed to save product', 'error');
     } finally {
       setSubmitting(false);
     }
@@ -89,11 +89,11 @@ const ManageProducts = () => {
     if (!confirm('Delete product?')) return;
     try {
       await dispatch(deleteProduct(id)).unwrap();
-      toast('Product deleted');
+      showToast('Product deleted');
       dispatch(fetchMyProducts());
       window.dispatchEvent(new Event('productsUpdated'));
     } catch {
-      toast('Failed to delete product', 'error');
+      showToast('Failed to delete product', 'error');
     }
   };
 

--- a/client/src/pages/OrderNow/OrderNow.tsx
+++ b/client/src/pages/OrderNow/OrderNow.tsx
@@ -7,6 +7,7 @@ import { sampleShops } from '../../data/sampleData';
 import type { RootState } from '../../store';
 import ModalSheet from '../../components/base/ModalSheet';
 import Loader from '../../components/Loader';
+import showToast from '../../components/ui/Toast';
 import styles from './OrderNow.module.scss';
 
 interface Product {
@@ -131,13 +132,13 @@ const OrderNow = () => {
           })
         )
       );
-      alert('Order placed');
+      showToast('Order placed');
       setMatched([]);
       setTranscript('');
       setManual('');
       setConfirmOpen(false);
     } catch {
-      alert('Failed to place order');
+      showToast('Failed to place order', 'error');
     } finally {
       setPlacing(false);
     }

--- a/client/src/pages/ReceivedOrders/ReceivedOrders.tsx
+++ b/client/src/pages/ReceivedOrders/ReceivedOrders.tsx
@@ -5,7 +5,7 @@ import Shimmer from '../../components/Shimmer';
 import { OrderCard } from '../../components/base';
 import fallbackImage from '../../assets/no-image.svg';
 import { type Status } from '../../components/ui/StatusChip';
-import toast from '../../components/toast';
+import showToast from '../../components/ui/Toast';
 import styles from './ReceivedOrders.module.scss';
 
 interface Order {
@@ -59,12 +59,12 @@ const ReceivedOrders = () => {
       setList((curr) =>
         curr.map((o) => (o._id === id ? { ...o, ...res.data } : o))
       );
-      toast(
+      showToast(
         action === 'accept' ? 'Order accepted' : 'Order rejected',
         'success'
       );
     } catch {
-      toast(`Failed to ${action} order`, 'error');
+      showToast(`Failed to ${action} order`, 'error');
       setList(prev);
     }
   };

--- a/client/src/pages/UiPreview.tsx
+++ b/client/src/pages/UiPreview.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Toolbar from '../components/ui/Toolbar';
 import SectionHeader from '../components/ui/SectionHeader';
 import StatusChip from '../components/ui/StatusChip';
+import showToast from '../components/ui/Toast';
 import {
   ProductCard,
   OrderCard,
@@ -54,7 +55,7 @@ const UiPreview = () => {
         <ProductCard
           product={product}
           ctaLabel="Add to Cart"
-          onCtaClick={() => alert('Added to cart')}
+          onCtaClick={() => showToast('Added to cart')}
         />
         <OrderCard {...order} />
         <FacetFilterBar

--- a/client/src/pages/VerificationRequests/VerificationRequests.tsx
+++ b/client/src/pages/VerificationRequests/VerificationRequests.tsx
@@ -5,7 +5,7 @@ import {
   acceptVerification,
   rejectVerification,
 } from '../../api/admin';
-import toast from '../../components/toast';
+import showToast from '../../components/ui/Toast';
 import './VerificationRequests.scss';
 
 interface Request {
@@ -95,12 +95,12 @@ const VerificationRequests = () => {
     try {
       if (newStatus === 'approved') await acceptVerification(id);
       else await rejectVerification(id);
-      toast(
+      showToast(
         `Request ${newStatus === 'approved' ? 'approved' : 'rejected'}`,
       );
     } catch {
       setRequests(prev);
-      toast('Failed to update request', 'error');
+      showToast('Failed to update request', 'error');
     } finally {
       setActionId('');
     }

--- a/client/src/pages/VoiceOrder/VoiceOrder.tsx
+++ b/client/src/pages/VoiceOrder/VoiceOrder.tsx
@@ -7,6 +7,7 @@ import { sampleShops } from '../../data/sampleData';
 import type { RootState } from '../../store';
 import styles from './VoiceOrder.module.scss';
 import Loader from '../../components/Loader';
+import showToast from '../../components/ui/Toast';
 
 interface Product {
   _id: string;
@@ -54,7 +55,7 @@ const VoiceOrder = () => {
     const SpeechRecognition =
       (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
     if (!SpeechRecognition) {
-      alert('Speech recognition not supported');
+      showToast('Speech recognition not supported', 'error');
       return;
     }
     const recognition = new SpeechRecognition();
@@ -103,9 +104,9 @@ const VoiceOrder = () => {
         shopId: item.shop._id,
         source: 'voice-order',
       });
-      alert('Order placed');
+      showToast('Order placed');
     } catch {
-      alert('Failed to place order');
+      showToast('Failed to place order', 'error');
     } finally {
       setOrderingId('');
     }

--- a/client/src/styles/_controls.scss
+++ b/client/src/styles/_controls.scss
@@ -17,7 +17,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid var(--blue-500);
+    outline: 2px solid var(--color-focus-ring);
     outline-offset: 2px;
   }
 
@@ -81,9 +81,9 @@ textarea,
   padding: var(--space-2) var(--space-3);
   transition: border-color 0.2s, box-shadow 0.2s;
 
-  &:focus {
+  &:focus-visible {
     outline: none;
-    border-color: var(--blue-500);
+    border-color: var(--color-focus-ring);
     box-shadow: 0 0 0 2px var(--blue-100);
   }
 
@@ -108,6 +108,10 @@ a,
   &:visited {
     color: var(--blue-800);
   }
+
+  &:focus-visible {
+    outline-offset: 2px;
+  }
 }
 
 /* Chips */
@@ -122,6 +126,11 @@ a,
   color: var(--gray-700);
   cursor: pointer;
   border: 1px solid transparent;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+  }
 }
 
 .chip--selected {
@@ -145,6 +154,11 @@ a,
   color: var(--gray-600);
   border-bottom: 2px solid transparent;
   transition: color 0.2s, border-color 0.2s;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+  }
 }
 
 .tab:hover {

--- a/client/src/styles/_theme.scss
+++ b/client/src/styles/_theme.scss
@@ -72,7 +72,7 @@
   --color-primary-hover: var(--blue-700);
   --color-primary-contrast: var(--white);
   --color-on-primary: var(--color-primary-contrast);
-  --color-border: var(--blue-100);
+  --color-border: var(--blue-200);
   --color-focus-ring: var(--blue-500);
   --color-success: #16A34A;
   --color-warning: #D97706;
@@ -118,7 +118,7 @@
   --color-primary-hover: var(--blue-700);
   --color-primary-contrast: var(--white);
   --color-on-primary: var(--color-primary-contrast);
-  --color-border: var(--blue-100);
+  --color-border: var(--blue-200);
   --color-focus-ring: var(--blue-500);
   --color-success: #16A34A;
   --color-warning: #D97706;

--- a/client/src/styles/main.scss
+++ b/client/src/styles/main.scss
@@ -77,6 +77,7 @@ button {
 :focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
+  outline-color: var(--color-focus-ring);
 }
 
 /* Utility classes */


### PR DESCRIPTION
## Summary
- tune blue-and-white theme tokens and focus ring
- standardize button, input, link, chip, and tab focus styles
- add Toast helper and replace browser alerts with toasts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a07f00b7408332af67756a278ee47f