### PR TITLE
Restore original API URL in client env files

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,4 +1,4 @@
-VITE_API_URL=http://localhost:5000/api
+VITE_API_URL=https://manacity4-0.onrender.com/api
 VITE_FIREBASE_API_KEY=AIza...
 VITE_FIREBASE_AUTH_DOMAIN=mana-city-98fa0.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=mana-city-98fa0

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,4 +1,4 @@
-VITE_API_URL=http://localhost:5000/api
+VITE_API_URL=https://manacity4-0.onrender.com/api
 VITE_FIREBASE_API_KEY=AIza...
 VITE_FIREBASE_AUTH_DOMAIN=mana-city-98fa0.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=mana-city-98fa0

--- a/client/README.md
+++ b/client/README.md
@@ -5,7 +5,7 @@
 Copy `.env.example` to `.env` and fill in your Firebase project settings:
 
 ```
-VITE_API_URL=http://localhost:5000/api
+VITE_API_URL=https://manacity4-0.onrender.com/api
 VITE_FIREBASE_API_KEY=AIza...
 VITE_FIREBASE_AUTH_DOMAIN=mana-city-98fa0.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=mana-city-98fa0


### PR DESCRIPTION
## Summary
- revert VITE_API_URL to https://manacity4-0.onrender.com/api in client .env and .env.example
- update README instructions to reference the original API URL

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase)*
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase-admin)*

------
https://chatgpt.com/codex/tasks/task_e_68a58843163c8332a8d9883feccef87b