### PR TITLE
feat: add shop ordering modal and mobile toolbar

### DIFF
--- a/client/src/components/ui/OrderModal/OrderModal.module.scss
+++ b/client/src/components/ui/OrderModal/OrderModal.module.scss
@@ -1,0 +1,50 @@
+.modal {
+  padding: 1rem;
+
+  .product {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    img {
+      width: 64px;
+      height: 64px;
+      object-fit: cover;
+      border-radius: 8px;
+    }
+
+    .info {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+  }
+
+  .stepper {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    button {
+      width: 32px;
+      height: 32px;
+      border: 1px solid #ccc;
+      background: #fff;
+      border-radius: 8px;
+    }
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+
+    button {
+      padding: 0.5rem 1rem;
+      background: var(--color-primary, #1a1a1a);
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+    }
+  }
+}

--- a/client/src/components/ui/OrderModal/OrderModal.tsx
+++ b/client/src/components/ui/OrderModal/OrderModal.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../../../store';
+import api from '../../../api/client';
+import ModalSheet from '../../base/ModalSheet';
+import type { Product } from '../ProductCard';
+import showToast from '../Toast';
+import fallbackImage from '../../../assets/no-image.svg';
+import styles from './OrderModal.module.scss';
+
+interface OrderModalProps {
+  open: boolean;
+  onClose: () => void;
+  product: Product | null;
+  shopId: string;
+}
+
+const OrderModal = ({ open, onClose, product, shopId }: OrderModalProps) => {
+  const user = useSelector((state: RootState) => state.user as any);
+  const [quantity, setQuantity] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (open) setQuantity(1);
+  }, [open]);
+
+  const increment = () => setQuantity((q) => q + 1);
+  const decrement = () => setQuantity((q) => Math.max(1, q - 1));
+
+  const placeOrder = async () => {
+    if (!product) return;
+    try {
+      setLoading(true);
+      await api.post('/orders/place', {
+        userId: user?._id,
+        productId: product._id,
+        quantity,
+        shopId,
+        source: 'shop-details',
+      });
+      showToast('Order placed', 'success');
+      onClose();
+    } catch {
+      showToast('Failed to place order', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ModalSheet open={open} onClose={onClose}>
+      {product && (
+        <div className={styles.modal}>
+          <div className={styles.product}>
+            <img
+              src={product.image || fallbackImage}
+              alt={product.name}
+              onError={(e) => (e.currentTarget.src = fallbackImage)}
+            />
+            <div className={styles.info}>
+              <h4>{product.name}</h4>
+              <p>₹{product.price}</p>
+            </div>
+          </div>
+          <div className={styles.stepper}>
+            <button onClick={decrement} aria-label="Decrease quantity">-</button>
+            <span>{quantity}</span>
+            <button onClick={increment} aria-label="Increase quantity">+</button>
+          </div>
+          <div className={styles.actions}>
+            <button onClick={placeOrder} disabled={loading}>
+              {loading ? 'Placing...' : 'Confirm Order'}
+            </button>
+          </div>
+        </div>
+      )}
+    </ModalSheet>
+  );
+};
+
+export default OrderModal;
+

--- a/client/src/pages/ShopDetails/ShopDetails.scss
+++ b/client/src/pages/ShopDetails/ShopDetails.scss
@@ -2,8 +2,38 @@
   display: flex;
   flex-direction: column;
 
+  .mini-toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(4px);
+
+    @media (min-width: 768px) {
+      display: none;
+    }
+
+    button,
+    a {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      border: none;
+      border-radius: 50%;
+      background: #fff;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      color: #333;
+    }
+  }
+
   .hero {
     width: 100%;
+    position: relative;
 
     .cover {
       width: 100%;
@@ -12,25 +42,20 @@
       border-radius: 12px;
     }
 
-    .content {
+    .overlay {
+      position: absolute;
+      inset: 0;
       display: flex;
-      align-items: center;
-      gap: 1rem;
-      margin-top: -40px;
-      padding: 0 1rem 1rem;
-    }
-
-    .logo {
-      width: 80px;
-      height: 80px;
-      border-radius: 50%;
-      object-fit: cover;
-      border: 4px solid #fff;
-      background: #fff;
-    }
-
-    .info {
-      flex: 1;
+      flex-direction: column;
+      justify-content: flex-end;
+      padding: 1rem;
+      color: #fff;
+      background: linear-gradient(
+        180deg,
+        rgba(0, 0, 0, 0.2),
+        rgba(0, 0, 0, 0.7)
+      );
+      border-radius: 12px;
 
       h2 {
         margin: 0;
@@ -44,27 +69,27 @@
         margin-top: 0.25rem;
       }
 
-      .area {
+      .address {
         margin-top: 0.25rem;
-        color: #555;
       }
-    }
 
-    .call {
-      display: flex;
-      align-items: center;
-      gap: 0.25rem;
-      background: var(--color-primary, #1a1a1a);
-      color: #fff;
-      padding: 0.5rem 0.75rem;
-      border-radius: 8px;
-      text-decoration: none;
+      .status {
+        margin-top: 0.5rem;
+
+        &.open {
+          color: var(--color-success, #28a745);
+        }
+
+        &.closed {
+          color: var(--color-danger, #dc3545);
+        }
+      }
     }
   }
 
   .filters {
     position: sticky;
-    top: 0;
+    top: 56px;
     z-index: 5;
     display: flex;
     gap: 1rem;


### PR DESCRIPTION
## Summary
- add mobile toolbar with back, call, and share actions
- overlay shop details on cover image with open status
- enable ordering via modal with quantity stepper and toasts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f50ce9388332b67b354c23197681