### PR TITLE
refactor: use AppError and validation

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,10 +1,11 @@
 const User = require("../models/User");
+const AppError = require("../utils/AppError");
 
 exports.getProfile = async (req, res) => {
   res.status(200).json({ user: req.user });
 };
 
-exports.updateProfile = async (req, res) => {
+exports.updateProfile = async (req, res, next) => {
   try {
     const { name, location, address } = req.body;
 
@@ -30,7 +31,7 @@ exports.updateProfile = async (req, res) => {
       },
     });
   } catch (err) {
-    res.status(500).json({ error: "Failed to update profile" });
+    next(AppError.internal('PROFILE_UPDATE_FAILED', 'Failed to update profile'));
   }
 };
 

--- a/server/utils/AppError.js
+++ b/server/utils/AppError.js
@@ -1,0 +1,38 @@
+class AppError extends Error {
+  constructor(statusCode, code, message, options = {}) {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+    this.message = message;
+    if (options.details) {
+      this.details = options.details;
+    }
+    if (options.fieldErrors) {
+      this.fieldErrors = options.fieldErrors;
+    }
+    Object.setPrototypeOf(this, new.target.prototype);
+    Error.captureStackTrace?.(this, AppError);
+  }
+  static badRequest(code = 'BAD_REQUEST', message = 'Bad request', details) {
+    return new AppError(400, code, message, { details });
+  }
+  static unauthorized(code = 'UNAUTHORIZED', message = 'Unauthorized', details) {
+    return new AppError(401, code, message, { details });
+  }
+  static forbidden(code = 'FORBIDDEN', message = 'Forbidden', details) {
+    return new AppError(403, code, message, { details });
+  }
+  static notFound(code = 'NOT_FOUND', message = 'Not found', details) {
+    return new AppError(404, code, message, { details });
+  }
+  static conflict(code = 'CONFLICT', message = 'Conflict', details) {
+    return new AppError(409, code, message, { details });
+  }
+  static unprocessable(code = 'VALIDATION_ERROR', message = 'Invalid input', fieldErrors) {
+    return new AppError(422, code, message, { fieldErrors });
+  }
+  static internal(code = 'INTERNAL_ERROR', message = 'Something went wrong') {
+    return new AppError(500, code, message);
+  }
+}
+module.exports = AppError;


### PR DESCRIPTION
## Summary
- add AppError utility for structured errors
- update validate middleware to leverage AppError and forward errors
- refactor auth, user, and cart controllers to throw AppError and propagate via next

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b543e9a88332b71cd2eef8c10001