### PR TITLE
fix ProductCard import paths

### DIFF
--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../../api/client';
 import Shimmer from '../../components/Shimmer';
-import ProductCard from '../../components/ui/ProductCard';
+import ProductCard from '../../components/ui/ProductCard.tsx';
 import SectionHeader from '../../components/ui/SectionHeader';
 import HorizontalCarousel from '../../components/ui/HorizontalCarousel';
 import SkeletonProductCard from '../../components/ui/Skeletons/SkeletonProductCard';

--- a/client/src/pages/ManageProducts/ManageProducts.tsx
+++ b/client/src/pages/ManageProducts/ManageProducts.tsx
@@ -9,7 +9,7 @@ import {
   type Product,
 } from '../../store/slices/productSlice';
 import Loader from '../../components/Loader';
-import ProductCard from '../../components/ui/ProductCard';
+import ProductCard from '../../components/ui/ProductCard.tsx';
 import showToast from '../../components/ui/Toast';
 import styles from './ManageProducts.module.scss';
 

--- a/client/src/pages/ProductDetails/ProductDetails.tsx
+++ b/client/src/pages/ProductDetails/ProductDetails.tsx
@@ -9,7 +9,7 @@ import { addToCart } from "../../store/slices/cartSlice";
 import fallbackImage from "../../assets/no-image.svg";
 import PriceBlock from "../../components/ui/PriceBlock";
 import HorizontalCarousel from "../../components/ui/HorizontalCarousel";
-import ProductCard from "../../components/ui/ProductCard";
+import ProductCard from "../../components/ui/ProductCard.tsx";
 import SectionHeader from "../../components/ui/SectionHeader";
 import { QuantityStepper } from "../../components/base";
 

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { ProfileHeader, Tabs, OrderCard } from '../../components/base';
-import ProductCard from '../../components/ui/ProductCard';
+import ProductCard from '../../components/ui/ProductCard.tsx';
 import type { RootState } from '../../store';
 import { sampleShops } from '../../data/sampleData';
 import { setUser } from '../../store/slices/userSlice';

--- a/client/src/pages/ShopDetails/ShopDetails.tsx
+++ b/client/src/pages/ShopDetails/ShopDetails.tsx
@@ -5,7 +5,7 @@ import { FiPhone } from 'react-icons/fi';
 import api from '../../api/client';
 import { sampleShops } from '../../data/sampleData';
 import Shimmer from '../../components/Shimmer';
-import ProductCard, { type Product } from '../../components/ui/ProductCard';
+import ProductCard, { type Product } from '../../components/ui/ProductCard.tsx';
 import SkeletonProductCard from '../../components/ui/Skeletons/SkeletonProductCard';
 import EmptyState from '../../components/ui/EmptyState';
 import './ShopDetails.scss';

--- a/client/src/pages/SpecialShop/SpecialShop.tsx
+++ b/client/src/pages/SpecialShop/SpecialShop.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import api from '../../api/client';
 import { sampleSpecialProducts } from '../../data/sampleHomeData';
 import { FacetFilterBar } from '../../components/base';
-import ProductCard from '../../components/ui/ProductCard';
+import ProductCard from '../../components/ui/ProductCard.tsx';
 import SkeletonProductCard from '../../components/ui/Skeletons/SkeletonProductCard';
 import EmptyState from '../../components/ui/EmptyState';
 import styles from './SpecialShop.module.scss';


### PR DESCRIPTION
## Summary
- add explicit .tsx extension for ProductCard imports to resolve dev server lookup

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1bb6de40c8332a60ddf6d656751ce