### PR TITLE
feat: improve accessibility and performance

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,47 +1,49 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, Suspense, lazy } from 'react';
 import { useDispatch } from 'react-redux';
-import Landing from './pages/Landing/Landing';
-import Login from './pages/auth/Login/Login';
-import Signup from './pages/auth/Signup/Signup';
 import ProtectedRoute from './components/ProtectedRoute';
-import './styles/main.scss';
-import OTP from './pages/auth/OTP/OTP';
-import Profile from './pages/Profile/Profile';
-import Home from './pages/Home/Home';
-import Shops from './pages/Shops/Shops';
-import ShopDetails from './pages/ShopDetails/ShopDetails';
-import ProductDetails from './pages/ProductDetails/ProductDetails';
-import EventDetails from './pages/EventDetails/EventDetails';
-import VerifiedDetails from './pages/Verified/Details';
-import VerifiedList from './pages/Verified/List';
-import SpecialShop from './pages/SpecialShop/SpecialShop';
-import Settings from './pages/Settings/Settings';
-import Cart from './pages/Cart/Cart';
-import Events from './pages/Events/Events';
-import VoiceOrder from './pages/VoiceOrder/VoiceOrder';
-import OrderNow from './pages/OrderNow/OrderNow';
-import ManageProducts from './pages/ManageProducts/ManageProducts';
-import ReceivedOrders from './pages/Orders/ReceivedOrders';
-import MyOrders from './pages/Orders/MyOrders';
-import OrderDetail from './pages/Orders/OrderDetail';
-import Notifications from './pages/Notifications/Notifications';
-import TabLayout from './layouts/TabLayout';
-import AdminLogin from './pages/AdminLogin/AdminLogin';
-import AdminDashboard from './pages/AdminDashboard';
-import AdminShops from './pages/AdminShops';
-import AdminProducts from './pages/AdminProducts';
-import AdminEvents from './pages/AdminEvents';
-import VerificationRequests from './pages/VerificationRequests';
-import BusinessRequests from './pages/BusinessRequests';
-import AdminUsers from './pages/AdminUsers';
-import AdminAnalytics from './pages/AdminAnalytics';
 import AdminProtectedRoute from './components/AdminProtectedRoute';
+import TabLayout from './layouts/TabLayout';
 import AdminLayout from './layouts/AdminLayout';
+import './styles/main.scss';
 import { setUser } from './store/slices/userSlice';
 import { setAdminToken } from './store/slices/adminSlice';
 import type { AppDispatch } from './store';
