### PR TITLE
feat: add request context middleware

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,16 +19,17 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
+    "firebase-admin": "^12.0.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.14.1",
-    "zod": "^3.23.8",
-    "firebase-admin": "^12.0.0"
+    "pino": "^9.0.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "jest": "^29.7.0",
     "nodemon": "^3.1.10",
+    "supertest": "^7.1.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.3",
-    "supertest": "^7.1.1"
+    "typescript": "^5.4.3"
   }
 }

--- a/server/src/middleware/context.ts
+++ b/server/src/middleware/context.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from 'crypto';
+import { Request, Response, NextFunction } from 'express';
+import pino from 'pino';
+
+const logger = pino();
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    traceId: string;
+    log: pino.Logger;
+  }
+}
+
+const context = (req: Request, res: Response, next: NextFunction): void => {
+  const traceId = randomUUID();
+  req.traceId = traceId;
+  req.log = logger.child({ traceId });
+
+  req.log.info({ method: req.method, path: req.path }, 'request start');
+
+  res.on('finish', () => {
+    req.log.info({ status: res.statusCode }, 'request end');
+  });
+
+  next();
+};
+
+export default context;


### PR DESCRIPTION
## Summary
- add middleware that assigns trace IDs and initializes per-request logger
- include pino in server dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b11521348332bc3a5bb4b5f4c108