### PR TITLE
feat: add order pages and card

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,8 +22,9 @@ import Events from './pages/Events/Events';
 import VoiceOrder from './pages/VoiceOrder/VoiceOrder';
 import OrderNow from './pages/OrderNow/OrderNow';
 import ManageProducts from './pages/ManageProducts/ManageProducts';
-import ReceivedOrders from './pages/ReceivedOrders/ReceivedOrders';
-import MyOrders from './pages/MyOrders/MyOrders';
+import ReceivedOrders from './pages/Orders/ReceivedOrders';
+import MyOrders from './pages/Orders/MyOrders';
+import OrderDetail from './pages/Orders/OrderDetail';
 import Notifications from './pages/Notifications/Notifications';
 import TabLayout from './layouts/TabLayout';
 import AdminLogin from './pages/AdminLogin/AdminLogin';
@@ -104,6 +105,7 @@ function App() {
           <Route path="/product/:id" element={<ProductDetails />} />
           <Route path="/events/:id" element={<EventDetails />} />
           <Route path="/verified-users/:id" element={<VerifiedUserDetails />} />
+          <Route path="/orders/:id" element={<OrderDetail />} />
           <Route path="/cart" element={<Cart />} />
         </Route>
       </Routes>

--- a/client/src/components/ui/OrderCard/OrderCard.module.scss
+++ b/client/src/components/ui/OrderCard/OrderCard.module.scss
@@ -1,0 +1,70 @@
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover,
+.card:focus-within {
+  box-shadow: var(--shadow-md);
+}
+
+.thumbs {
+  display: flex;
+  gap: var(--spacing-xs);
+
+  img {
+    width: 48px;
+    height: 48px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+  }
+}
+
+.info {
+  flex: 1;
+  text-align: left;
+
+  h4 {
+    margin: 0 0 var(--spacing-xs);
+  }
+
+  .date {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+  }
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+
+  .phone {
+    font-size: var(--font-size-sm);
+  }
+
+  button {
+    padding: 0.25rem 0.5rem;
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    background: var(--color-primary);
+    color: var(--color-on-primary);
+
+    &:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.status {
+  margin-left: var(--spacing-sm);
+}

--- a/client/src/components/ui/OrderCard/OrderCard.tsx
+++ b/client/src/components/ui/OrderCard/OrderCard.tsx
@@ -1,0 +1,88 @@
+import { Link } from 'react-router-dom';
+import PriceBlock from '../PriceBlock';
+import StatusChip, { type Status } from '../StatusChip';
+import styles from './OrderCard.module.scss';
+
+export interface OrderItem {
+  id: string;
+  title: string;
+  image: string;
+}
+
+export interface OrderCardProps {
+  items: OrderItem[];
+  shop: string;
+  date: string; // ISO string
+  status: Status;
+  total: number;
+  quantity?: number;
+  phone?: string;
+  to?: string;
+  onAccept?: () => void;
+  onReject?: () => void;
+  onCancel?: () => void;
+  onCall?: () => void;
+  className?: string;
+}
+
+const OrderCard = ({
+  items,
+  shop,
+  date,
+  status,
+  total,
+  quantity,
+  phone,
+  to,
+  onAccept,
+  onReject,
+  onCancel,
+  onCall,
+  className = '',
+}: OrderCardProps) => {
+  const content = (
+    <div className={`${styles.card} ${className}`}>
+      <div className={styles.thumbs}>
+        {items.slice(0, 3).map((item) => (
+          <img key={item.id} src={item.image} alt={item.title} />
+        ))}
+      </div>
+      <div className={styles.info}>
+        <h4>{shop}</h4>
+        <p className={styles.date}>{new Date(date).toLocaleDateString()}</p>
+        {quantity !== undefined && <p className={styles.qty}>Qty: {quantity}</p>}
+        <PriceBlock price={total} />
+      </div>
+      <StatusChip status={status} className={styles.status} />
+      {(onAccept || onReject || onCancel || onCall || phone) && (
+        <div className={styles.actions}>
+          {phone && <span className={styles.phone}>{phone}</span>}
+          {onCall && (
+            <button type="button" onClick={onCall} aria-label="Call buyer">
+              Call
+            </button>
+          )}
+          {onAccept && (
+            <button type="button" onClick={onAccept} aria-label="Accept order">
+              Accept
+            </button>
+          )}
+          {onReject && (
+            <button type="button" onClick={onReject} aria-label="Reject order">
+              Reject
+            </button>
+          )}
+          {onCancel && (
+            <button type="button" onClick={onCancel} aria-label="Cancel order">
+              Cancel
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  return to ? <Link to={to}>{content}</Link> : content;
+};
+
+export default OrderCard;

--- a/client/src/components/ui/OrderCard/index.ts
+++ b/client/src/components/ui/OrderCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from './OrderCard';
+export type { OrderCardProps, OrderItem } from './OrderCard';

--- a/client/src/pages/Orders/MyOrders.module.scss
+++ b/client/src/pages/Orders/MyOrders.module.scss
@@ -1,0 +1,78 @@
+@import "../../styles/variables";
+@import "../../styles/mixins";
+
+.myOrders {
+  padding: 1rem;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+
+  .chip {
+    padding: 0.4rem 0.8rem;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: var(--color-surface);
+    font-size: 0.85rem;
+    cursor: pointer;
+    color: var(--color-text);
+    transition: background 0.2s ease;
+
+    &:hover {
+      background: var(--color-surface-alt);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-focus-ring);
+      outline-offset: 2px;
+    }
+
+    &.active {
+      background: var(--color-primary);
+      color: var(--color-on-primary);
+      border-color: var(--color-primary);
+    }
+  }
+}
+
+.group {
+  margin-bottom: 1rem;
+}
+
+  .month {
+    position: sticky;
+    top: 0;
+    background: var(--color-bg);
+    padding: 0.25rem 0;
+    font-weight: bold;
+    z-index: 1;
+  }
+
+.empty {
+  text-align: center;
+  margin-top: 2rem;
+
+  img {
+    width: 150px;
+    margin-bottom: 1rem;
+  }
+}
+
+.card {
+  margin-bottom: 0.75rem;
+}
+
+.browse {
+  margin-top: 1rem;
+  @include button-style($primary-color, var(--color-on-primary));
+}

--- a/client/src/pages/Orders/MyOrders.tsx
+++ b/client/src/pages/Orders/MyOrders.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import api from '../../api/client';
+import Shimmer from '../../components/Shimmer';
+import OrderCard from '../../components/ui/OrderCard';
+import fallbackImage from '../../assets/no-image.svg';
+import { type Status } from '../../components/ui/StatusChip';
+import styles from './MyOrders.module.scss';
+
+interface Order {
+  _id: string;
+  product: { name: string; image?: string; price: number; shop?: { name: string } };
+  quantity: number;
+  status: Status;
+  createdAt: string;
+}
+
+const MyOrders = () => {
+  const [list, setList] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.get(`/orders/my?${searchParams.toString()}`);
+      setList(res.data);
+    } catch {
+      setList([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const updateFilter = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (value) params.set(key, value);
+    else params.delete(key);
+    setSearchParams(params);
+  };
+
+  const clearFilters = (...keys: string[]) => {
+    const params = new URLSearchParams(searchParams);
+    keys.forEach((k) => params.delete(k));
+    setSearchParams(params);
+  };
+
+  const cancel = async (id: string) => {
+    await api.post(`/orders/cancel/${id}`);
+    load();
+  };
+
+  const groups = useMemo(() => {
+    const map = new Map<string, Order[]>();
+    list.forEach((o) => {
+      const month = new Date(o.createdAt).toLocaleDateString(undefined, {
+        month: 'long',
+        year: 'numeric',
+      });
+      if (!map.has(month)) map.set(month, []);
+      map.get(month)!.push(o);
+    });
+    return Array.from(map.entries());
+  }, [list]);
+
+  const status = searchParams.get('status') ?? '';
+  const startDate = searchParams.get('startDate') ?? '';
+  const endDate = searchParams.get('endDate') ?? '';
+
+  const chips = [
+    status && { label: `Status: ${status}`, onRemove: () => clearFilters('status') },
+    (startDate || endDate) && {
+      label:
+        startDate && endDate
+          ? `Date: ${startDate} - ${endDate}`
+          : startDate
+          ? `From: ${startDate}`
+          : `Until: ${endDate}`,
+      onRemove: () => clearFilters('startDate', 'endDate'),
+    },
+  ].filter(Boolean) as { label: string; onRemove: () => void }[];
+
+  return (
+    <div className={styles.myOrders}>
+      <h2>My Orders</h2>
+      <div className={styles.filters}>
+        <select value={status} onChange={(e) => updateFilter('status', e.target.value)}>
+          <option value="">All Statuses</option>
+          <option value="pending">Pending</option>
+          <option value="accepted">Accepted</option>
+          <option value="cancelled">Cancelled</option>
+          <option value="completed">Completed</option>
+        </select>
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => updateFilter('startDate', e.target.value)}
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => updateFilter('endDate', e.target.value)}
+        />
+      </div>
+      {chips.length > 0 && (
+        <div className={styles.chips}>
+          {chips.map((c) => (
+            <button key={c.label} className={styles.chip} onClick={c.onRemove}>
+              {c.label} ✕
+            </button>
+          ))}
+        </div>
+      )}
+      {loading ? (
+        [1, 2, 3].map((n) => (
+          <Shimmer key={n} className={`${styles.card} shimmer rounded`} style={{ height: 80 }} />
+        ))
+      ) : list.length === 0 ? (
+        <div className={styles.empty}>
+          <img src={fallbackImage} alt="No orders" />
+          <p>You haven’t placed any orders yet.</p>
+          <a href="/shops" className={styles.browse}>Browse Shops</a>
+        </div>
+      ) : (
+        groups.map(([month, orders]) => (
+          <div key={month} className={styles.group}>
+            <div className={styles.month}>{month}</div>
+            {orders.map((i) => (
+              <OrderCard
+                key={i._id}
+                items={[
+                  {
+                    id: i._id,
+                    title: i.product.name,
+                    image: i.product.image || fallbackImage,
+                  },
+                ]}
+                shop={i.product.shop?.name || ''}
+                date={i.createdAt}
+                status={i.status}
+                quantity={i.quantity}
+                total={i.product.price * i.quantity}
+                onCancel={i.status === 'pending' ? () => cancel(i._id) : undefined}
+                to={`/orders/${i._id}`}
+              />
+            ))}
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default MyOrders;

--- a/client/src/pages/Orders/OrderDetail.module.scss
+++ b/client/src/pages/Orders/OrderDetail.module.scss
@@ -1,0 +1,64 @@
+@import "../../styles/variables";
+@import "../../styles/mixins";
+
+.orderDetail {
+  padding: 1rem;
+}
+
+.items {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+}
+
+.item {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+
+  img {
+    width: 64px;
+    height: 64px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+  }
+
+  .itemInfo {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.25rem;
+  }
+}
+
+.total {
+  margin: 1rem 0;
+  font-weight: bold;
+}
+
+.timeline {
+  display: flex;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+
+  li {
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+  }
+
+  .active {
+    background: var(--color-primary);
+    color: var(--color-on-primary);
+  }
+}
+
+.call {
+  display: inline-block;
+  margin-top: 1rem;
+  @include button-style($primary-color, var(--color-on-primary));
+  text-decoration: none;
+}

--- a/client/src/pages/Orders/OrderDetail.tsx
+++ b/client/src/pages/Orders/OrderDetail.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../../api/client';
+import PriceBlock from '../../components/ui/PriceBlock';
+import StatusChip, { type Status } from '../../components/ui/StatusChip';
+import styles from './OrderDetail.module.scss';
+
+interface OrderItem {
+  _id: string;
+  name: string;
+  image?: string;
+  price: number;
+  quantity: number;
+}
+
+interface Order {
+  _id: string;
+  items: OrderItem[];
+  status: Status;
+  user?: { name: string; phone?: string };
+  createdAt: string;
+}
+
+const OrderDetail = () => {
+  const { id } = useParams();
+  const [order, setOrder] = useState<Order | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await api.get(`/orders/${id}`);
+        const data = res.data;
+        const items = data.items || [
+          {
+            _id: data.product?._id || 'item',
+            name: data.product?.name || 'Item',
+            image: data.product?.image,
+            price: data.product?.price || 0,
+            quantity: data.quantity || 1,
+          },
+        ];
+        setOrder({ ...data, items });
+      } catch {
+        setOrder(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  if (loading) return <p className={styles.orderDetail}>Loading...</p>;
+  if (!order) return <p className={styles.orderDetail}>Order not found.</p>;
+
+  const total = order.items.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  );
+
+  const statuses: Status[] = ['pending', 'accepted', 'cancelled', 'completed'];
+
+  return (
+    <div className={styles.orderDetail}>
+      <h2>Order Detail</h2>
+      <ul className={styles.items}>
+        {order.items.map((item) => (
+          <li key={item._id} className={styles.item}>
+            {item.image && <img src={item.image} alt={item.name} />}
+            <div className={styles.itemInfo}>
+              <span>{item.name}</span>
+              <span>Qty: {item.quantity}</span>
+              <PriceBlock price={item.price * item.quantity} />
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div className={styles.total}>Total: <PriceBlock price={total} /></div>
+      <ul className={styles.timeline}>
+        {statuses.map((s) => (
+          <li key={s} className={s === order.status ? styles.active : ''}>
+            <StatusChip status={s} />
+          </li>
+        ))}
+      </ul>
+      {order.user?.phone && (
+        <a href={`tel:${order.user.phone}`} className={styles.call}>
+          Call {order.user.name}
+        </a>
+      )}
+    </div>
+  );
+};
+
+export default OrderDetail;

--- a/client/src/pages/Orders/ReceivedOrders.module.scss
+++ b/client/src/pages/Orders/ReceivedOrders.module.scss
@@ -1,0 +1,44 @@
+@import "../../styles/variables";
+@import "../../styles/mixins";
+
+.receivedOrders {
+  padding: 1rem;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+
+  .chip {
+    padding: 0.4rem 0.8rem;
+    border: none;
+    border-radius: 999px;
+    background: var(--color-surface);
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+}
+
+.empty {
+  text-align: center;
+  margin-top: 2rem;
+
+  img {
+    width: 150px;
+    margin-bottom: 1rem;
+  }
+}
+
+.card {
+  margin-bottom: 0.75rem;
+}
+

--- a/client/src/pages/Orders/ReceivedOrders.tsx
+++ b/client/src/pages/Orders/ReceivedOrders.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import api from '../../api/client';
+import Shimmer from '../../components/Shimmer';
+import OrderCard from '../../components/ui/OrderCard';
+import fallbackImage from '../../assets/no-image.svg';
+import { type Status } from '../../components/ui/StatusChip';
+import showToast from '../../components/ui/Toast';
+import styles from './ReceivedOrders.module.scss';
+
+interface Order {
+  _id: string;
+  user: { name: string; phone?: string };
+  product: { name: string; price: number; image?: string };
+  quantity: number;
+  status: Status;
+  createdAt: string;
+}
+
+const ReceivedOrders = () => {
+  const [list, setList] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.get(`/orders/received?${searchParams.toString()}`);
+      setList(res.data);
+    } catch {
+      setList([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const updateFilter = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (value) params.set(key, value);
+    else params.delete(key);
+    setSearchParams(params);
+  };
+
+  const clearFilters = (...keys: string[]) => {
+    const params = new URLSearchParams(searchParams);
+    keys.forEach((k) => params.delete(k));
+    setSearchParams(params);
+  };
+
+  const act = async (id: string, action: 'accept' | 'reject') => {
+    const prev = list;
+    setList((curr) =>
+      curr.map((o) =>
+        o._id === id
+          ? { ...o, status: action === 'accept' ? 'accepted' : 'cancelled' }
+          : o
+      )
+    );
+    try {
+      const res = await api.post(`/orders/${action}/${id}`);
+      setList((curr) => curr.map((o) => (o._id === id ? { ...o, ...res.data } : o)));
+      showToast(
+        action === 'accept' ? 'Order accepted' : 'Order cancelled',
+        'success'
+      );
+    } catch {
+      showToast(`Failed to ${action} order`, 'error');
+      setList(prev);
+    }
+  };
+
+  const status = searchParams.get('status') ?? '';
+  const startDate = searchParams.get('startDate') ?? '';
+  const endDate = searchParams.get('endDate') ?? '';
+
+  const chips = [
+    status && { label: `Status: ${status}`, onRemove: () => clearFilters('status') },
+    (startDate || endDate) && {
+      label:
+        startDate && endDate
+          ? `Date: ${startDate} - ${endDate}`
+          : startDate
+          ? `From: ${startDate}`
+          : `Until: ${endDate}`,
+      onRemove: () => clearFilters('startDate', 'endDate'),
+    },
+  ].filter(Boolean) as { label: string; onRemove: () => void }[];
+
+  return (
+    <div className={styles.receivedOrders}>
+      <h2>Received Orders</h2>
+      <div className={styles.filters}>
+        <select value={status} onChange={(e) => updateFilter('status', e.target.value)}>
+          <option value="">All Statuses</option>
+          <option value="pending">Pending</option>
+          <option value="accepted">Accepted</option>
+          <option value="cancelled">Cancelled</option>
+          <option value="completed">Completed</option>
+        </select>
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => updateFilter('startDate', e.target.value)}
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => updateFilter('endDate', e.target.value)}
+        />
+      </div>
+      {chips.length > 0 && (
+        <div className={styles.chips}>
+          {chips.map((c) => (
+            <button key={c.label} className={styles.chip} onClick={c.onRemove}>
+              {c.label} ✕
+            </button>
+          ))}
+        </div>
+      )}
+      {loading ? (
+        [1, 2, 3].map((n) => (
+          <Shimmer key={n} className={`${styles.card} shimmer rounded`} style={{ height: 80 }} />
+        ))
+      ) : list.length === 0 ? (
+        <div className={styles.empty}>
+          <img src={fallbackImage} alt="No orders" />
+          <p>You haven't received any orders yet.</p>
+        </div>
+      ) : (
+        list.map((i) => (
+          <OrderCard
+            key={i._id}
+            items={[
+              {
+                id: i._id,
+                title: i.product.name,
+                image: i.product.image || fallbackImage,
+              },
+            ]}
+            shop={i.user.name}
+            date={i.createdAt}
+            status={i.status}
+            quantity={i.quantity}
+            total={i.product.price * i.quantity}
+            onAccept={i.status === 'pending' ? () => act(i._id, 'accept') : undefined}
+            onReject={i.status === 'pending' ? () => act(i._id, 'reject') : undefined}
+            phone={i.user.phone}
+            onCall={
+              i.status === 'accepted' && i.user.phone
+                ? () => (window.location.href = `tel:${i.user.phone}`)
+                : undefined
+            }
+            to={`/orders/${i._id}`}
+          />
+        ))
+      )}
+    </div>
+  );
+};
+
+export default ReceivedOrders;


### PR DESCRIPTION
## Summary
- add reusable OrderCard component with status chip and actions
- implement MyOrders, ReceivedOrders with URL-persisted filters
- create OrderDetail page with timeline and contact option

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68a1fabf2d6083328a69037a2bb4d80d