### PR TITLE
Replace gradient backgrounds with white

### DIFF
--- a/client/src/layouts/TabLayout.scss
+++ b/client/src/layouts/TabLayout.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
+  background: #fff;
 
   .top-header {
     display: flex;

--- a/client/src/pages/Landing/Landing.scss
+++ b/client/src/pages/Landing/Landing.scss
@@ -9,7 +9,7 @@
   align-items: center;
   text-align: center;
   padding: 2rem;
-  background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
+  background: #fff;
 
   .logo {
     margin-bottom: 1.5rem;

--- a/client/src/pages/Profile/Profile.module.scss
+++ b/client/src/pages/Profile/Profile.module.scss
@@ -9,7 +9,7 @@
   min-height: 100vh;
 
   &.colorful {
-    background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
+    background: #fff;
   }
 
   &.light {

--- a/client/src/pages/auth/Login/Login.scss
+++ b/client/src/pages/auth/Login/Login.scss
@@ -8,7 +8,7 @@
   align-items: center;
   padding: 2rem;
   min-height: 100vh;
-  background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
+  background: #fff;
 
   .info-panel {
     display: none;


### PR DESCRIPTION
## Summary
- Remove primary color gradient backgrounds
- Use plain white backgrounds for TabLayout, Landing, Login, and Profile components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a08118416c8332877ff96de43446e3