### PR TITLE
feat: add product inventory and variant schemas

### DIFF
--- a/server/models/Inventory.js
+++ b/server/models/Inventory.js
@@ -1,0 +1,38 @@
+const { Schema, model } = require('mongoose');
+
+const inventorySchema = new Schema(
+  {
+    productId: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+    variantId: { type: Schema.Types.ObjectId, ref: 'ProductVariant' },
+    stock: { type: Number, default: 0 },
+    threshold: { type: Number, default: 0 },
+    isInStock: { type: Boolean, default: true },
+  },
+  { timestamps: true }
+);
+
+inventorySchema.pre('save', function (next) {
+  this.isInStock = this.stock > this.threshold;
+  next();
+});
+
+inventorySchema.statics.adjustStock = async function (productId, variantId, delta) {
+  const query = { productId };
+  if (variantId) query.variantId = variantId;
+  const update = { $inc: { stock: delta } };
+  const options = { new: true, upsert: true };
+  const doc = await this.findOneAndUpdate(query, update, options);
+  if (doc) {
+    doc.isInStock = doc.stock > doc.threshold;
+    await doc.save();
+  }
+  return doc;
+};
+
+inventorySchema.index({ productId: 1 });
+inventorySchema.index({ productId: 1, variantId: 1 }, { unique: true });
+
+const InventoryModel = model('Inventory', inventorySchema);
+
+module.exports = { InventoryModel };
+

