### PR TITLE
feat: add zod validation middleware

### DIFF
--- a/server/src/middleware/validate.ts
+++ b/server/src/middleware/validate.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodSchema, ZodError } from 'zod';
+import AppError from '../utils/AppError';
+
+type Source = 'body' | 'query' | 'params';
+
+const validate = (schema: ZodSchema, source: Source = 'body') => {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    try {
+      req[source] = schema.parse(req[source]);
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const fieldErrors: Record<string, string> = {};
+        error.errors.forEach((issue) => {
+          const field = issue.path.join('.');
+          fieldErrors[field] = issue.message;
+        });
+        throw AppError.unprocessable('VALIDATION_ERROR', 'Invalid input', fieldErrors);
+      }
+      next(error);
+    }
+  };
+};
+
+export default validate;


### PR DESCRIPTION
## Summary
- add TypeScript validation middleware using Zod
- raise AppError with detailed field messages on validation failure

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6accf801083329fa0013aa2380ea1