### PR TITLE
feat: add event card and calendar registration

### DIFF
--- a/client/src/components/ui/EventCard/EventCard.module.scss
+++ b/client/src/components/ui/EventCard/EventCard.module.scss
@@ -1,0 +1,48 @@
+@import "../../../styles/mixins";
+
+.card {
+  background: var(--color-surface);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-align: center;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-md);
+  }
+
+  img {
+    width: 100%;
+    height: 140px;
+    object-fit: cover;
+    border-radius: 8px;
+    margin-bottom: 0.5rem;
+  }
+
+  h3 {
+    margin: 0.5rem 0 0.2rem;
+    font-size: 1.1rem;
+    color: var(--color-primary);
+  }
+
+  .date,
+  .location {
+    margin: 0.2rem 0;
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+  }
+
+  .registerBtn {
+    margin-top: 0.5rem;
+    padding: 0.4rem 0.8rem;
+    @include button-style(var(--color-primary), var(--color-on-primary));
+    font-weight: 600;
+
+    &:hover {
+      background: var(--color-primary-hover);
+    }
+  }
+}

--- a/client/src/components/ui/EventCard/EventCard.tsx
+++ b/client/src/components/ui/EventCard/EventCard.tsx
@@ -1,0 +1,61 @@
+import { useNavigate } from "react-router-dom";
+import fallbackImage from "../../../assets/no-image.svg";
+import styles from "./EventCard.module.scss";
+
+export interface EventItem {
+  _id: string;
+  title?: string;
+  name?: string;
+  startDate?: string;
+  date?: string;
+  banner?: string;
+  image?: string;
+  location?: string;
+}
+
+interface Props {
+  event: EventItem;
+}
+
+const EventCard = ({ event }: Props) => {
+  const navigate = useNavigate();
+  const date = event.startDate || event.date;
+
+  if (date && new Date(date) < new Date()) return null;
+
+  const formattedDate = date
+    ? new Date(date).toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      })
+    : "";
+
+  return (
+    <div
+      className={styles.card}
+      onClick={() => navigate(`/events/${event._id}`)}
+    >
+      <img
+        src={event.banner || event.image || fallbackImage}
+        alt={event.title || event.name}
+        onError={(e) => (e.currentTarget.src = fallbackImage)}
+      />
+      <h3>{event.title || event.name}</h3>
+      {formattedDate && <p className={styles.date}>{formattedDate}</p>}
+      {event.location && (
+        <p className={styles.location}>{event.location}</p>
+      )}
+      <button
+        className={styles.registerBtn}
+        onClick={(e) => {
+          e.stopPropagation();
+          navigate(`/events/${event._id}`);
+        }}
+      >
+        Register
+      </button>
+    </div>
+  );
+};
+
+export default EventCard;

--- a/client/src/pages/EventDetails/EventDetails.scss
+++ b/client/src/pages/EventDetails/EventDetails.scss
@@ -76,6 +76,20 @@
       color: var(--color-success);
     }
 