--- a/server/models/Inventory.ts
+++ b/server/models/Inventory.ts
@@ -1,0 +1,66 @@
+import { Schema, Document, model, Model } from 'mongoose';
+
+export interface InventoryAttrs {
+  productId: Schema.Types.ObjectId;
+  variantId?: Schema.Types.ObjectId;
+  stock: number;
+  threshold?: number;
+  isInStock?: boolean;
+}
+
+export interface InventoryDoc extends Document, InventoryAttrs {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface InventoryModel extends Model<InventoryDoc> {
+  adjustStock(
+    productId: Schema.Types.ObjectId,
+    variantId: Schema.Types.ObjectId | null,
+    delta: number
+  ): Promise<InventoryDoc | null>;
+}
+
+const inventorySchema = new Schema<InventoryDoc>(
+  {
+    productId: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+    variantId: { type: Schema.Types.ObjectId, ref: 'ProductVariant' },
+    stock: { type: Number, default: 0 },
+    threshold: { type: Number, default: 0 },
+    isInStock: { type: Boolean, default: true },
+  },
+  { timestamps: true }
+);
+
+inventorySchema.pre('save', function (next) {
+  this.isInStock = this.stock > this.threshold;
+  next();
+});
+
+inventorySchema.statics.adjustStock = async function (
+  productId: Schema.Types.ObjectId,
+  variantId: Schema.Types.ObjectId | null,
+  delta: number
+) {
+  const query: any = { productId };
+  if (variantId) query.variantId = variantId;
+  const update = { $inc: { stock: delta } };
+  const options = { new: true, upsert: true };
+  const doc = await this.findOneAndUpdate(query, update, options);
+  if (doc) {
+    doc.isInStock = doc.stock > doc.threshold;
+    await doc.save();
+  }
+  return doc;
+};
+
+inventorySchema.index({ productId: 1 });
+inventorySchema.index({ productId: 1, variantId: 1 }, { unique: true });
+
+export const InventoryModel = model<InventoryDoc, InventoryModel>(
+  'Inventory',
+  inventorySchema
+);
+
+export default InventoryModel;
+

--- a/server/models/ProductVariant.js
+++ b/server/models/ProductVariant.js
@@ -1,0 +1,20 @@
+const { Schema, model } = require('mongoose');
+
+const productVariantSchema = new Schema(
+  {
+    productId: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+    name: { type: String, required: true },
+    sku: { type: String, required: true, unique: true },
+    priceOverride: { type: Number },
+    mrpOverride: { type: Number },
+  },
+  { timestamps: true }
+);
+
+productVariantSchema.index({ productId: 1 });
+productVariantSchema.index({ sku: 1 }, { unique: true });
+
+const ProductVariantModel = model('ProductVariant', productVariantSchema);
+
+module.exports = { ProductVariantModel };
+

--- a/server/models/ProductVariant.ts
+++ b/server/models/ProductVariant.ts
@@ -1,0 +1,36 @@
+import { Schema, Document, model } from 'mongoose';
+
+export interface ProductVariantAttrs {
+  productId: Schema.Types.ObjectId;
+  name: string;
+  sku: string;
+  priceOverride?: number;
+  mrpOverride?: number;
+}
+
+export interface ProductVariantDoc extends Document, ProductVariantAttrs {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const productVariantSchema = new Schema<ProductVariantDoc>(
+  {
+    productId: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+    name: { type: String, required: true },
+    sku: { type: String, required: true, unique: true },
+    priceOverride: { type: Number },
+    mrpOverride: { type: Number },
+  },
+  { timestamps: true }
+);
+
+productVariantSchema.index({ productId: 1 });
+productVariantSchema.index({ sku: 1 }, { unique: true });
+
+export const ProductVariantModel = model<ProductVariantDoc>(
+  'ProductVariant',
+  productVariantSchema
+);
+
+export default ProductVariantModel;
+

--- a/server/tests/inventoryModel.test.js
+++ b/server/tests/inventoryModel.test.js
@@ -1,0 +1,39 @@
+const mongoose = require('mongoose');
+const { InventoryModel } = require('../models/Inventory');
+
+describe('Inventory schema', () => {
+  it('derives isInStock from stock and threshold', async () => {
+    const inv = new InventoryModel({
+      productId: new mongoose.Types.ObjectId(),
+      stock: 5,
+      threshold: 2,
+    });
+    await inv.validate();
+    expect(inv.isInStock).toBe(true);
+    inv.stock = 1;
+    await inv.validate();
+    expect(inv.isInStock).toBe(false);
+  });
+
+  it('adjustStock uses atomic $inc', async () => {
+    const spy = jest
+      .spyOn(InventoryModel, 'findOneAndUpdate')
+      .mockResolvedValue({ stock: 0, threshold: 0, save: jest.fn() });
+    await InventoryModel.adjustStock('pid', null, 3);
+    expect(spy).toHaveBeenCalledWith(
+      { productId: 'pid' },
+      { $inc: { stock: 3 } },
+      { new: true, upsert: true }
+    );
+    spy.mockRestore();
+  });
+
+  it('has compound unique index on productId and variantId', () => {
+    const indexes = InventoryModel.schema.indexes();
+    const compound = indexes.find(
+      ([idx, opts]) => idx.productId === 1 && idx.variantId === 1 && opts.unique
+    );
+    expect(compound).toBeDefined();
+  });
+});
+

--- a/server/tests/sampleSeed.test.js
+++ b/server/tests/sampleSeed.test.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+const { ProductModel } = require('../models/Product');
+const { seedSampleProducts } = require('../utils/seedSampleProducts');
+
+describe('Sample product seeder', () => {
+  it('creates 10 products per shop', async () => {
+    const spy = jest.spyOn(ProductModel, 'insertMany').mockResolvedValue([]);
+    const shopIds = [new mongoose.Types.ObjectId(), new mongoose.Types.ObjectId()];
+    await seedSampleProducts(shopIds);
+    expect(spy).toHaveBeenCalled();
+    const products = spy.mock.calls[0][0];
+    expect(products).toHaveLength(20);
+    const firstShopCount = products.filter(
+      (p) => p.shopId.toString() === shopIds[0].toString()
+    ).length;
+    expect(firstShopCount).toBe(10);
+    spy.mockRestore();
+  });
+});
+

--- a/server/utils/seedSampleProducts.js
+++ b/server/utils/seedSampleProducts.js
@@ -1,0 +1,25 @@
+const { ProductModel } = require('../models/Product');
+
+async function seedSampleProducts(shopIds, count = 10) {
+  const products = [];
+  for (const shopId of shopIds) {
+    for (let i = 0; i < count; i++) {
+      products.push({
+        shopId,
+        title: `Sample Product ${i + 1}`,
+        description: '',
+        images: [],
+        category: 'general',
+        tags: [],
+        ratingAvg: 0,
+        ratingCount: 0,
+        pricing: { mrp: 100, price: 90, currency: 'USD' },
+        status: 'active',
+      });
+    }
+  }
+  return ProductModel.insertMany(products);
+}
+
+module.exports = { seedSampleProducts };
+

--- a/server/utils/seedSampleProducts.ts
+++ b/server/utils/seedSampleProducts.ts
@@ -1,0 +1,29 @@
+import { Types } from 'mongoose';
+import { ProductModel, ProductAttrs } from '../models/Product';
+
+export async function seedSampleProducts(
+  shopIds: Types.ObjectId[],
+  count = 10
+) {
+  const products: Partial<ProductAttrs>[] = [];
+  for (const shopId of shopIds) {
+    for (let i = 0; i < count; i++) {
+      products.push({
+        shopId,
+        title: `Sample Product ${i + 1}`,
+        description: '',
+        images: [],
+        category: 'general',
+        tags: [],
+        ratingAvg: 0,
+        ratingCount: 0,
+        pricing: { mrp: 100, price: 90, currency: 'USD' },
+        status: 'active',
+      });
+    }
+  }
+  return ProductModel.insertMany(products);
+}
+
+export default seedSampleProducts;
+


### PR DESCRIPTION
## Summary
- add Product schema with media assets, pricing, and multiple indexes
- support ProductVariant and Inventory with atomic stock adjustment
- include utility to seed 10 sample products per shop

## Testing
- ⚠️ `npm test` *(fails: jest not found)*
- ⚠️ `npm install` *(fails: 403 Forbidden for jest package)*

------
https://chatgpt.com/codex/tasks/task_e_68a409b16de88332ab10269b5c2b40db