### PR TITLE
Fix notification and verification request typings

### DIFF
--- a/client/src/pages/Notifications/Notifications.tsx
+++ b/client/src/pages/Notifications/Notifications.tsx
@@ -133,14 +133,13 @@ const Notifications = () => {
               {items.map((n) => (
                 <NotificationCard
                   key={n._id}
-                  icon={n.image}
                   title={n.title}
-                  message={n.message}
+                  message={n.body}
                   timestamp={n.createdAt}
                   read={n.isRead}
-                  ctaLabel={n.link ? 'View' : undefined}
-                  onClick={() => n.link && navigate(n.link)}
-                  onCtaClick={() => n.link && navigate(n.link)}
+                  ctaLabel={n.cta?.label}
+                  onClick={() => n.cta && navigate(n.cta.href)}
+                  onCtaClick={() => n.cta && navigate(n.cta.href)}
                   onSwipeLeft={() => handleMarkRead(n._id)}
                 />
               ))}

--- a/client/src/pages/VerificationRequests/VerificationRequests.tsx
+++ b/client/src/pages/VerificationRequests/VerificationRequests.tsx
@@ -19,7 +19,11 @@ interface Request {
   createdAt: string;
 }
 
-type RequestRow = Request & { actions?: string };
+type RequestRow = Request & {
+  name: string;
+  phone: string;
+  actions?: string;
+};
 
 interface RequestResponse {
   requests: Request[];
@@ -103,9 +107,15 @@ const VerificationRequests = () => {
     }
   };
 
+  const rows: RequestRow[] = requests.map((r) => ({
+    ...r,
+    name: r.user.name,
+    phone: r.user.phone,
+  }));
+
   const columns: Column<RequestRow>[] = [
-    { key: 'name', label: 'Name', render: (r) => r.user.name },
-    { key: 'phone', label: 'Phone', render: (r) => r.user.phone },
+    { key: 'name', label: 'Name' },
+    { key: 'phone', label: 'Phone' },
     { key: 'profession', label: 'Profession' },
     { key: 'bio', label: 'Bio' },
     {
@@ -163,9 +173,9 @@ const VerificationRequests = () => {
       </div>
       <DataTable<RequestRow>
         columns={columns}
-        rows={requests as RequestRow[]}
+        rows={rows}
         page={page}
-        pageSize={requests.length || 1}
+        pageSize={rows.length || 1}
         total={total}
         onPageChange={changePage}
         loading={loading}


### PR DESCRIPTION
## Summary
- Use notification body and CTA fields when rendering notifications
- Flatten verification request user data for DataTable columns

## Testing
- `npm run lint`
- `npm run build`
- `npm test` (server) *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a558a71fa08332b06df312286e05b0