### PR TITLE
Refactor admin tables with shared components

### DIFF
--- a/client/src/components/ui/StatusChip.module.scss
+++ b/client/src/components/ui/StatusChip.module.scss
@@ -7,18 +7,25 @@
   text-transform: capitalize;
 }
 
-.pending {
+.pending,
+.upcoming {
   background: var(--blue-100);
   color: var(--blue-700);
 }
 
-.accepted {
+.accepted,
+.approved,
+.active,
+.ongoing {
   background: var(--blue-600);
   color: var(--white);
 }
 
 .rejected,
-.cancelled {
+.cancelled,
+.suspended,
+.inactive,
+.past {
   background: var(--color-danger);
   color: var(--white);
 }

--- a/client/src/components/ui/StatusChip.tsx
+++ b/client/src/components/ui/StatusChip.tsx
@@ -5,7 +5,14 @@ export type Status =
   | 'accepted'
   | 'rejected'
   | 'cancelled'
-  | 'completed';
+  | 'completed'
+  | 'approved'
+  | 'active'
+  | 'suspended'
+  | 'inactive'
+  | 'upcoming'
+  | 'ongoing'
+  | 'past';
 
 interface StatusChipProps {
   status: Status;

--- a/client/src/pages/AdminAnalytics/AdminAnalytics.tsx
+++ b/client/src/pages/AdminAnalytics/AdminAnalytics.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { fetchMetrics, fetchMetricSeries, type MetricsSummary, type SeriesPoint } from '../../api/admin';
+import DataTable, { type Column } from '../../components/admin/DataTable';
 import Loader from '../../components/Loader';
 import './AdminAnalytics.scss';
 
@@ -9,6 +10,16 @@ const AdminAnalytics = () => {
   const [metrics, setMetrics] = useState<MetricsSummary | null>(null);
   const [series, setSeries] = useState<Record<string, SeriesPoint[]>>({});
   const [loading, setLoading] = useState(false);
+
+  const shopColumns: Column<{ name: string; orders: number; id: string }>[] = [
+    { key: 'name', label: 'Shop' },
+    { key: 'orders', label: 'Orders' },
+  ];
+
+  const productColumns: Column<{ name: string; orders: number; id: string }>[] = [
+    { key: 'name', label: 'Product' },
+    { key: 'orders', label: 'Orders' },
+  ];
 
   const load = async () => {
     setLoading(true);
@@ -59,15 +70,15 @@ const AdminAnalytics = () => {
             <Suspense fallback={<Loader />}>
               <div className="chart">
                 <h3>Orders</h3>
-                <Chart data={series.orders || []} />
+                <Chart data={series.orders || []} height={80} />
               </div>
               <div className="chart">
                 <h3>Signups</h3>
-                <Chart data={series.signups || []} />
+                <Chart data={series.signups || []} height={80} />
               </div>
               <div className="chart">
                 <h3>GMV</h3>
-                <Chart data={series.gmv || []} />
+                <Chart data={series.gmv || []} height={80} />
               </div>
             </Suspense>
           </section>
@@ -75,14 +86,15 @@ const AdminAnalytics = () => {
             <div className="table">
               <h3>Top Shops</h3>
               {metrics.topShops && metrics.topShops.length ? (
-                <table>
-                  <thead><tr><th>Shop</th><th>Orders</th></tr></thead>
-                  <tbody>
-                    {metrics.topShops.map((s) => (
-                      <tr key={s.id}><td>{s.name}</td><td>{s.orders}</td></tr>
-                    ))}
-                  </tbody>
-                </table>
+                <DataTable<{ name: string; orders: number; id: string }>
+                  columns={shopColumns}
+                  rows={metrics.topShops}
+                  page={1}
+                  pageSize={metrics.topShops.length}
+                  total={metrics.topShops.length}
+                  onPageChange={() => {}}
+                  rowKey={(r) => r.id}
+                />
               ) : (
                 <p>No data</p>
               )}
@@ -90,14 +102,15 @@ const AdminAnalytics = () => {
             <div className="table">
               <h3>Top Products</h3>
               {metrics.topProducts && metrics.topProducts.length ? (
-                <table>
-                  <thead><tr><th>Product</th><th>Orders</th></tr></thead>
-                  <tbody>
-                    {metrics.topProducts.map((p) => (
-                      <tr key={p.id}><td>{p.name}</td><td>{p.orders}</td></tr>
-                    ))}
-                  </tbody>
-                </table>
+                <DataTable<{ name: string; orders: number; id: string }>
+                  columns={productColumns}
+                  rows={metrics.topProducts}
+                  page={1}
+                  pageSize={metrics.topProducts.length}
+                  total={metrics.topProducts.length}
+                  onPageChange={() => {}}
+                  rowKey={(r) => r.id}
+                />
               ) : (
                 <p>No data</p>
               )}

--- a/client/src/pages/AdminProducts/AdminProducts.tsx
+++ b/client/src/pages/AdminProducts/AdminProducts.tsx
@@ -5,7 +5,8 @@ import {
   deleteProduct as apiDeleteProduct,
   type ProductQueryParams,
 } from '../../api/admin';
-import Loader from '../../components/Loader';
+import DataTable, { type Column } from '../../components/admin/DataTable';
+import StatusChip from '../../components/ui/StatusChip';
 import showToast from '../../components/ui/Toast';
 import './AdminProducts.scss';
 
@@ -24,6 +25,8 @@ interface Product {
   images?: string[];
   updatedAt: string;
 }
+
+type ProductRow = Product & { actions?: string };
 
 const emptyForm = {
   name: '',
@@ -143,7 +146,52 @@ const AdminProducts = () => {
     }
   };
 
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const columns: Column<ProductRow>[] = [
+    {
+      key: 'image',
+      label: 'Image',
+      render: (p) =>
+        p.image ? (
+          <img
+            src={p.image}
+            alt={p.name}
+            width={40}
+            height={40}
+            loading="lazy"
+            style={{ objectFit: 'cover' }}
+          />
+        ) : null,
+    },
+    { key: 'name', label: 'Name' },
+    {
+      key: 'shopName',
+      label: 'Shop',
+      render: (p) => p.shopName || p.shopId,
+    },
+    { key: 'category', label: 'Category' },
+    { key: 'price', label: 'Price' },
+    { key: 'stock', label: 'Stock' },
+    {
+      key: 'status',
+      label: 'Status',
+      render: (p) => <StatusChip status={p.status as any} />,
+    },
+    {
+      key: 'updatedAt',
+      label: 'Updated',
+      render: (p) => new Date(p.updatedAt).toLocaleDateString(),
+    },
+    {
+      key: 'actions',
+      label: '',
+      render: (p) => (
+        <div className="actions">
+          <button onClick={() => openEdit(p)}>Edit</button>
+          <button onClick={() => handleDelete(p._id)}>Delete</button>
+        </div>
+      ),
+    },
+  ];
 
   return (
     <div className="admin-products">
@@ -209,68 +257,15 @@ const AdminProducts = () => {
           <option value="price">Price: Low to High</option>
         </select>
       </div>
-      {loading ? (
-        <Loader />
-      ) : (
-        <table className="products-table">
-          <thead>
-            <tr>
-              <th>Image</th>
-              <th>Name</th>
-              <th>Shop</th>
-              <th>Category</th>
-              <th>Price</th>
-              <th>Stock</th>
-              <th>Status</th>
-              <th>Updated</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            {products.map((p) => (
-              <tr key={p._id}>
-                <td>
-                  {p.image ? (
-                    <img
-                      src={p.image}
-                      alt={p.name}
-                      width={40}
-                      height={40}
-                      loading="lazy"
-                      style={{ objectFit: 'cover' }}
-                    />
-                  ) : null}
-                </td>
-                <td>{p.name}</td>
-                <td>{p.shopName || p.shopId}</td>
-                <td>{p.category}</td>
-                <td>{p.price}</td>
-                <td>{p.stock}</td>
-                <td>{p.status}</td>
-                <td>{new Date(p.updatedAt).toLocaleDateString()}</td>
-                <td className="actions">
-                  <button onClick={() => openEdit(p)}>Edit</button>
-                  <button onClick={() => handleDelete(p._id)}>Delete</button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-      <div className="pagination">
-        <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
-          Prev
-        </button>
-        <span>
-          {page}/{totalPages}
-        </span>
-        <button
-          disabled={page >= totalPages}
-          onClick={() => setPage((p) => p + 1)}
-        >
-          Next
-        </button>
-      </div>
+      <DataTable<ProductRow>
+        columns={columns}
+        rows={products as ProductRow[]}
+        page={page}
+        pageSize={pageSize}
+        total={total}
+        onPageChange={setPage}
+        loading={loading}
+      />
       {edit && (
         <div className="modal">
           <form className="modal-content" onSubmit={handleSave}>

--- a/client/src/pages/BusinessRequests/BusinessRequests.tsx
+++ b/client/src/pages/BusinessRequests/BusinessRequests.tsx
@@ -6,6 +6,8 @@ import {
   rejectShop,
   type BusinessRequestParams,
 } from '../../api/admin';
+import DataTable, { type Column } from '../../components/admin/DataTable';
+import StatusChip from '../../components/ui/StatusChip';
 import showToast from '../../components/ui/Toast';
 import './BusinessRequests.scss';
 
@@ -23,6 +25,8 @@ interface ShopRequest {
     phone: string;
   };
 }
+
+type RequestRow = ShopRequest & { actions?: string };
 
 const BusinessRequests = () => {
   const [requests, setRequests] = useState<ShopRequest[]>([]);
@@ -87,6 +91,48 @@ const BusinessRequests = () => {
     }
   };
 
+  const columns: Column<RequestRow>[] = [
+    {
+      key: 'owner',
+      label: 'User',
+      render: (r) => r.owner?.name,
+    },
+    { key: 'name', label: 'Shop Name' },
+    { key: 'category', label: 'Category' },
+    { key: 'location', label: 'Location' },
+    { key: 'address', label: 'Address' },
+    {
+      key: 'createdAt',
+      label: 'Requested At',
+      render: (r) => new Date(r.createdAt).toLocaleDateString(),
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      render: (r) => <StatusChip status={r.status as any} />,
+    },
+    {
+      key: 'actions',
+      label: 'Actions',
+      render: (r) => (
+        <>
+          <button
+            onClick={() => handleAction(r._id, 'approved')}
+            disabled={actionId === r._id}
+          >
+            Approve
+          </button>
+          <button
+            onClick={() => handleAction(r._id, 'rejected')}
+            disabled={actionId === r._id}
+          >
+            Reject
+          </button>
+        </>
+      ),
+    },
+  ];
+
   return (
     <div className="business-requests">
       <h1>Business Requests</h1>
@@ -113,51 +159,15 @@ const BusinessRequests = () => {
           onChange={(e) => updateParam('location', e.target.value)}
         />
       </div>
-      {loading ? (
-        <p>Loading...</p>
-      ) : (
-        <table>
-          <thead>
-            <tr>
-              <th>User</th>
-              <th>Shop Name</th>
-              <th>Category</th>
-              <th>Location</th>
-              <th>Address</th>
-              <th>Requested At</th>
-              <th>Status</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {requests.map((req) => (
-              <tr key={req._id}>
-                <td>{req.owner?.name}</td>
-                <td>{req.name}</td>
-                <td>{req.category}</td>
-                <td>{req.location}</td>
-                <td>{req.address}</td>
-                <td>{new Date(req.createdAt).toLocaleDateString()}</td>
-                <td>{req.status}</td>
-                <td>
-                  <button
-                    onClick={() => handleAction(req._id, 'approved')}
-                    disabled={actionId === req._id}
-                  >
-                    Approve
-                  </button>
-                  <button
-                    onClick={() => handleAction(req._id, 'rejected')}
-                    disabled={actionId === req._id}
-                  >
-                    Reject
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <DataTable<RequestRow>
+        columns={columns}
+        rows={requests as RequestRow[]}
+        page={1}
+        pageSize={requests.length || 1}
+        total={requests.length}
+        onPageChange={() => {}}
+        loading={loading}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- refactor all admin listings to use shared DataTable with sticky headers and pagination
- expand StatusChip to cover additional admin states
- shrink analytics charts and render top lists with DataTable

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ef1bb53c8332bea00c45f41c434b