### PR TITLE
Add Review model with subject-type rating indices

### DIFF
--- a/server/models/Review.js
+++ b/server/models/Review.js
@@ -1,0 +1,19 @@
+const { Schema, model } = require('mongoose');
+
+const reviewSchema = new Schema(
+  {
+    subjectType: { type: String, enum: ['shop', 'product', 'professional'], required: true },
+    subjectId: { type: Schema.Types.ObjectId, required: true },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    rating: { type: Number, required: true, min: 1, max: 5 },
+    comment: { type: String, default: '' },
+  },
+  { timestamps: true }
+);
+
+reviewSchema.index({ subjectType: 1, subjectId: 1, rating: -1 });
+
+const ReviewModel = model('Review', reviewSchema);
+
+module.exports = { ReviewModel };
+

--- a/server/models/Review.ts
+++ b/server/models/Review.ts
@@ -1,0 +1,32 @@
+import { Schema, Document, model } from 'mongoose';
+
+export interface ReviewAttrs {
+  subjectType: 'shop' | 'product' | 'professional';
+  subjectId: Schema.Types.ObjectId;
+  userId: Schema.Types.ObjectId;
+  rating: number;
+  comment?: string;
+}
+
+export interface ReviewDoc extends Document, ReviewAttrs {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const reviewSchema = new Schema<ReviewDoc>(
+  {
+    subjectType: { type: String, enum: ['shop', 'product', 'professional'], required: true },
+    subjectId: { type: Schema.Types.ObjectId, required: true },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    rating: { type: Number, required: true, min: 1, max: 5 },
+    comment: { type: String, default: '' },
+  },
+  { timestamps: true }
+);
+
+reviewSchema.index({ subjectType: 1, subjectId: 1, rating: -1 });
+
+export const ReviewModel = model<ReviewDoc>('Review', reviewSchema);
+
+export default ReviewModel;
+


### PR DESCRIPTION
## Summary
- add Review schema for shops, products and professionals
- include rating, comment and timestamps
- index reviews by subject and rating

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a41ace0698833281b4eb2f0aac0835