### PR TITLE
test: add unit and integration tests

### DIFF
--- a/server/tests/eventIntegration.test.ts
+++ b/server/tests/eventIntegration.test.ts
@@ -1,0 +1,42 @@
+import Event from '../models/Event';
+import { getAllEvents, registerForEvent } from '../controllers/eventController';
+
+describe('event flows', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('lists only upcoming events when requested', async () => {
+    const events: any[] = [];
+    const cursor: any = Promise.resolve(events);
+    cursor.sort = jest.fn().mockReturnThis();
+    cursor.skip = jest.fn().mockReturnThis();
+    cursor.limit = jest.fn().mockResolvedValue(events);
+    jest.spyOn(Event, 'find').mockReturnValue(cursor);
+    jest.spyOn(Event, 'countDocuments').mockResolvedValue(0);
+
+    const req: any = { query: { status: 'upcoming', page: '1', pageSize: '10' } };
+    const json = jest.fn();
+    await getAllEvents(req, { json } as any);
+    expect(Event.find).toHaveBeenCalledWith({ startAt: { $gt: expect.any(Date) } });
+    expect(json).toHaveBeenCalledWith({ items: events, total: 0 });
+  });
+
+  it('registers for event', async () => {
+    const save = jest.fn();
+    const event: any = {
+      _id: 'e1',
+      registeredUsers: [],
+      capacity: 10,
+      startAt: new Date(Date.now() + 60_000),
+      save,
+    };
+    jest.spyOn(Event, 'findById').mockResolvedValue(event);
+    const req: any = { params: { id: 'e1' }, user: { _id: 'u1' } };
+    const json = jest.fn();
+    await registerForEvent(req, { json } as any);
+    expect(save).toHaveBeenCalled();
+    expect(event.registeredUsers).toContain('u1');
+    expect(json).toHaveBeenCalledWith({ message: 'Registered successfully' });
+  });
+});

--- a/server/tests/eventStatusTransitions.test.ts
+++ b/server/tests/eventStatusTransitions.test.ts
@@ -1,0 +1,51 @@
+import mongoose from 'mongoose';
+import { EventModel, EventStatus } from '../models/Event';
+
+describe('event status transitions', () => {
+  const now = new Date();
+  const base = {
+    title: 'Test',
+    category: 'gaming',
+    registrationClosesAt: now,
+    capacity: 10,
+    organizerId: new mongoose.Types.ObjectId(),
+    location: { type: 'online' },
+  };
+
+  it('sets upcoming, active and ended based on time', async () => {
+    const upcoming = new EventModel({
+      ...base,
+      startAt: new Date(now.getTime() + 60_000),
+      endAt: new Date(now.getTime() + 120_000),
+    });
+    await upcoming.validate();
+    expect(upcoming.status).toBe(EventStatus.UPCOMING);
+
+    const active = new EventModel({
+      ...base,
+      startAt: new Date(now.getTime() - 60_000),
+      endAt: new Date(now.getTime() + 60_000),
+    });
+    await active.validate();
+    expect(active.status).toBe(EventStatus.ACTIVE);
+
+    const ended = new EventModel({
+      ...base,
+      startAt: new Date(now.getTime() - 120_000),
+      endAt: new Date(now.getTime() - 60_000),
+    });
+    await ended.validate();
+    expect(ended.status).toBe(EventStatus.ENDED);
+  });
+
+  it('keeps cancelled status', async () => {
+    const cancelled = new EventModel({
+      ...base,
+      startAt: new Date(now.getTime() - 120_000),
+      endAt: new Date(now.getTime() + 120_000),
+      status: EventStatus.CANCELLED,
+    });
+    await cancelled.validate();
+    expect(cancelled.status).toBe(EventStatus.CANCELLED);
+  });
+});

