### PR TITLE
feat: enhance voice ordering with confirmation

### DIFF
--- a/client/src/components/ui/ModalSheet/VoiceConfirmSheet.module.scss
+++ b/client/src/components/ui/ModalSheet/VoiceConfirmSheet.module.scss
@@ -1,0 +1,30 @@
+@import '../../../styles/variables';
+
+.sheet {
+  padding: 1rem;
+  text-align: center;
+
+  h4 {
+    margin-bottom: 1rem;
+  }
+
+  .name,
+  .shop,
+  .price {
+    margin: 0.25rem 0;
+  }
+
+  .actions {
+    margin-top: 1rem;
+
+    button {
+      width: 100%;
+      padding: 0.6rem;
+      background: $primary-color;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+    }
+  }
+}

--- a/client/src/components/ui/ModalSheet/VoiceConfirmSheet.tsx
+++ b/client/src/components/ui/ModalSheet/VoiceConfirmSheet.tsx
@@ -1,0 +1,43 @@
+import ModalSheet from '../../base/ModalSheet';
+import styles from './VoiceConfirmSheet.module.scss';
+
+interface Product {
+  _id: string;
+  name: string;
+  price: number;
+}
+
+interface Shop {
+  _id: string;
+  name: string;
+}
+
+interface Props {
+  open: boolean;
+  item: { product: Product; shop: Shop; quantity: number } | null;
+  loading: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const VoiceConfirmSheet = ({ open, item, loading, onClose, onConfirm }: Props) => (
+  <ModalSheet open={open} onClose={onClose}>
+    {item && (
+      <div className={styles.sheet}>
+        <h4>Confirm Order</h4>
+        <p className={styles.name}>
+          {item.product.name} × {item.quantity}
+        </p>
+        <p className={styles.shop}>{item.shop.name}</p>
+        <p className={styles.price}>₹{item.product.price * item.quantity}</p>
+        <div className={styles.actions}>
+          <button onClick={onConfirm} disabled={loading}>
+            {loading ? 'Placing…' : 'Place Order'}
+          </button>
+        </div>
+      </div>
+    )}
+  </ModalSheet>
+);
+
+export default VoiceConfirmSheet;

--- a/client/src/pages/VoiceOrder/VoiceOrder.module.scss
+++ b/client/src/pages/VoiceOrder/VoiceOrder.module.scss
@@ -4,6 +4,9 @@
 .voiceOrder {
   padding: 2rem;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   h2 {
     font-size: 1.6rem;
@@ -28,11 +31,48 @@
     animation: pulse 1.2s infinite ease-in-out;
   }
 
+  .hint {
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+    color: #666;
+  }
+
   .transcript {
     margin-top: 1rem;
+    width: 100%;
+    max-width: 400px;
+    height: 80px;
+    padding: 0.5rem;
     font-size: 1rem;
     color: #333;
-    min-height: 1.5rem;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    resize: vertical;
+  }
+
+  .process {
+    margin-top: 0.5rem;
+    padding: 0.4rem 0.75rem;
+    background: $primary-color;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+
+  .chips {
+    margin-top: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+  }
+
+  .chip {
+    padding: 0.3rem 0.6rem;
+    background: #f0f0f0;
+    border-radius: 16px;
+    font-size: 0.85rem;
   }
 
   .results {


### PR DESCRIPTION
## Summary
- add voice order confirmation sheet before placing order
- show language-specific hints, live transcript editing, and recognized item chips
- support manual text entry and improved mic interaction

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a207a701b883329e0bc8c6a7d05d8e