### PR TITLE
Handle unknown API routes with JSON 404

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ const orderRoutes = require("./routes/orderRoutes");
 const adminRoutes = require("./routes/adminRoutes");
 const productRoutes = require("./routes/productRoutes");
 const adminUserRoutes = require("./routes/adminUserRoutes");
+const AppError = require("./utils/AppError");
 
 const app = express();
 app.use(cors());
@@ -34,6 +35,10 @@ app.use("/api/orders", orderRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/products", productRoutes);
 app.use("/api/users", adminUserRoutes);
+
+app.use('/api', (_req, _res, next) =>
+  next(AppError.notFound('ROUTE_NOT_FOUND', 'API route not found'))
+);
 
 mongoose
   .connect(process.env.MONGO_URI)


### PR DESCRIPTION
## Summary
- import AppError and add catch-all `/api` middleware to return `ROUTE_NOT_FOUND` JSON errors

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b7d3539483328fc63c2d80e8e9c2