### PR TITLE
feat: enhance shop listing with filters and sorting

### DIFF
--- a/client/src/components/ui/FacetFilterBar/FacetFilterBar.module.scss
+++ b/client/src/components/ui/FacetFilterBar/FacetFilterBar.module.scss
@@ -1,0 +1,58 @@
+.bar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--color-card);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.controls {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+
+  input,
+  select {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    flex: 1;
+    min-width: 140px;
+  }
+}
+
+.chips {
+  display: flex;
+  overflow-x: auto;
+  gap: 0.5rem;
+  align-items: center;
+
+  button {
+    flex-shrink: 0;
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    border-radius: 999px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.2s ease;
+
+    &.active {
+      background: $primary-color;
+      color: var(--color-on-primary);
+      border-color: $primary-color;
+    }
+  }
+
+  .openNow {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    margin-left: auto;
+  }
+}

--- a/client/src/components/ui/FacetFilterBar/FacetFilterBar.tsx
+++ b/client/src/components/ui/FacetFilterBar/FacetFilterBar.tsx
@@ -1,0 +1,85 @@
+import styles from './FacetFilterBar.module.scss';
+
+interface Props {
+  search: string;
+  onSearch: (v: string) => void;
+  location: string;
+  locations: string[];
+  onLocationChange: (v: string) => void;
+  category: string;
+  categories: string[];
+  onCategoryChange: (v: string) => void;
+  openOnly: boolean;
+  onOpenChange: (v: boolean) => void;
+  sort: string;
+  onSortChange: (v: string) => void;
+}
+
+const FacetFilterBar = ({
+  search,
+  onSearch,
+  location,
+  locations,
+  onLocationChange,
+  category,
+  categories,
+  onCategoryChange,
+  openOnly,
+  onOpenChange,
+  sort,
+  onSortChange,
+}: Props) => {
+  return (
+    <div className={styles.bar}>
+      <div className={styles.controls}>
+        <input
+          type="text"
+          placeholder="Search shops..."
+          value={search}
+          onChange={(e) => onSearch(e.target.value)}
+        />
+        <select value={location} onChange={(e) => onLocationChange(e.target.value)}>
+          <option value="">All locations</option>
+          {locations.map((loc) => (
+            <option key={loc} value={loc}>
+              {loc}
+            </option>
+          ))}
+        </select>
+        <select value={sort} onChange={(e) => onSortChange(e.target.value)}>
+          <option value="rating">Rating</option>
+          <option value="distance">Distance</option>
+          <option value="productCount">Product count</option>
+        </select>
+      </div>
+      <div className={styles.chips}>
+        <button
+          className={!category ? styles.active : ''}
+          onClick={() => onCategoryChange('')}
+        >
+          All
+        </button>
+        {categories.map((c) => (
+          <button
+            key={c}
+            className={category === c ? styles.active : ''}
+            onClick={() => onCategoryChange(c)}
+          >
+            {c}
+          </button>
+        ))}
+        <label className={styles.openNow}>
+          <input
+            type="checkbox"
+            checked={openOnly}
+            onChange={(e) => onOpenChange(e.target.checked)}
+          />
+          Open now
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default FacetFilterBar;
+

--- a/client/src/components/ui/ShopCard/ShopCard.module.scss
+++ b/client/src/components/ui/ShopCard/ShopCard.module.scss
@@ -1,0 +1,59 @@
+.card {
+  background: var(--color-card);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+
+  img {
+    width: 100%;
+    height: 160px;
+    object-fit: cover;
+  }
+
+  .info {
+    padding: 0.75rem;
+
+    h3 {
+      margin: 0 0 0.25rem;
+      font-size: 1.1rem;
+    }
+
+    .category {
+      margin: 0;
+      color: var(--color-muted);
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+      font-size: 0.85rem;
+      align-items: center;
+    }
+
+    .rating {
+      color: $primary-color;
+    }
+
+    .distance {
+      color: var(--color-muted);
+    }
+
+    .status {
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      &.open {
+        background: var(--color-success);
+        color: var(--color-on-primary);
+      }
+      &.closed {
+        background: var(--color-danger);
+        color: var(--color-on-primary);
+      }
+    }
+  }
+}

--- a/client/src/components/ui/ShopCard/ShopCard.tsx
+++ b/client/src/components/ui/ShopCard/ShopCard.tsx
@@ -1,0 +1,49 @@
+import { motion } from 'framer-motion';
+import styles from './ShopCard.module.scss';
+import fallbackImage from '../../../assets/no-image.svg';
+
+export interface ShopCardProps {
+  shop: {
+    _id: string;
+    name: string;
+    category: string;
+    image?: string;
+    logo?: string;
+    rating?: number;
+    distance?: number;
+    isOpen?: boolean;
+  };
+  onClick?: () => void;
+}
+
+const ShopCard = ({ shop, onClick }: ShopCardProps) => (
+  <motion.div whileHover={{ scale: 1.02 }} className={styles.card} onClick={onClick}>
+    <img
+      src={shop.logo || shop.image || fallbackImage}
+      alt={shop.name}
+      onError={(e) => (e.currentTarget.src = fallbackImage)}
+    />
+    <div className={styles.info}>
+      <h3>{shop.name}</h3>
+      <p className={styles.category}>{shop.category}</p>
+      <div className={styles.meta}>
+        {shop.rating !== undefined && (
+          <span className={styles.rating}>★ {shop.rating.toFixed(1)}</span>
+        )}
+        {shop.distance !== undefined && (
+          <span className={styles.distance}>{shop.distance} km</span>
+        )}
+        {shop.isOpen !== undefined && (
+          <span
+            className={`${styles.status} ${shop.isOpen ? styles.open : styles.closed}`}
+          >
+            {shop.isOpen ? 'Open' : 'Closed'}
+          </span>
+        )}
+      </div>
+    </div>
+  </motion.div>
+);
+
+export default ShopCard;
+

--- a/client/src/pages/Shops/Shops.module.scss
+++ b/client/src/pages/Shops/Shops.module.scss
@@ -5,60 +5,6 @@
   padding: 1rem;
   @include respond(md) { padding: 2rem; }
 
-  .searchBar {
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    background: var(--color-card);
-    padding-bottom: 0.75rem;
-    margin-bottom: 0.75rem;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .searchBar input,
-  .searchBar select {
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    flex: 1;
-    min-width: 140px;
-  }
-
-  .toggle {
-    display: flex;
-    align-items: center;
-    gap: 0.3rem;
-    font-size: 0.9rem;
-  }
-
-  .categoryRow {
-    display: flex;
-    overflow-x: auto;
-    gap: 0.5rem;
-    padding-bottom: 0.75rem;
-    margin-bottom: 1rem;
-
-    button {
-      flex-shrink: 0;
-      padding: 0.4rem 0.9rem;
-      border: 1px solid var(--color-border);
-      background: var(--color-bg);
-      border-radius: 999px;
-      cursor: pointer;
-      white-space: nowrap;
-      transition: background 0.2s ease;
-
-      &.active {
-        background: $primary-color;
-        color: var(--color-on-primary);
-        border-color: $primary-color;
-      }
-    }
-  }
-
   .list {
     display: grid;
     gap: 1rem;


### PR DESCRIPTION
## Summary
- add reusable ShopCard component with rating, distance and open state
- create sticky FacetFilterBar supporting search, location, category and sort options
- sync shop list filters and sorting with URL parameters for persistence

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1b451fe0c833299521c7347fe7e36