### PR TITLE
feat: enhance order and shop endpoints

### DIFF
--- a/server/routes/orderRoutes.js
+++ b/server/routes/orderRoutes.js
@@ -5,6 +5,7 @@ const {
   placeOrder,
   getMyOrders,
   getReceivedOrders,
+  getOrderById,
   acceptOrder,
   rejectOrder,
   cancelOrder,
@@ -13,6 +14,7 @@ const {
 router.post("/place/:productId", protect, placeOrder);
 router.get("/my", protect, getMyOrders);
 router.get("/received", protect, getReceivedOrders);
+router.get("/:id", protect, getOrderById);
 router.post("/accept/:id", protect, acceptOrder);
 router.post("/reject/:id", protect, rejectOrder);
 router.post("/cancel/:id", protect, cancelOrder);

--- a/server/utils/normalize.js
+++ b/server/utils/normalize.js
@@ -1,0 +1,24 @@
+exports.normalizeProduct = (p) => ({
+  id: p._id.toString(),
+  _id: p._id.toString(),
+  name: p.name,
+  price: p.price,
+  mrp: p.mrp,
+  discount: p.mrp ? Math.round(((p.mrp - p.price) / p.mrp) * 100) : 0,
+  stock: p.stock,
+  images: p.images,
+  image: p.images?.[0] || '',
+  category: p.category,
+  shopId: p.shop?._id ? p.shop._id.toString() : p.shop.toString(),
+  shop: p.shop?._id ? p.shop._id.toString() : p.shop.toString(),
+  rating: p.rating || 0,
+  shopMeta:
+    p.shop && p.shop.name
+      ? {
+          id: p.shop._id.toString(),
+          name: p.shop.name,
+          image: p.shop.image,
+          location: p.shop.location,
+        }
+      : undefined,
+});


### PR DESCRIPTION
## Summary
- add product normalization utility and enrich order responses with shop metadata
- support pagination and additional product fields on order and shop product APIs
- expose order detail endpoint for retrieving individual order info

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f4e8a16c8332a75bb9464292efb6