### PR TITLE
feat: add cart model with totals

### DIFF
--- a/server/tests/cartModel.test.js
+++ b/server/tests/cartModel.test.js
@@ -1,0 +1,68 @@
+const mongoose = require('mongoose');
+const { CartModel } = require('../models/Cart');
+
+describe('Cart schema', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(CartModel.prototype, 'save')
+      .mockImplementation(function () {
+        return this.validate().then(() => this);
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('upserts items and computes totals', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const productId = new mongoose.Types.ObjectId();
+    const findOne = jest
+      .spyOn(CartModel, 'findOne')
+      .mockResolvedValueOnce(null);
+
+    const cart1 = await CartModel.upsertItem(userId, {
+      productId,
+      qty: 2,
+      unitPrice: 10,
+      appliedDiscount: 1,
+    });
+    expect(cart1.items).toHaveLength(1);
+    expect(cart1.subtotal).toBe(20);
+    expect(cart1.discountTotal).toBe(1);
+    expect(cart1.grandTotal).toBe(19);
+
+    findOne.mockResolvedValueOnce(cart1);
+    const cart2 = await CartModel.upsertItem(userId, {
+      productId,
+      qty: 1,
+      unitPrice: 10,
+    });
+    expect(cart2.items[0].qty).toBe(3);
+    expect(cart2.subtotal).toBe(30);
+    expect(cart2.grandTotal).toBe(29);
+  });
+
+  it('removes items and recomputes totals', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const productId = new mongoose.Types.ObjectId();
+    const cart = new CartModel({
+      userId,
+      items: [{ productId, qty: 1, unitPrice: 10 }],
+    });
+    await cart.validate();
+    jest.spyOn(CartModel, 'findOne').mockResolvedValueOnce(cart);
+
+    const res = await CartModel.removeItem(userId, productId);
+    expect(res.items).toHaveLength(0);
+    expect(res.subtotal).toBe(0);
+    expect(res.grandTotal).toBe(0);
+  });
+
+  it('has userId index', () => {
+    const indexes = CartModel.schema.indexes();
+    const idx = indexes.find(([fields]) => fields.userId === 1);
+    expect(idx).toBeDefined();
+  });
+});
+

--- a/server/tests/cartSeed.test.js
+++ b/server/tests/cartSeed.test.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+const { seedSampleCarts } = require('../utils/seedSampleCarts');
+const { CartModel } = require('../models/Cart');
+
+describe('Sample cart seeder', () => {
+  it('creates carts for users with computed totals', async () => {
+    jest
+      .spyOn(CartModel.prototype, 'save')
+      .mockImplementation(function () {
+        return this.validate().then(() => this);
+      });
+    const userIds = [new mongoose.Types.ObjectId(), new mongoose.Types.ObjectId()];
+    const productId = new mongoose.Types.ObjectId();
+    const carts = await seedSampleCarts(userIds, productId);
+    expect(carts).toHaveLength(2);
+    expect(carts[0].grandTotal).toBe(100);
+  });
+});
+

--- a/server/utils/seedSampleCarts.js
+++ b/server/utils/seedSampleCarts.js
@@ -1,0 +1,18 @@
+const { CartModel } = require('../models/Cart');
+
+async function seedSampleCarts(userIds, productId) {
+  const carts = [];
+  for (const userId of userIds) {
+    const cart = new CartModel({
+      userId,
+      items: [{ productId, qty: 1, unitPrice: 100 }],
+      currency: 'USD',
+    });
+    await cart.save();
+    carts.push(cart);
+  }
+  return carts;
+}
+
+module.exports = { seedSampleCarts };
+

--- a/server/utils/seedSampleCarts.ts
+++ b/server/utils/seedSampleCarts.ts
@@ -1,0 +1,22 @@
+import { Types } from 'mongoose';
+import { CartModel, CartAttrs } from '../models/Cart';
+
+export async function seedSampleCarts(
+  userIds: Types.ObjectId[],
+  productId: Types.ObjectId
+) {
+  const carts: CartAttrs[] = [] as any;
+  for (const userId of userIds) {
+    const cart = new CartModel({
+      userId,
+      items: [{ productId, qty: 1, unitPrice: 100 }],
+      currency: 'USD',
+    } as Partial<CartAttrs>);
+    await cart.save();
+    carts.push(cart);
+  }
+  return carts;
+}
+
+export default seedSampleCarts;
+


### PR DESCRIPTION
## Summary
- add Cart model with item list and computed totals
- provide utilities for seeding sample carts
- cover cart upsert/remove and seeding with tests

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install --include=dev` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a40c0423c88332b46079b585607bac