### PR TITLE
fix eventcard type import

### DIFF
--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import api from "../../api/client";
 import { sampleEvents } from "../../data/sampleHomeData";
 import Shimmer from "../../components/Shimmer";
-import EventCard, { EventItem } from "../../components/ui/EventCard/EventCard";
+import EventCard from "../../components/ui/EventCard/EventCard";
+import type { EventItem } from "../../components/ui/EventCard/EventCard";
 import "./Events.scss";
 
 const Events = () => {


### PR DESCRIPTION
## Summary
- fix runtime import of EventItem by using type-only import in Events page

## Testing
- `npm test` *(fails: missing script `test`)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ebcffb1c8332883968ed9ba551b8