### PR TITLE
feat: add shop model

### DIFF
--- a/server/tests/shopModel.test.js
+++ b/server/tests/shopModel.test.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose');
+const { ShopModel } = require('../models/Shop');
+
+describe('Shop schema', () => {
+  it('validates required fields', async () => {
+    const shop = new ShopModel({ name: 'Test Shop', category: 'general' });
+    await expect(shop.validate()).rejects.toThrow();
+  });
+
+  it('autogenerates unique slug', async () => {
+    const spy = jest
+      .spyOn(ShopModel, 'exists')
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const shop = new ShopModel({
+      ownerId: new mongoose.Types.ObjectId(),
+      name: 'My Shop',
+      category: 'general',
+    });
+    await shop.validate();
+    expect(shop.slug).toBe('my-shop-1');
+    spy.mockRestore();
+  });
+
+  it('has geo 2dsphere index', () => {
+    const indexes = ShopModel.schema.indexes();
+    const geoIndex = indexes.find(([idx]) => idx.geo === '2dsphere');
+    expect(geoIndex).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add Shop model with address, geolocation, hours, and ratings
- ensure unique slugs and helpful indexes
- cover model with basic unit tests

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a404889b3c8332a55557088fcd460a