### PR TITLE
Revamp cart with sticky summary and empty state

### DIFF
--- a/client/src/components/ui/EmptyState.module.scss
+++ b/client/src/components/ui/EmptyState.module.scss
@@ -1,5 +1,23 @@
 .empty {
   text-align: center;
-  padding: var(--spacing-lg) 0;
+  padding: var(--space-6) 0;
   color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.image {
+  width: 160px;
+  height: auto;
+}
+
+.cta {
+  padding: var(--space-3) var(--space-5);
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
 }

--- a/client/src/components/ui/EmptyState.tsx
+++ b/client/src/components/ui/EmptyState.tsx
@@ -2,11 +2,20 @@ import styles from './EmptyState.module.scss';
 
 interface EmptyStateProps {
   message: string;
+  image?: string;
+  ctaLabel?: string;
+  onCtaClick?: () => void;
 }
 
-const EmptyState = ({ message }: EmptyStateProps) => (
+const EmptyState = ({ message, image, ctaLabel, onCtaClick }: EmptyStateProps) => (
   <div className={styles.empty}>
+    {image && <img src={image} alt="" className={styles.image} />}
     <p>{message}</p>
+    {ctaLabel && onCtaClick && (
+      <button type="button" className={styles.cta} onClick={onCtaClick}>
+        {ctaLabel}
+      </button>
+    )}
   </div>
 );
 

--- a/client/src/components/ui/QuantityStepper/QuantityStepper.module.scss
+++ b/client/src/components/ui/QuantityStepper/QuantityStepper.module.scss
@@ -1,0 +1,32 @@
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.button {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+  }
+}
+
+.value {
+  min-width: 24px;
+  text-align: center;
+}

--- a/client/src/components/ui/QuantityStepper/QuantityStepper.tsx
+++ b/client/src/components/ui/QuantityStepper/QuantityStepper.tsx
@@ -1,0 +1,43 @@
+import { motion } from 'framer-motion';
+import styles from './QuantityStepper.module.scss';
+
+export interface QuantityStepperProps {
+  value: number;
+  min?: number;
+  max?: number;
+  onChange: (v: number) => void;
+}
+
+const QuantityStepper = ({ value, min = 1, max = 99, onChange }: QuantityStepperProps) => {
+  const dec = () => value > min && onChange(value - 1);
+  const inc = () => value < max && onChange(value + 1);
+
+  return (
+    <div className={styles.stepper}>
+      <motion.button
+        type="button"
+        className={styles.button}
+        whileTap={{ scale: 0.95 }}
+        onClick={dec}
+        disabled={value <= min}
+        aria-label="Decrease quantity"
+      >
+        -
+      </motion.button>
+      <span className={styles.value}>{value}</span>
+      <motion.button
+        type="button"
+        className={styles.button}
+        whileTap={{ scale: 0.95 }}
+        onClick={inc}
+        disabled={value >= max}
+        aria-label="Increase quantity"
+      >
+        +
+      </motion.button>
+    </div>
+  );
+};
+
+export default QuantityStepper;
+

--- a/client/src/pages/Cart/Cart.module.scss
+++ b/client/src/pages/Cart/Cart.module.scss
@@ -2,33 +2,96 @@
 @import "../../styles/variables";
 
 .cart {
-  padding: 1rem;
-  @include respond(md) { padding: 2rem; }
+  padding: var(--space-4);
 
-  h2 {
-    margin-bottom: 1rem;
-    font-size: 1.5rem;
+  @include respond(md) {
+    padding: var(--space-5);
   }
+}
 
-  .empty {
-    text-align: center;
-    color: var(--color-muted);
-    margin-top: 2rem;
-  }
+.content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-5);
 
-  .content {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1rem;
-    @include respond(md) {
-      grid-template-columns: 2fr 1fr;
-      align-items: flex-start;
-    }
+  @include respond(md) {
+    grid-template-columns: 2fr 1fr;
+    align-items: flex-start;
   }
+}
 
-  .list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.item {
+  display: flex;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+
+  img {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
   }
+}
+
+.details {
+  flex: 1;
+}
+
+.title {
+  margin: 0 0 var(--space-2);
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.remove {
+  background: none;
+  border: none;
+  color: var(--color-danger);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+
+.summary {
+  position: sticky;
+  top: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.total {
+  font-weight: 600;
+}
+
+.checkout {
+  width: 100%;
+  padding: var(--space-3);
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- add flexible EmptyState with illustration and CTA
- add reusable QuantityStepper UI component
- redesign cart page with item controls and sticky totals summary

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f82f7708833284166fb34e8eaa37