### PR TITLE
feat: enhance profile management

### DIFF
--- a/client/src/components/ui/ProfileHeader/ProfileHeader.module.scss
+++ b/client/src/components/ui/ProfileHeader/ProfileHeader.module.scss
@@ -1,0 +1,81 @@
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-sm);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.info {
+  flex: 1;
+  text-align: left;
+}
+
+.nameRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.role {
+  background: var(--blue-100);
+  color: var(--blue-700);
+  padding: 0 var(--spacing-xs);
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  text-transform: capitalize;
+}
+
+.location {
+  margin-top: var(--spacing-xs);
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.stats {
+  display: flex;
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-sm);
+}
+
+.actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}
+
+.actions button {
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+}
+
+.actions button + button {
+  background: var(--blue-100);
+  color: var(--blue-700);
+  border-color: var(--blue-100);
+}
+
+.nameRow h3 {
+  color: var(--gray-900);
+  margin: 0;
+}
+

--- a/client/src/components/ui/ProfileHeader/ProfileHeader.tsx
+++ b/client/src/components/ui/ProfileHeader/ProfileHeader.tsx
@@ -1,0 +1,56 @@
+import { motion } from 'framer-motion';
+import styles from './ProfileHeader.module.scss';
+
+export interface ProfileHeaderProps {
+  avatar: string;
+  name: string;
+  role: string;
+  location?: string;
+  stats?: Array<{ label: string; value: number }>;
+  actions?: Array<{ label: string; onClick: () => void }>;
+}
+
+const ProfileHeader = ({
+  avatar,
+  name,
+  role,
+  location,
+  stats = [],
+  actions = [],
+}: ProfileHeaderProps) => (
+  <motion.div
+    className={styles.header}
+    initial={{ opacity: 0, y: 20 }}
+    animate={{ opacity: 1, y: 0 }}
+  >
+    <img src={avatar} alt={name} className={styles.avatar} />
+    <div className={styles.info}>
+      <div className={styles.nameRow}>
+        <h3>{name}</h3>
+        <span className={styles.role}>{role}</span>
+      </div>
+      {location && <p className={styles.location}>{location}</p>}
+      {stats.length > 0 && (
+        <div className={styles.stats}>
+          {stats.map((s) => (
+            <span key={s.label}>
+              <strong>{s.value}</strong> {s.label}
+            </span>
+          ))}
+        </div>
+      )}
+      {actions.length > 0 && (
+        <div className={styles.actions}>
+          {actions.map(({ label, onClick }) => (
+            <button key={label} type="button" onClick={onClick}>
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  </motion.div>
+);
+
+export default ProfileHeader;
+

--- a/client/src/components/ui/ProfileHeader/index.ts
+++ b/client/src/components/ui/ProfileHeader/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ProfileHeader';
+export type { ProfileHeaderProps } from './ProfileHeader';

--- a/client/src/pages/Profile/Profile.module.scss
+++ b/client/src/pages/Profile/Profile.module.scss
@@ -264,3 +264,100 @@
     }
   }
 }
+
+.tabs {
+  width: 100%;
+  max-width: 720px;
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  position: relative;
+}
+
+.tabButton {
+  background: transparent;
+  border: none;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  position: relative;
+  color: var(--color-text-secondary);
+}
+
+.tabButtonActive {
+  color: var(--color-text);
+}
+
+.underline {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--color-primary);
+}
+
+.productsTab {
+  width: 100%;
+}
+
+.productItem {
+  position: relative;
+}
+
+.productActions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.productActions button {
+  flex: 1;
+}
+
+.productForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+
+  h3 {
+    margin-bottom: 0.5rem;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.9rem;
+    font-weight: 600;
+
+    input {
+      width: 100%;
+      padding: 0.6rem;
+      margin-top: 0.3rem;
+      border: 1px solid var(--color-border);
+      border-radius: 8px;
+      font-size: 1rem;
+    }
+  }
+
+  .modalActions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-top: 0.5rem;
+  }
+}
+
+.confirm {
+  padding: 1rem;
+  text-align: center;
+
+  .modalActions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+}
+

--- a/client/src/pages/Profile/modals/DeleteProductModal.tsx
+++ b/client/src/pages/Profile/modals/DeleteProductModal.tsx
@@ -1,0 +1,27 @@
+import ModalSheet from '../../../components/base/ModalSheet';
+import styles from '../Profile.module.scss';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const DeleteProductModal = ({ open, onClose, onConfirm }: Props) => (
+  <ModalSheet open={open} onClose={onClose}>
+    <div className={styles.confirm}>
+      <p>Remove this product?</p>
+      <div className={styles.modalActions}>
+        <button type="button" onClick={onClose}>
+          Cancel
+        </button>
+        <button type="button" onClick={onConfirm}>
+          Remove
+        </button>
+      </div>
+    </div>
+  </ModalSheet>
+);
+
+export default DeleteProductModal;
+

--- a/client/src/pages/Profile/modals/ProductModal.tsx
+++ b/client/src/pages/Profile/modals/ProductModal.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import ModalSheet from '../../../components/base/ModalSheet';
+import styles from '../Profile.module.scss';
+
+export interface ProductForm {
+  _id?: string;
+  name: string;
+  price: number;
+  image?: string;
+}
+
+interface Props {
+  open: boolean;
+  initial?: ProductForm | null;
+  onClose: () => void;
+  onSave: (data: ProductForm) => void;
+}
+
+const empty: ProductForm = { name: '', price: 0, image: '' };
+
+const ProductModal = ({ open, initial, onClose, onSave }: Props) => {
+  const [form, setForm] = useState<ProductForm>(empty);
+
+  useEffect(() => {
+    setForm(initial || empty);
+  }, [initial, open]);
+
+  return (
+    <ModalSheet open={open} onClose={onClose}>
+      <form
+        className={styles.productForm}
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSave(form);
+        }}
+      >
+        <h3>{initial ? 'Edit' : 'Add'} Product</h3>
+        <label>
+          Name
+          <input
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            required
+          />
+        </label>
+        <label>
+          Price
+          <input
+            type="number"
+            value={form.price}
+            onChange={(e) =>
+              setForm({ ...form, price: Number(e.target.value) })
+            }
+            required
+            min={0}
+          />
+        </label>
+        <label>
+          Image URL
+          <input
+            value={form.image || ''}
+            onChange={(e) => setForm({ ...form, image: e.target.value })}
+          />
+        </label>
+        <div className={styles.modalActions}>
+          <button type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="submit">{initial ? 'Update' : 'Add'}</button>
+        </div>
+      </form>
+    </ModalSheet>
+  );
+};
+
+export default ProductModal;
+


### PR DESCRIPTION
## Summary
- add modern profile header with stats and action buttons
- implement querystring-based tabs with animated underline
- allow inline product management with add/edit/delete modals

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1fc978aac83329768000c70a58f64