+    .add-calendar-btn {
+      @include button-style(var(--color-primary), var(--color-on-primary));
+      display: inline-block;
+      margin-top: 0.8rem;
+      padding: 0.7rem 1.5rem;
+      font-weight: 600;
+      border-radius: 8px;
+      text-decoration: none;
+
+      &:hover {
+        background-color: var(--color-primary-hover);
+      }
+    }
+
     .leaderboard {
       margin-top: 2rem;
 

--- a/client/src/pages/EventDetails/EventDetails.tsx
+++ b/client/src/pages/EventDetails/EventDetails.tsx
@@ -20,6 +20,22 @@ interface Event {
   registeredUsers?: { user: string }[];
 }
 
+const getCalendarUrl = (event: Event) => {
+  const date = event.startDate || event.date;
+  if (!date) return "#";
+  const start = new Date(date)
+    .toISOString()
+    .replace(/-|:|\.\d\d\d/g, "");
+  const end = new Date(new Date(date).getTime() + 60 * 60 * 1000)
+    .toISOString()
+    .replace(/-|:|\.\d\d\d/g, "");
+  return `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
+    event.name
+  )}&dates=${start}/${end}&details=${encodeURIComponent(
+    event.description
+  )}&location=${encodeURIComponent(event.location)}`;
+};
+
 const EventDetails = () => {
   const { id } = useParams();
   const [event, setEvent] = useState<Event | null>(null);
@@ -78,7 +94,7 @@ const EventDetails = () => {
       .post(`/events/${id}/register`)
       .then(() => {
         setRegistered(true);
-        setMessage("Registered successfully!");
+        setMessage("You're registered!");
         setEvent((prev) =>
           prev
             ? {
@@ -140,8 +156,17 @@ const EventDetails = () => {
         >
           {registering ? <Loader /> : registered ? 'Registered' : 'Register Now'}
         </button>
-
         {message && <p className="message">{message}</p>}
+        {registered && (
+          <a
+            href={getCalendarUrl(event)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="add-calendar-btn"
+          >
+            Add to Calendar
+          </a>
+        )}
 
         {leaderboard.length > 0 && (
           <div className="leaderboard">

--- a/client/src/pages/Events/Events.scss
+++ b/client/src/pages/Events/Events.scss
@@ -1,5 +1,3 @@
-@import "../../styles/mixins";
-
 .events {
   padding: 2rem;
 
@@ -8,77 +6,9 @@
     margin-bottom: 1rem;
   }
 
-  .tabs {
-    display: flex;
-    gap: 0.5rem;
-    margin-bottom: 1.5rem;
-
-    .tab {
-      padding: 0.4rem 0.9rem;
-      border: 1px solid var(--color-border);
-      border-radius: 16px;
-      background: var(--color-surface-alt);
-      cursor: pointer;
-      font-weight: 500;
-      color: var(--color-text);
-
-      &.active {
-        background: var(--color-primary);
-        color: var(--color-on-primary);
-        border-color: var(--color-primary);
-      }
-    }
-  }
-
   .event-list {
     display: grid;
     gap: 1rem;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  }
-
-  .event-card {
-    background: var(--color-surface);
-    border-radius: 12px;
-    padding: 1rem;
-    box-shadow: var(--shadow-sm);
-    cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-    text-align: center;
-
-    &:hover {
-      transform: translateY(-4px);
-      box-shadow: var(--shadow-md);
-    }
-
-    img {
-      width: 100%;
-      height: 140px;
-      object-fit: cover;
-      border-radius: 8px;
-      margin-bottom: 0.5rem;
-    }
-
-    h3 {
-      margin: 0.5rem 0 0.2rem;
-      font-size: 1.1rem;
-      color: var(--color-primary);
-    }
-
-    .date,
-    .location {
-      margin: 0.2rem 0;
-      color: var(--color-text-secondary);
-      font-size: 0.9rem;
-    }
-
-    .register-btn {
-      margin-top: 0.5rem;
-      padding: 0.4rem 0.8rem;
-      @include button-style(var(--color-primary), var(--color-on-primary));
-      font-weight: 600;
-      &:hover {
-        background: var(--color-primary-hover);
-      }
-    }
   }
 }

--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -1,28 +1,13 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import api from "../../api/client";
 import { sampleEvents } from "../../data/sampleHomeData";
 import Shimmer from "../../components/Shimmer";
+import EventCard, { EventItem } from "../../components/ui/EventCard/EventCard";
 import "./Events.scss";
-import fallbackImage from "../../assets/no-image.svg";
-
-interface EventItem {
-  _id: string;
-  title?: string;
-  name?: string;
-  startDate?: string;
-  date?: string;
-  status?: string;
-  banner?: string;
-  image?: string;
-  location?: string;
-}
 
 const Events = () => {
   const [events, setEvents] = useState<EventItem[]>([]);
   const [loading, setLoading] = useState(true);
-  const [tab, setTab] = useState<"upcoming" | "ongoing" | "past">("upcoming");
-  const navigate = useNavigate();
 
   useEffect(() => {
     api
@@ -38,72 +23,36 @@ const Events = () => {
       .finally(() => setLoading(false));
   }, []);
 
-  const filteredEvents = events.filter((ev) => {
-    if (tab === "past") return ev.status === "closed" || ev.status === "past";
-    return (ev.status || "upcoming") === tab;
+  const upcomingEvents = events.filter((ev) => {
+    const date = ev.startDate || ev.date;
+    return !date || new Date(date) >= new Date();
   });
 
   return (
     <div className="events">
       <h2>Events & Tournaments</h2>
-      <div className="tabs">
-        {(["upcoming", "ongoing", "past"] as const).map((t) => (
-          <button
-            key={t}
-            className={`tab ${tab === t ? "active" : ""}`}
-            onClick={() => setTab(t)}
-          >
-            {t.charAt(0).toUpperCase() + t.slice(1)}
-          </button>
-        ))}
-      </div>
       <div className="event-list">
         {loading
           ? Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="event-card">
+              <div
+                key={i}
+                style={{
+                  background: "var(--color-surface)",
+                  borderRadius: "12px",
+                  padding: "1rem",
+                  boxShadow: "var(--shadow-sm)",
+                }}
+              >
                 <Shimmer className="rounded" style={{ height: 140 }} />
-                <Shimmer style={{ height: 16, marginTop: 8, width: "70%" }} />
-                <Shimmer style={{ height: 14, marginTop: 4, width: "40%" }} />
+                <Shimmer
+                  style={{ height: 16, marginTop: 8, width: "70%" }}
+                />
+                <Shimmer
+                  style={{ height: 14, marginTop: 4, width: "40%" }}
+                />
               </div>
             ))
-          : filteredEvents.map((ev, i) => {
-              const date = ev.startDate || ev.date || "";
-              const formattedDate = date
-                ? new Date(date).toLocaleString(undefined, {
-                    dateStyle: "medium",
-                    timeStyle: "short",
-                  })
-                : "";
-              return (
-                <div
-                  key={ev._id || i}
-                  className="event-card"
-                  onClick={() => navigate(`/events/${ev._id}`)}
-                >
-                  <img
-                    src={ev.banner || ev.image || fallbackImage}
-                    alt={ev.title || ev.name}
-                    onError={(e) => (e.currentTarget.src = fallbackImage)}
-                  />
-                  <h3>{ev.title || ev.name}</h3>
-                  {formattedDate && (
-                    <p className="date">{formattedDate}</p>
-                  )}
-                  {ev.location && (
-                    <p className="location">{ev.location}</p>
-                  )}
-                  <button
-                    className="register-btn"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      navigate(`/events/${ev._id}`);
-                    }}
-                  >
-                    Register
-                  </button>
-                </div>
-              );
-            })}
+          : upcomingEvents.map((ev) => <EventCard key={ev._id} event={ev} />)}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add reusable EventCard with image, timing and location
- filter past events from Events page
- show post-registration message and add-to-calendar link on Event details

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2006b3fc8833296f2b0b5b92a4d5c