--- a/server/tests/orderIntegration.test.ts
+++ b/server/tests/orderIntegration.test.ts
@@ -1,0 +1,79 @@
+import Order from '../models/Order';
+import { getMyOrders, getReceivedOrders, acceptOrder } from '../controllers/orderController';
+import { normalizeProduct } from '../utils/normalize';
+
+jest.mock('../utils/normalize', () => ({
+  normalizeProduct: jest.fn((p) => p),
+}));
+
+describe('order flows', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('filters orders and hides phone until accepted', async () => {
+    const orders = [
+      {
+        status: 'pending',
+        user: { name: 'Alice', phone: '111' },
+        product: { name: 'Apple', price: 10 },
+        toObject() { return this; },
+      },
+      {
+        status: 'accepted',
+        user: { name: 'Bob', phone: '222' },
+        product: { name: 'Banana', price: 20 },
+        toObject() { return this; },
+      },
+    ];
+    const query: any = Promise.resolve(orders);
+    query.populate = jest.fn().mockReturnThis();
+    query.where = jest.fn().mockReturnThis();
+    query.equals = jest.fn().mockReturnThis();
+    query.skip = jest.fn().mockReturnThis();
+    query.limit = jest.fn().mockReturnThis();
+    jest.spyOn(Order, 'find').mockReturnValue(query);
+
+    const req: any = { user: { _id: 'u1' }, query: {} };
+    const json = jest.fn();
+    await getReceivedOrders(req, { json } as any);
+    const result = json.mock.calls[0][0];
+    expect(result[0].user.phone).toBeUndefined();
+    expect(result[1].user.phone).toBe('222');
+  });
+
+  it('filters my orders by status', async () => {
+    const orders = [
+      { status: 'pending', shop: { name: 'Shop A' }, product: {}, toObject() { return this; } },
+    ];
+    const query: any = Promise.resolve(orders);
+    query.populate = jest.fn().mockReturnThis();
+    query.where = jest.fn().mockReturnThis();
+    query.equals = jest.fn().mockReturnThis();
+    query.skip = jest.fn().mockReturnThis();
+    query.limit = jest.fn().mockReturnThis();
+    jest.spyOn(Order, 'find').mockReturnValue(query);
+
+    const req: any = { user: { _id: 'u1' }, query: { status: 'pending' } };
+    const json = jest.fn();
+    await getMyOrders(req, { json } as any);
+    expect(Order.find).toHaveBeenCalledWith({ user: 'u1' });
+    expect(query.where).toHaveBeenCalledWith('status');
+    expect(query.equals).toHaveBeenCalledWith('pending');
+  });
+
+  it('reveals phone on accept', async () => {
+    const order: any = {
+      business: 'b1',
+      user: { name: 'Bob', phone: '999' },
+      status: 'pending',
+      save: jest.fn(),
+    };
+    jest.spyOn(Order, 'findById').mockResolvedValue(order);
+    const req: any = { params: { id: 'o1' }, user: { _id: 'b1' } };
+    const json = jest.fn();
+    await acceptOrder(req, { json } as any);
+    expect(order.status).toBe('accepted');
+    expect(json).toHaveBeenCalledWith(order);
+  });
+});

--- a/server/tests/paginationHelper.test.ts
+++ b/server/tests/paginationHelper.test.ts
@@ -1,0 +1,33 @@
+import { parsePagination, applyPagination, PaginationOptions } from '../utils/pagination';
+
+describe('pagination helper', () => {
+  it('parses pagination query with sorting', () => {
+    const opts = parsePagination({ page: '2', limit: '5', sort: '-createdAt,ratingAvg' });
+    expect(opts.page).toBe(2);
+    expect(opts.limit).toBe(5);
+    expect(opts.skip).toBe(5);
+    expect(opts.sort).toEqual({ createdAt: -1, ratingAvg: 1 });
+  });
+
+  it('applies pagination to mongoose query', () => {
+    const skip = jest.fn().mockReturnThis();
+    const limit = jest.fn().mockReturnThis();
+    const sort = jest.fn().mockReturnThis();
+    const lean = jest.fn().mockReturnThis();
+    const select = jest.fn().mockReturnThis();
+    const query: any = { skip, limit, sort, lean, select };
+    const options: PaginationOptions = {
+      page: 1,
+      limit: 2,
+      skip: 0,
+      sort: { createdAt: -1 },
+      lean: true,
+    } as any;
+    applyPagination(query, options, { name: 1 });
+    expect(skip).toHaveBeenCalledWith(0);
+    expect(limit).toHaveBeenCalledWith(2);
+    expect(sort).toHaveBeenCalledWith({ createdAt: -1 });
+    expect(lean).toHaveBeenCalled();
+    expect(select).toHaveBeenCalledWith({ name: 1 });
+  });
+});

