### PR TITLE
feat: add verification and business request models

### DIFF
--- a/server/models/BusinessRequest.ts
+++ b/server/models/BusinessRequest.ts
@@ -1,0 +1,46 @@
+import { Schema, Document, model } from 'mongoose';
+import { ShopAttrs } from './Shop';
+
+export enum BusinessRequestStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+}
+
+export interface BusinessRequestAttrs {
+  userId: Schema.Types.ObjectId;
+  shopDraft?: Partial<ShopAttrs>;
+  status: BusinessRequestStatus;
+  adminNotes?: string;
+}
+
+export interface BusinessRequestDoc
+  extends Document,
+    BusinessRequestAttrs {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const businessRequestSchema = new Schema<BusinessRequestDoc>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    shopDraft: { type: Schema.Types.Mixed },
+    status: {
+      type: String,
+      enum: Object.values(BusinessRequestStatus),
+      default: BusinessRequestStatus.PENDING,
+    },
+    adminNotes: { type: String },
+  },
+  { timestamps: true }
+);
+
+businessRequestSchema.index({ userId: 1, status: 1, createdAt: -1 });
+
+export const BusinessRequestModel = model<BusinessRequestDoc>(
+  'BusinessRequest',
+  businessRequestSchema
+);
+
+export default BusinessRequestModel;
+

--- a/server/models/VerificationRequest.ts
+++ b/server/models/VerificationRequest.ts
@@ -1,0 +1,47 @@
+import { Schema, Document, model } from 'mongoose';
+
+export enum VerificationRequestStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+}
+
+export interface VerificationRequestAttrs {
+  userId: Schema.Types.ObjectId;
+  profession: string;
+  bio?: string;
+  status: VerificationRequestStatus;
+  adminNotes?: string;
+}
+
+export interface VerificationRequestDoc
+  extends Document,
+    VerificationRequestAttrs {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const verificationRequestSchema = new Schema<VerificationRequestDoc>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    profession: { type: String, required: true },
+    bio: { type: String, default: '' },
+    status: {
+      type: String,
+      enum: Object.values(VerificationRequestStatus),
+      default: VerificationRequestStatus.PENDING,
+    },
+    adminNotes: { type: String },
+  },
+  { timestamps: true }
+);
+
+verificationRequestSchema.index({ userId: 1, status: 1, createdAt: -1 });
+
+export const VerificationRequestModel = model<VerificationRequestDoc>(
+  'VerificationRequest',
+  verificationRequestSchema
+);
+
+export default VerificationRequestModel;
+


### PR DESCRIPTION
## Summary
- add VerificationRequest schema for tracking verification applications
- add BusinessRequest schema for onboarding shops with optional draft data

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4153d61248332b75ca89b7f3e054a