### PR TITLE
feat: add order model

### DIFF
--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -1,31 +1,75 @@
-const mongoose = require("mongoose");
+const { Schema, model } = require('mongoose');
 
-const orderSchema = new mongoose.Schema(
+const orderItemSchema = new Schema(
   {
-    user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
-    business: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "User",
-      required: true,
-    },
-    product: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "Product",
-      required: true,
-    },
-    shop: { type: mongoose.Schema.Types.ObjectId, ref: "Shop", required: true },
-    quantity: { type: Number, default: 1 },
+    productId: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+    variantId: { type: Schema.Types.ObjectId, ref: 'ProductVariant' },
+    title: { type: String, required: true },
+    image: { type: String, required: true },
+    unitPrice: { type: Number, required: true },
+    qty: { type: Number, required: true },
+    total: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const pricingSchema = new Schema(
+  {
+    subtotal: { type: Number, required: true },
+    discountTotal: { type: Number, default: 0 },
+    grandTotal: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const contactAtAcceptanceSchema = new Schema(
+  {
+    buyerPhone: { type: String, required: true },
+    buyerName: { type: String, required: true },
+  },
+  { _id: false }
+);
+
+const paymentSchema = new Schema(
+  {
+    status: { type: String, default: 'pending' },
+    method: { type: String },
+    txnId: { type: String },
+  },
+  { _id: false }
+);
+
+const timelineSchema = new Schema(
+  {
+    placedAt: { type: Date, default: Date.now },
+    acceptedAt: { type: Date },
+    cancelledAt: { type: Date },
+    completedAt: { type: Date },
+  },
+  { _id: false }
+);
+
+const orderSchema = new Schema(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    shopId: { type: Schema.Types.ObjectId, ref: 'Shop', required: true },
+    items: { type: [orderItemSchema], required: true },
     status: {
       type: String,
-      enum: ["pending", "accepted", "rejected", "cancelled", "completed"],
-      default: "pending",
+      enum: ['pending', 'accepted', 'cancelled', 'completed'],
+      default: 'pending',
     },
-    createdAt: { type: Date, default: Date.now },
+    pricing: { type: pricingSchema, required: true },
+    contactAtAcceptance: { type: contactAtAcceptanceSchema },
+    payment: { type: paymentSchema, default: { status: 'pending' } },
+    timeline: { type: timelineSchema, required: true },
+    notes: { type: String },
   },
   { timestamps: true }
 );
 
-orderSchema.index({ status: 1 });
-orderSchema.index({ createdAt: -1 });
+orderSchema.index({ userId: 1, status: 1, createdAt: -1 });
+orderSchema.index({ shopId: 1, status: 1, createdAt: -1 });
 
-module.exports = mongoose.model("Order", orderSchema);
+module.exports = model('Order', orderSchema);
+

--- a/server/models/Order.ts
+++ b/server/models/Order.ts
@@ -1,0 +1,127 @@
+import { Schema, Document, model } from 'mongoose';
+
+export interface OrderItem {
+  productId: Schema.Types.ObjectId;
+  variantId?: Schema.Types.ObjectId;
+  title: string;
+  image: string;
+  unitPrice: number;
+  qty: number;
+  total: number;
+}
+
+const OrderItemSchema = new Schema<OrderItem>(
+  {
+    productId: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+    variantId: { type: Schema.Types.ObjectId, ref: 'ProductVariant' },
+    title: { type: String, required: true },
+    image: { type: String, required: true },
+    unitPrice: { type: Number, required: true },
+    qty: { type: Number, required: true },
+    total: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+export interface Pricing {
+  subtotal: number;
+  discountTotal: number;
+  grandTotal: number;
+}
+
+const PricingSchema = new Schema<Pricing>(
+  {
+    subtotal: { type: Number, required: true },
+    discountTotal: { type: Number, default: 0 },
+    grandTotal: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+export interface ContactAtAcceptance {
+  buyerPhone: string;
+  buyerName: string;
+}
+
+const ContactAtAcceptanceSchema = new Schema<ContactAtAcceptance>(
+  {
+    buyerPhone: { type: String, required: true },
+    buyerName: { type: String, required: true },
+  },
+  { _id: false }
+);
+
+export interface Payment {
+  status: string;
+  method?: string;
+  txnId?: string;
+}
+
+const PaymentSchema = new Schema<Payment>(
+  {
+    status: { type: String, default: 'pending' },
+    method: { type: String },
+    txnId: { type: String },
+  },
+  { _id: false }
+);
+
+export interface Timeline {
+  placedAt: Date;
+  acceptedAt?: Date;
+  cancelledAt?: Date;
+  completedAt?: Date;
+}
+
+const TimelineSchema = new Schema<Timeline>(
+  {
+    placedAt: { type: Date, default: Date.now },
+    acceptedAt: { type: Date },
+    cancelledAt: { type: Date },
+    completedAt: { type: Date },
+  },
+  { _id: false }
+);
+
+export interface OrderAttrs {
+  userId: Schema.Types.ObjectId;
+  shopId: Schema.Types.ObjectId;
+  items: OrderItem[];
+  status?: 'pending' | 'accepted' | 'cancelled' | 'completed';
+  pricing: Pricing;
+  contactAtAcceptance?: ContactAtAcceptance;
+  payment?: Payment;
+  timeline: Timeline;
+  notes?: string;
+}
+
+export interface OrderDoc extends Document, OrderAttrs {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const orderSchema = new Schema<OrderDoc>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    shopId: { type: Schema.Types.ObjectId, ref: 'Shop', required: true },
+    items: { type: [OrderItemSchema], required: true },
+    status: {
+      type: String,
+      enum: ['pending', 'accepted', 'cancelled', 'completed'],
+      default: 'pending',
+    },
+    pricing: { type: PricingSchema, required: true },
+    contactAtAcceptance: { type: ContactAtAcceptanceSchema },
+    payment: { type: PaymentSchema, default: { status: 'pending' } },
+    timeline: { type: TimelineSchema, required: true },
+    notes: { type: String },
+  },
+  { timestamps: true }
+);
+
+orderSchema.index({ userId: 1, status: 1, createdAt: -1 });
+orderSchema.index({ shopId: 1, status: 1, createdAt: -1 });
+
+export const OrderModel = model<OrderDoc>('Order', orderSchema);
+export default OrderModel;
+


### PR DESCRIPTION
## Summary
- implement comprehensive Order model with item, pricing, contact, payment, and timeline fields
- add compound indexes for efficient user and shop order queries

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4101c64248332af46853daab8d439