--- a/server/tests/registrationIntegration.test.ts
+++ b/server/tests/registrationIntegration.test.ts
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose';
+import { RegistrationModel, RegistrationStatus } from '../models/Registration';
+import { EventModel } from '../models/Event';
+
+describe('registration approve flow', () => {
+  it('updates event registered count on approval changes', async () => {
+    const eventId = new mongoose.Types.ObjectId();
+    const spy = jest.spyOn(EventModel, 'findByIdAndUpdate').mockResolvedValue(null as any);
+
+    const reg: any = new RegistrationModel({ eventId, userId: new mongoose.Types.ObjectId(), status: RegistrationStatus.APPROVED });
+    reg.$locals = { wasNew: true };
+    const hook = (RegistrationModel as any).schema.s.hooks._posts.get('save')[0].fn;
+    await hook.call(reg, reg, () => {});
+    expect(spy).toHaveBeenCalledWith(eventId, { $inc: { registeredCount: 1 } });
+
+    spy.mockClear();
+    reg.$locals = { wasNew: false, prevStatus: RegistrationStatus.APPROVED };
+    reg.status = RegistrationStatus.PENDING;
+    await hook.call(reg, reg, () => {});
+    expect(spy).toHaveBeenCalledWith(eventId, { $inc: { registeredCount: -1 } });
+  });
+});

--- a/server/tests/shopIntegration.test.ts
+++ b/server/tests/shopIntegration.test.ts
@@ -1,0 +1,75 @@
+import { getAllShops, getProductsByShop } from '../controllers/shopController';
+import Shop from '../models/Shop';
+import Product from '../models/Product';
+import { normalizeProduct } from '../utils/normalize';
+
+jest.mock('../utils/normalize', () => ({
+  normalizeProduct: jest.fn((p) => p),
+}));
+
+describe('shop flows', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('lists shops with filters, sort and pagination', async () => {
+    const createdAt = new Date();
+    const items = [
+      {
+        _id: '1',
+        name: 'Alpha',
+        ownerName: 'Owner',
+        category: 'general',
+        location: 'City',
+        status: 'approved',
+        productsCount: 2,
+        createdAt,
+      },
+    ];
+    const aggregate = jest
+      .spyOn(Shop, 'aggregate')
+      .mockResolvedValueOnce(items)
+      .mockResolvedValueOnce([{ total: 1 }]);
+
+    const req: any = {
+      query: { q: 'Alpha', status: 'active', page: '1', pageSize: '10', sort: '-createdAt' },
+    };
+    const json = jest.fn();
+    await getAllShops(req, { json } as any);
+    expect(aggregate).toHaveBeenCalledTimes(2);
+    expect(json).toHaveBeenCalledWith({
+      items: [
+        {
+          id: '1',
+          _id: '1',
+          name: 'Alpha',
+          owner: 'Owner',
+          category: 'general',
+          location: 'City',
+          status: 'active',
+          productsCount: 2,
+          createdAt,
+        },
+      ],
+      total: 1,
+    });
+  });
+
+  it('queries products for shop with pagination', async () => {
+    const products = [
+      { _id: 'p1', name: 'Prod', shop: { _id: 's1', name: 'Alpha', image: '', location: 'City' } },
+    ];
+    const query: any = Promise.resolve(products);
+    query.populate = jest.fn().mockReturnThis();
+    query.skip = jest.fn().mockReturnThis();
+    query.limit = jest.fn().mockResolvedValue(products);
+    jest.spyOn(Product, 'find').mockReturnValue(query);
+
+    const req: any = { params: { id: 's1' }, query: { page: '2', limit: '1' } };
+    const json = jest.fn();
+    await getProductsByShop(req, { json } as any);
+    expect(query.skip).toHaveBeenCalledWith(1);
+    expect(query.limit).toHaveBeenCalledWith(1);
+    expect(json).toHaveBeenCalledWith(products);
+  });
+});

--- a/server/tests/slugUtil.test.ts
+++ b/server/tests/slugUtil.test.ts
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose';
+import { slugify, generateSlug } from '../utils/slug';
+
+describe('slug utilities', () => {
+  it('slugify converts text to slug', () => {
+    expect(slugify(' Hello World! ')).toBe('hello-world');
+  });
+
+  it('generateSlug appends increment when slug exists', async () => {
+    const exists = jest
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const model = { exists } as unknown as mongoose.Model<any>;
+    const slug = await generateSlug(model, 'Test Value');
+    expect(slug).toBe('test-value-1');
+    expect(exists).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for slug utilities and pagination helper
- cover event status transitions
- exercise shop listing, product listing, order flows, and event registration

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a546500d7c8332949d44099ec68801