-import UiPreview from './pages/UiPreview';
+import Loader from './components/Loader';
+
+const Landing = lazy(() => import('./pages/Landing/Landing'));
+const Login = lazy(() => import('./pages/auth/Login/Login'));
+const Signup = lazy(() => import('./pages/auth/Signup/Signup'));
+const OTP = lazy(() => import('./pages/auth/OTP/OTP'));
+const Profile = lazy(() => import('./pages/Profile/Profile'));
+const Home = lazy(() => import('./pages/Home/Home'));
+const Shops = lazy(() => import('./pages/Shops/Shops'));
+const ShopDetails = lazy(() => import('./pages/ShopDetails/ShopDetails'));
+const ProductDetails = lazy(() => import('./pages/ProductDetails/ProductDetails'));
+const EventDetails = lazy(() => import('./pages/EventDetails/EventDetails'));
+const VerifiedDetails = lazy(() => import('./pages/Verified/Details'));
+const VerifiedList = lazy(() => import('./pages/Verified/List'));
+const SpecialShop = lazy(() => import('./pages/SpecialShop/SpecialShop'));
+const Settings = lazy(() => import('./pages/Settings/Settings'));
+const Cart = lazy(() => import('./pages/Cart/Cart'));
+const Events = lazy(() => import('./pages/Events/Events'));
+const VoiceOrder = lazy(() => import('./pages/VoiceOrder/VoiceOrder'));
+const OrderNow = lazy(() => import('./pages/OrderNow/OrderNow'));
+const ManageProducts = lazy(() => import('./pages/ManageProducts/ManageProducts'));
+const ReceivedOrders = lazy(() => import('./pages/Orders/ReceivedOrders'));
+const MyOrders = lazy(() => import('./pages/Orders/MyOrders'));
+const OrderDetail = lazy(() => import('./pages/Orders/OrderDetail'));
+const Notifications = lazy(() => import('./pages/Notifications/Notifications'));
+const AdminLogin = lazy(() => import('./pages/AdminLogin/AdminLogin'));
+const AdminDashboard = lazy(() => import('./pages/AdminDashboard'));
+const AdminShops = lazy(() => import('./pages/AdminShops'));
+const AdminProducts = lazy(() => import('./pages/AdminProducts'));
+const AdminEvents = lazy(() => import('./pages/AdminEvents'));
+const VerificationRequests = lazy(() => import('./pages/VerificationRequests'));
+const BusinessRequests = lazy(() => import('./pages/BusinessRequests'));
+const AdminUsers = lazy(() => import('./pages/AdminUsers'));
+const AdminAnalytics = lazy(() => import('./pages/AdminAnalytics'));
+const UiPreview = lazy(() => import('./pages/UiPreview'));
 
 function App() {
   const dispatch = useDispatch<AppDispatch>();
@@ -64,7 +66,8 @@ function App() {
 
   return (
     <BrowserRouter>
-      <Routes>
+      <Suspense fallback={<Loader />}>
+        <Routes>
         <Route path="/" element={<Landing />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
@@ -108,7 +111,8 @@ function App() {
           <Route path="/orders/:id" element={<OrderDetail />} />
           <Route path="/cart" element={<Cart />} />
         </Route>
-      </Routes>
+        </Routes>
+      </Suspense>
     </BrowserRouter>
   );
 }

--- a/client/src/components/base/ProductCard.tsx
+++ b/client/src/components/base/ProductCard.tsx
@@ -21,9 +21,31 @@ interface ProductCardProps {
 
 const ProductCard = ({ product, ctaLabel, onCtaClick, onClick, className = '' }: ProductCardProps) => {
   return (
-    <div className={`${styles.card} ${className}`} onClick={onClick}>
+    <div
+      className={`${styles.card} ${className}`}
+      onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
+      aria-label={onClick ? `View ${product.title}` : undefined}
+    >
       <div className={styles.imageWrapper}>
-        <img src={product.image} alt={product.title} loading="lazy" />
+        <img
+          src={product.image}
+          alt={product.title}
+          loading="lazy"
+          width={300}
+          height={400}
+        />
         {product.discount && <span className={styles.badge}>{product.discount}% OFF</span>}
         <div className={styles.wishlist}>
           <WishlistHeart />

--- a/client/src/components/ui/NotificationCard/NotificationCard.tsx
+++ b/client/src/components/ui/NotificationCard/NotificationCard.tsx
@@ -1,4 +1,5 @@
-import { ReactNode, useRef } from 'react';
+import { useRef } from 'react';
+import type { ReactNode } from 'react';
 import styles from './NotificationCard.module.scss';
 
 export interface NotificationCardProps {

--- a/client/src/pages/AdminProducts/AdminProducts.tsx
+++ b/client/src/pages/AdminProducts/AdminProducts.tsx
@@ -230,7 +230,16 @@ const AdminProducts = () => {
             {products.map((p) => (
               <tr key={p._id}>
                 <td>
-                  {p.image ? <img src={p.image} alt="" width={40} /> : null}
+                  {p.image ? (
+                    <img
+                      src={p.image}
+                      alt={p.name}
+                      width={40}
+                      height={40}
+                      loading="lazy"
+                      style={{ objectFit: 'cover' }}
+                    />
+                  ) : null}
                 </td>
                 <td>{p.name}</td>
                 <td>{p.shopName || p.shopId}</td>

--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import api from "../../api/client";
 import { sampleEvents } from "../../data/sampleHomeData";
 import Shimmer from "../../components/Shimmer";
-import EventCard, { EventItem } from "../../components/ui/EventCard/EventCard";
+import EventCard from "../../components/ui/EventCard/EventCard";
+import type { EventItem } from "../../components/ui/EventCard/EventCard";
 import "./Events.scss";
 
 const Events = () => {

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -82,10 +82,23 @@ const Home = () => {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
         onClick={() => banner.link && navigate(banner.link)}
+        role={banner.link ? 'button' : undefined}
+        tabIndex={banner.link ? 0 : undefined}
+        aria-label={banner.title}
+        onKeyDown={(e) => {
+          if (banner.link && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault();
+            navigate(banner.link);
+          }
+        }}
       >
         <img
           src={banner.image || fallbackImage}
           alt="Admin Update"
+          loading="lazy"
+          width={1200}
+          height={300}
+          style={{ objectFit: 'cover' }}
           onError={(e) => (e.currentTarget.src = fallbackImage)}
         />
         <div className="banner-text">
@@ -177,18 +190,35 @@ const Section = ({ title, data, type, loading, seeAll, navigate }: SectionProps)
               key={item._id}
               className="card"
               whileHover={{ scale: 1.03 }}
-            >
-              <img
-                src={item.image || fallbackImage}
-                alt={item.name || item.title}
-                onError={(e) => (e.currentTarget.src = fallbackImage)}
-                onClick={() =>
+              role="button"
+              tabIndex={0}
+              aria-label={`View ${item.name || item.title}`}
+              onClick={() =>
+                navigate(
+                  type === 'user'
+                    ? `/verified-users/${item._id}`
+                    : `/events/${item._id}`,
+                )
+              }
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
                   navigate(
                     type === 'user'
                       ? `/verified-users/${item._id}`
                       : `/events/${item._id}`,
-                  )
+                  );
                 }
+              }}
+            >
+              <img
+                src={item.image || fallbackImage}
+                alt={item.name || item.title}
+                loading="lazy"
+                width={150}
+                height={150}
+                style={{ objectFit: 'cover', aspectRatio: '1 / 1' }}
+                onError={(e) => (e.currentTarget.src = fallbackImage)}
               />
               <div className="card-info">
                 <h4>{item.name || item.title}</h4>

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -99,12 +99,16 @@ const Profile = () => {
   };
 
   const handleSaveProduct = (data: ProductForm) => {
+    const withImage = { ...data, image: data.image || '' };
     if (editingProduct) {
       setProducts((prev) =>
-        prev.map((p) => (p._id === editingProduct._id ? { ...p, ...data } : p))
+        prev.map((p) => (p._id === editingProduct._id ? { ...p, ...withImage } : p))
       );
     } else {
-      setProducts((prev) => [...prev, { ...data, _id: Date.now().toString() }]);
+      setProducts((prev) => [
+        ...prev,
+        { ...withImage, _id: Date.now().toString() },
+      ]);
     }
     setProductModalOpen(false);
   };

--- a/client/src/styles/main.scss
+++ b/client/src/styles/main.scss
@@ -61,6 +61,7 @@ h6 {
 /* Image responsiveness */
 img {
   max-width: 100%;
+  height: auto;
   display: block;
 }
 
@@ -71,6 +72,13 @@ select,
 button {
   font: inherit;
   color: inherit;
+}
+
+/* Ensure tappable elements meet minimum target size */
+button,
+a {
+  min-width: 44px;
+  min-height: 44px;
 }
 
 /* Focus states */


### PR DESCRIPTION
## Summary
- enforce minimum tap target size and remove image shifts
- improve keyboard and ARIA support on product and home cards
- enable route-based code splitting and lazy load heavy pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3eba3f8b88332a51684f72cc5f062