### PR TITLE
feat(server): add global error middleware

### DIFF
--- a/server/src/middleware/error.ts
+++ b/server/src/middleware/error.ts
@@ -1,0 +1,57 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodError } from 'zod';
+import AppError from '../utils/AppError';
+
+const error = (
+  err: unknown,
+  req: Request,
+  res: Response,
+  _next: NextFunction
+): void => {
+  if (err instanceof AppError) {
+    const { statusCode, code, message, details, fieldErrors } = err;
+    res.status(statusCode).json({
+      success: false,
+      error: {
+        code,
+        message,
+        ...(details && { details }),
+        ...(fieldErrors && { fieldErrors }),
+      },
+      traceId: req.traceId,
+    });
+    return;
+  }
+
+  if ((err as { name?: string }).name === 'ZodError') {
+    const zodError = err as ZodError;
+    const fieldErrors: Record<string, string> = {};
+    zodError.errors.forEach((issue) => {
+      const field = issue.path.join('.');
+      fieldErrors[field] = issue.message;
+    });
+    res.status(422).json({
+      success: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid input',
+        fieldErrors,
+      },
+      traceId: req.traceId,
+    });
+    return;
+  }
+
+  req.log.error(err);
+
+  res.status(500).json({
+    success: false,
+    error: {
+      code: 'INTERNAL_ERROR',
+      message: 'Something went wrong',
+    },
+    traceId: req.traceId,
+  });
+};
+
+export default error;


### PR DESCRIPTION
## Summary
- add centralized Express error handler returning consistent JSON and trace IDs

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b24ca3ec8332be5dcd34a5d1579c