### PR TITLE
feat: add migrations and seed scripts

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "jest",
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "seed": "ts-node scripts/seed/dev.ts"
   },
   "keywords": [],
   "author": "",
@@ -24,6 +25,8 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.3"
   }
 }

--- a/server/scripts/migrate/backfill-slugs.ts
+++ b/server/scripts/migrate/backfill-slugs.ts
@@ -1,0 +1,39 @@
+import mongoose from 'mongoose';
+import ShopModel from '../../models/Shop';
+import ProductModel from '../../models/Product';
+import EventModel from '../../models/Event';
+import { generateSlug } from '../../utils/slug';
+
+async function backfillSlugs() {
+  const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/manacity';
+  await mongoose.connect(uri);
+
+  const tasks = [
+    { model: ShopModel, field: 'name' as const },
+    { model: ProductModel, field: 'title' as const },
+    { model: EventModel, field: 'title' as const },
+  ];
+
+  for (const { model, field } of tasks) {
+    const docs = await model.find({ $or: [ { slug: { $exists: false } }, { slug: '' } ] });
+    if (!docs.length) continue;
+    for (const doc of docs) {
+      const base = (doc as any)[field];
+      if (!base) continue;
+      (doc as any).slug = await generateSlug(model as any, base);
+      await doc.save();
+    }
+  }
+
+  await mongoose.disconnect();
+}
+
+backfillSlugs()
+  .then(() => {
+    console.log('Slug backfill completed');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('Slug backfill failed', err);
+    process.exit(1);
+  });

--- a/server/scripts/migrate/create-indexes.ts
+++ b/server/scripts/migrate/create-indexes.ts
@@ -1,0 +1,33 @@
+import mongoose from 'mongoose';
+import ShopModel from '../../models/Shop';
+import ProductModel from '../../models/Product';
+import EventModel from '../../models/Event';
+import OrderModel from '../../models/Order';
+import UserModel from '../../models/User';
+import NotificationModel from '../../models/Notification';
+
+async function createIndexes() {
+  const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/manacity';
+  await mongoose.connect(uri);
+
+  await Promise.all([
+    ShopModel.syncIndexes(),
+    ProductModel.syncIndexes(),
+    EventModel.syncIndexes(),
+    OrderModel.syncIndexes(),
+    UserModel.syncIndexes(),
+    NotificationModel.syncIndexes(),
+  ]);
+
+  await mongoose.disconnect();
+}
+
+createIndexes()
+  .then(() => {
+    console.log('Index creation completed');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('Index creation failed', err);
+    process.exit(1);
+  });

--- a/server/scripts/migrate/normalize-statuses.ts
+++ b/server/scripts/migrate/normalize-statuses.ts
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+import NotificationModel from '../../models/Notification';
+
+async function normalizeStatuses() {
+  const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/manacity';
+  await mongoose.connect(uri);
+
+  await NotificationModel.updateMany(
+    { type: 'interest' },
+    { $set: { type: 'order' } }
+  );
+
+  await mongoose.disconnect();
+}
+
+normalizeStatuses()
+  .then(() => {
+    console.log('Status normalization completed');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('Status normalization failed', err);
+    process.exit(1);
+  });

--- a/server/scripts/seed/dev.ts
+++ b/server/scripts/seed/dev.ts
@@ -1,0 +1,102 @@
+import mongoose from 'mongoose';
+import ShopModel from '../../models/Shop';
+import ProductModel from '../../models/Product';
+import EventModel, { EventCategory } from '../../models/Event';
+import UserModel, { Role, VerificationStatus, BusinessStatus } from '../../models/User';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const VerifiedUser = require('../../models/VerifiedUser');
+
+async function seed() {
+  const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/manacity';
+  await mongoose.connect(uri);
+
+  // Clean database for deterministic seeds
+  await mongoose.connection.db.dropDatabase();
+
+  const cityNames = ['Alpha', 'Beta'];
+  const shopOwners: any[] = [];
+
+  // Create shops and products
+  for (let i = 0; i < cityNames.length * 5; i++) {
+    const city = cityNames[Math.floor(i / 5)];
+    const owner = await UserModel.create({
+      phone: `+15000000${i}`,
+      name: `Owner ${i}`,
+      roles: [Role.BUSINESS],
+      verificationStatus: VerificationStatus.VERIFIED,
+      businessStatus: BusinessStatus.ACTIVE,
+      location: { city, pincode: `1000${i}` },
+      auth: { passwordHash: `hash${i}` },
+    });
+    shopOwners.push(owner);
+    const shop = await ShopModel.create({
+      ownerId: owner._id,
+      name: `Shop ${i}`,
+      category: 'general',
+      address: {
+        label: 'Main',
+        line1: 'Street 1',
+        city,
+        state: 'State',
+        pincode: `1000${i}`,
+        isDefault: true,
+      },
+    });
+    for (let p = 0; p < 10; p++) {
+      await ProductModel.create({
+        shopId: shop._id,
+        title: `Product ${p} of Shop ${i}`,
+        category: 'misc',
+        pricing: { mrp: 100, price: 90, currency: 'USD' },
+      });
+    }
+  }
+
+  // Events
+  const organizer = shopOwners[0];
+  for (let e = 0; e < 3; e++) {
+    const start = new Date();
+    const end = new Date(start.getTime() + 3600000);
+    await EventModel.create({
+      title: `Event ${e}`,
+      category: EventCategory.CULTURE,
+      startAt: start,
+      endAt: end,
+      registrationClosesAt: start,
+      capacity: 100,
+      organizerId: organizer._id,
+      location: { type: 'online' },
+    });
+  }
+
+  // Verified professionals
+  for (let i = 0; i < 10; i++) {
+    const city = cityNames[i % cityNames.length];
+    const user = await UserModel.create({
+      phone: `+16000000${i}`,
+      name: `Pro ${i}`,
+      roles: [Role.VERIFIED],
+      verificationStatus: VerificationStatus.VERIFIED,
+      location: { city, pincode: `2000${i}` },
+      auth: { passwordHash: `prohash${i}` },
+    });
+    await VerifiedUser.create({
+      user: user._id,
+      profession: `Profession ${i}`,
+      bio: 'Experienced professional',
+      status: 'approved',
+    });
+  }
+
+  await mongoose.disconnect();
+}
+
+seed()
+  .then(() => {
+    console.log('Seeding completed');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('Seeding failed', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- backfill slugs for shops, products, and events
- normalize interest statuses to order
- ensure collection indexes are created
- seed development database with sample data and script

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run seed` *(fails: sh: 1: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4250a9c64833296ef75eed1651025