### PR TITLE
feat: add event and registration models

### DIFF
--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -1,39 +1,52 @@
-const mongoose = require("mongoose");
+const { Schema, model } = require('mongoose');
 
-const eventSchema = new mongoose.Schema(
-  {
-    title: { type: String, required: true },
-    startAt: { type: Date, required: true },
-    endAt: { type: Date, required: true },
-    capacity: { type: Number, required: true },
-    registeredUsers: [
-      { type: mongoose.Schema.Types.ObjectId, ref: "User" }
-    ]
-  },
-  { timestamps: true }
-);
+const coordinatesSchema = new Schema({
+  lat: { type: Number },
+  lng: { type: Number },
+}, { _id: false });
 
-function getStatus(e) {
+const locationSchema = new Schema({
+  type: { type: String, enum: ['online', 'venue'], required: true },
+  address: { type: String },
+  coordinates: { type: coordinatesSchema },
+}, { _id: false });
+
+function deriveStatus(e) {
+  if (e.status === 'cancelled') return 'cancelled';
   const now = new Date();
-  if (now < e.startAt) return "upcoming";
-  if (now > e.endAt) return "past";
-  return "ongoing";
+  if (now < e.startAt) return 'upcoming';
+  if (now >= e.startAt && now <= e.endAt) return 'active';
+  return 'ended';
 }
 
-eventSchema.virtual("status").get(function () {
-  return getStatus(this);
+const eventSchema = new Schema({
+  title: { type: String, required: true },
+  slug: { type: String, required: true, unique: true },
+  coverUrl: { type: String },
+  description: { type: String, default: '' },
+  category: { type: String, enum: ['gaming', 'sports', 'quiz', 'culture'], required: true },
+  startAt: { type: Date, required: true },
+  endAt: { type: Date, required: true },
+  registrationClosesAt: { type: Date, required: true },
+  status: { type: String, enum: ['upcoming', 'active', 'ended', 'cancelled'], default: 'upcoming' },
+  capacity: { type: Number, required: true },
+  registeredCount: { type: Number, default: 0 },
+  organizerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  location: { type: locationSchema, required: true },
+  isDeleted: { type: Boolean, default: false },
+}, { timestamps: true });
+
+eventSchema.pre('validate', function(next) {
+  if (this.status !== 'cancelled') {
+    this.status = deriveStatus(this);
+  }
+  next();
 });
 
-eventSchema.virtual("registered").get(function () {
-  return this.registeredUsers.length;
-});
+eventSchema.index({ slug: 1 }, { unique: true });
+eventSchema.index({ status: 1, startAt: -1 });
+eventSchema.index({ category: 1, startAt: -1 });
 
-// include virtuals when converting to JSON
-// eslint-disable-next-line func-names
-if (!eventSchema.options.toJSON) eventSchema.options.toJSON = {};
-// eslint-disable-next-line func-names
-if (!eventSchema.options.toObject) eventSchema.options.toObject = {};
-eventSchema.options.toJSON.virtuals = true;
-eventSchema.options.toObject.virtuals = true;
+const EventModel = model('Event', eventSchema);
 
-module.exports = mongoose.model("Event", eventSchema);
+module.exports = { EventModel };

--- a/server/models/Event.ts
+++ b/server/models/Event.ts
@@ -1,0 +1,99 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export enum EventCategory {
+  GAMING = 'gaming',
+  SPORTS = 'sports',
+  QUIZ = 'quiz',
+  CULTURE = 'culture',
+}
+
+export enum EventStatus {
+  UPCOMING = 'upcoming',
+  ACTIVE = 'active',
+  ENDED = 'ended',
+  CANCELLED = 'cancelled',
+}
+
+interface Coordinates {
+  lat: number;
+  lng: number;
+}
+
+interface Location {
+  type: 'online' | 'venue';
+  address?: string;
+  coordinates?: Coordinates;
+}
+
+const CoordinatesSchema = new Schema<Coordinates>({
+  lat: { type: Number },
+  lng: { type: Number },
+}, { _id: false });
+
+const LocationSchema = new Schema<Location>({
+  type: { type: String, enum: ['online', 'venue'], required: true },
+  address: { type: String },
+  coordinates: { type: CoordinatesSchema },
+}, { _id: false });
+
+export interface EventAttrs {
+  title: string;
+  slug: string;
+  coverUrl?: string;
+  description?: string;
+  category: EventCategory;
+  startAt: Date;
+  endAt: Date;
+  registrationClosesAt: Date;
+  status?: EventStatus;
+  capacity: number;
+  registeredCount?: number;
+  organizerId: Types.ObjectId;
+  location: Location;
+  isDeleted?: boolean;
+}
+
+export interface EventDoc extends Document<EventAttrs>, EventAttrs {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function deriveStatus(e: EventAttrs): EventStatus {
+  if (e.status === EventStatus.CANCELLED) return EventStatus.CANCELLED;
+  const now = new Date();
+  if (now < e.startAt) return EventStatus.UPCOMING;
+  if (now >= e.startAt && now <= e.endAt) return EventStatus.ACTIVE;
+  return EventStatus.ENDED;
+}
+
+const eventSchema = new Schema<EventDoc>({
+  title: { type: String, required: true },
+  slug: { type: String, required: true, unique: true },
+  coverUrl: { type: String },
+  description: { type: String, default: '' },
+  category: { type: String, enum: Object.values(EventCategory), required: true },
+  startAt: { type: Date, required: true },
+  endAt: { type: Date, required: true },
+  registrationClosesAt: { type: Date, required: true },
+  status: { type: String, enum: Object.values(EventStatus), default: EventStatus.UPCOMING },
+  capacity: { type: Number, required: true },
+  registeredCount: { type: Number, default: 0 },
+  organizerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  location: { type: LocationSchema, required: true },
+  isDeleted: { type: Boolean, default: false },
+}, { timestamps: true });
+
+eventSchema.pre('validate', function(next) {
+  if (this.status !== EventStatus.CANCELLED) {
+    this.status = deriveStatus(this);
+  }
+  next();
+});
+
+eventSchema.index({ slug: 1 }, { unique: true });
+eventSchema.index({ status: 1, startAt: -1 });
+eventSchema.index({ category: 1, startAt: -1 });
+
+export const EventModel = model<EventDoc>('Event', eventSchema);
+
+export default EventModel;

--- a/server/models/Registration.js
+++ b/server/models/Registration.js
@@ -1,0 +1,50 @@
+const { Schema, model } = require('mongoose');
+const { EventModel } = require('./Event');
+
+const registrationSchema = new Schema({
+  eventId: { type: Schema.Types.ObjectId, ref: 'Event', required: true },
+  userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  status: { type: String, enum: ['pending', 'approved', 'rejected'], default: 'pending' },
+  registeredAt: { type: Date, default: Date.now },
+  approvedAt: { type: Date },
+}, { timestamps: true });
+
+registrationSchema.index({ eventId: 1, userId: 1 }, { unique: true });
+
+registrationSchema.pre('save', async function(next) {
+  this.wasNew = this.isNew;
+  if (!this.isNew) {
+    const existing = await this.constructor.findById(this._id).select('status');
+    this.prevStatus = existing ? existing.status : undefined;
+  }
+  if (this.isModified('status') && this.status === 'approved' && !this.approvedAt) {
+    this.approvedAt = new Date();
+  }
+  next();
+});
+
+registrationSchema.post('save', async function(doc, next) {
+  let inc = 0;
+  const prev = this.prevStatus;
+  if (this.wasNew) {
+    if (doc.status === 'approved') inc = 1;
+  } else if (prev !== doc.status) {
+    if (prev !== 'approved' && doc.status === 'approved') inc = 1;
+    else if (prev === 'approved' && doc.status !== 'approved') inc = -1;
+  }
+  if (inc !== 0) {
+    await EventModel.findByIdAndUpdate(doc.eventId, { $inc: { registeredCount: inc } });
+  }
+  next();
+});
+
+registrationSchema.post('findOneAndDelete', async function(doc, next) {
+  if (doc && doc.status === 'approved') {
+    await EventModel.findByIdAndUpdate(doc.eventId, { $inc: { registeredCount: -1 } });
+  }
+  next();
+});
+
+const RegistrationModel = model('Registration', registrationSchema);
+
+module.exports = { RegistrationModel };

--- a/server/models/Registration.ts
+++ b/server/models/Registration.ts
@@ -1,0 +1,69 @@
+import { Schema, model, Document, Types } from 'mongoose';
+import { EventModel } from './Event';
+
+export enum RegistrationStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+}
+
+export interface RegistrationAttrs {
+  eventId: Types.ObjectId;
+  userId: Types.ObjectId;
+  status?: RegistrationStatus;
+  registeredAt?: Date;
+  approvedAt?: Date;
+}
+
+export interface RegistrationDoc extends Document<RegistrationAttrs>, RegistrationAttrs {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const registrationSchema = new Schema<RegistrationDoc>({
+  eventId: { type: Schema.Types.ObjectId, ref: 'Event', required: true },
+  userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  status: { type: String, enum: Object.values(RegistrationStatus), default: RegistrationStatus.PENDING },
+  registeredAt: { type: Date, default: Date.now },
+  approvedAt: { type: Date },
+}, { timestamps: true });
+
+registrationSchema.index({ eventId: 1, userId: 1 }, { unique: true });
+
+registrationSchema.pre('save', async function(next) {
+  this.$locals.wasNew = this.isNew;
+  if (!this.isNew) {
+    const existing = await (this.constructor as any).findById(this._id).select('status');
+    this.$locals.prevStatus = existing ? existing.status : undefined;
+  }
+  if (this.isModified('status') && this.status === RegistrationStatus.APPROVED && !this.approvedAt) {
+    this.approvedAt = new Date();
+  }
+  next();
+});
+
+registrationSchema.post('save', async function(doc, next) {
+  let inc = 0;
+  const prev = this.$locals.prevStatus;
+  if (this.$locals.wasNew) {
+    if (doc.status === RegistrationStatus.APPROVED) inc = 1;
+  } else if (prev !== doc.status) {
+    if (prev !== RegistrationStatus.APPROVED && doc.status === RegistrationStatus.APPROVED) inc = 1;
+    else if (prev === RegistrationStatus.APPROVED && doc.status !== RegistrationStatus.APPROVED) inc = -1;
+  }
+  if (inc !== 0) {
+    await EventModel.findByIdAndUpdate(doc.eventId, { $inc: { registeredCount: inc } });
+  }
+  next();
+});
+
+registrationSchema.post('findOneAndDelete', async function(doc, next) {
+  if (doc && doc.status === RegistrationStatus.APPROVED) {
+    await EventModel.findByIdAndUpdate(doc.eventId, { $inc: { registeredCount: -1 } });
+  }
+  next();
+});
+
+export const RegistrationModel = model<RegistrationDoc>('Registration', registrationSchema);
+
+export default RegistrationModel;

--- a/server/tests/eventRegistrationModel.test.js
+++ b/server/tests/eventRegistrationModel.test.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose');
+const { EventModel } = require('../models/Event');
+const { RegistrationModel } = require('../models/Registration');
+
+describe('Event and Registration schemas', () => {
+  it('derives status and has required indexes', async () => {
+    const now = new Date();
+    const event = new EventModel({
+      title: 'Sample Event',
+      slug: 'sample-event',
+      category: 'gaming',
+      startAt: new Date(now.getTime() - 1000),
+      endAt: new Date(now.getTime() + 1000),
+      registrationClosesAt: now,
+      capacity: 50,
+      organizerId: new mongoose.Types.ObjectId(),
+      location: { type: 'online' },
+    });
+    await event.validate();
+    expect(event.status).toBe('active');
+    const indexes = EventModel.schema.indexes();
+    const slugIndex = indexes.find(([idx]) => idx.slug === 1);
+    const statusIndex = indexes.find(([idx]) => idx.status === 1 && idx.startAt === -1);
+    const categoryIndex = indexes.find(([idx]) => idx.category === 1 && idx.startAt === -1);
+    expect(slugIndex).toBeDefined();
+    expect(statusIndex).toBeDefined();
+    expect(categoryIndex).toBeDefined();
+  });
+
+  it('has compound unique index and defaults for registration', async () => {
+    const reg = new RegistrationModel({
+      eventId: new mongoose.Types.ObjectId(),
+      userId: new mongoose.Types.ObjectId(),
+    });
+    await reg.validate();
+    expect(reg.status).toBe('pending');
+    const indexes = RegistrationModel.schema.indexes();
+    const compound = indexes.find(([idx, opts]) => idx.eventId === 1 && idx.userId === 1 && opts.unique);
+    expect(compound).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- define comprehensive Event model with location, status derivation and indexes
- add Registration model with approval tracking and registration count maintenance
- cover Event and Registration schema behaviours with tests

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4122fb870833289a846717147063e