### PR TITLE
feat: add notification cards with filters and pagination

### DIFF
--- a/client/src/api/notifications.ts
+++ b/client/src/api/notifications.ts
@@ -11,11 +11,28 @@ export interface Notification {
   isRead?: boolean;
 }
 
-export const fetchNotifications = async (): Promise<Notification[]> => {
-  const res = await api.get('/notifications');
-  return res.data;
+export interface NotificationsResponse {
+  notifications: Notification[];
+  hasMore: boolean;
+}
+
+export const fetchNotifications = async (
+  {
+    page = 1,
+    limit = 10,
+    type,
+  }: { page?: number; limit?: number; type?: string } = {},
+): Promise<NotificationsResponse> => {
+  const res = await api.get('/notifications', {
+    params: { page, limit, type },
+  });
+  if (Array.isArray(res.data)) {
+    return { notifications: res.data, hasMore: res.data.length === limit };
+  }
+  return res.data as NotificationsResponse;
 };
 
 export const markNotificationRead = async (id: string) => {
   await api.post(`/notifications/view/${id}`);
 };
+

--- a/client/src/components/ui/NotificationCard/NotificationCard.module.scss
+++ b/client/src/components/ui/NotificationCard/NotificationCard.module.scss
@@ -1,0 +1,51 @@
+.card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.read {
+  opacity: 0.6;
+}
+
+.icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.info {
+  flex: 1;
+  h5 {
+    margin: 0 0 var(--space-1);
+    font-size: var(--font-size-md);
+  }
+  p {
+    margin: 0;
+    font-size: var(--font-size-sm);
+    color: var(--color-muted);
+  }
+  .time {
+    display: block;
+    margin-top: var(--space-1);
+    font-size: var(--font-size-sm);
+    color: var(--color-muted);
+  }
+}
+
+.cta {
+  border: none;
+  background: var(--color-info);
+  color: var(--color-on-primary);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+

--- a/client/src/components/ui/NotificationCard/NotificationCard.tsx
+++ b/client/src/components/ui/NotificationCard/NotificationCard.tsx
@@ -1,0 +1,72 @@
+import { ReactNode, useRef } from 'react';
+import styles from './NotificationCard.module.scss';
+
+export interface NotificationCardProps {
+  icon?: string | ReactNode;
+  title: string;
+  message?: string;
+  timestamp: string;
+  read?: boolean;
+  ctaLabel?: string;
+  onClick?: () => void;
+  onCtaClick?: () => void;
+  onSwipeLeft?: () => void;
+}
+
+const NotificationCard = ({
+  icon,
+  title,
+  message,
+  timestamp,
+  read,
+  ctaLabel,
+  onClick,
+  onCtaClick,
+  onSwipeLeft,
+}: NotificationCardProps) => {
+  const touchStart = useRef(0);
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    touchStart.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+    const diff = touchStart.current - e.changedTouches[0].clientX;
+    if (diff > 50 && onSwipeLeft) onSwipeLeft();
+  };
+
+  return (
+    <div
+      className={`${styles.card} ${read ? styles.read : ''}`}
+      onClick={onClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      {typeof icon === 'string' ? (
+        <img src={icon} alt="" className={styles.icon} />
+      ) : (
+        icon
+      )}
+      <div className={styles.info}>
+        <h5>{title}</h5>
+        {message && <p>{message}</p>}
+        <span className={styles.time}>{new Date(timestamp).toLocaleTimeString()}</span>
+      </div>
+      {ctaLabel && (
+        <button
+          type="button"
+          className={styles.cta}
+          onClick={(e) => {
+            e.stopPropagation();
+            onCtaClick?.();
+          }}
+        >
+          {ctaLabel}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default NotificationCard;
+

--- a/client/src/components/ui/NotificationCard/SkeletonNotificationCard.tsx
+++ b/client/src/components/ui/NotificationCard/SkeletonNotificationCard.tsx
@@ -1,0 +1,15 @@
+import Shimmer from '../../Shimmer';
+import styles from './NotificationCard.module.scss';
+
+const SkeletonNotificationCard = () => (
+  <div className={styles.card}>
+    <Shimmer width={40} height={40} className={styles.icon} />
+    <div className={styles.info}>
+      <Shimmer style={{ height: 14, width: '60%', marginBottom: 6 }} />
+      <Shimmer style={{ height: 12, width: '80%' }} />
+    </div>
+  </div>
+);
+
+export default SkeletonNotificationCard;
+

--- a/client/src/components/ui/NotificationCard/index.ts
+++ b/client/src/components/ui/NotificationCard/index.ts
@@ -1,0 +1,3 @@
+export { default } from './NotificationCard';
+export { default as SkeletonNotificationCard } from './SkeletonNotificationCard';
+export * from './NotificationCard';

--- a/client/src/pages/Notifications/Notifications.scss
+++ b/client/src/pages/Notifications/Notifications.scss
@@ -29,51 +29,6 @@
     }
   }
 
-  .notif-item {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    background: var(--color-card);
-    border-radius: 8px;
-    padding: 0.5rem;
-    margin-bottom: 0.5rem;
-    box-shadow: var(--shadow-sm);
-
-    &.read {
-      opacity: 0.6;
-    }
-
-    img {
-      width: 40px;
-      height: 40px;
-      object-fit: cover;
-      border-radius: 50%;
-    }
-
-    .info {
-      flex: 1;
-
-      h5 {
-        margin: 0 0 4px;
-        font-size: 0.95rem;
-      }
-
-      p {
-        margin: 0;
-        font-size: 0.85rem;
-        color: var(--color-muted);
-      }
-    }
-
-    .mark-btn {
-      display: none;
-      background: transparent;
-      border: none;
-      color: var(--color-info);
-      cursor: pointer;
-    }
-  }
-
   .empty-state {
     text-align: center;
     margin-top: 2rem;
@@ -81,12 +36,3 @@
   }
 }
 
-@media (min-width: 600px) {
-  .notifications-page {
-    .notif-item {
-      .mark-btn {
-        display: inline-block;
-      }
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- add reusable NotificationCard with swipe handling and skeleton variant
- support paginated notification fetching with filters for orders, offers and system
- implement infinite scroll on notifications page with skeleton loading state

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a202f096dc8332b81f5c648c943408