### PR TITLE
chore: enforce middleware order and error handling

### DIFF
--- a/server/middleware/context.js
+++ b/server/middleware/context.js
@@ -1,0 +1,18 @@
+const { randomUUID } = require('crypto');
+const pino = require('pino');
+
+const logger = pino();
+
+module.exports = (req, res, next) => {
+  const traceId = randomUUID();
+  req.traceId = traceId;
+  req.log = logger.child({ traceId });
+
+  req.log.info({ method: req.method, path: req.path }, 'request start');
+
+  res.on('finish', () => {
+    req.log.info({ status: res.statusCode }, 'request end');
+  });
+
+  next();
+};

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -1,0 +1,47 @@
+const { ZodError } = require('zod');
+const AppError = require('../utils/AppError');
+
+module.exports = (err, req, res, _next) => {
+  if (err instanceof AppError) {
+    const { statusCode, code, message, details, fieldErrors } = err;
+    res.status(statusCode).json({
+      success: false,
+      error: {
+        code,
+        message,
+        ...(details && { details }),
+        ...(fieldErrors && { fieldErrors }),
+      },
+      traceId: req.traceId,
+    });
+    return;
+  }
+
+  if (err instanceof ZodError) {
+    const fieldErrors = {};
+    err.errors.forEach((issue) => {
+      const field = issue.path.join('.');
+      fieldErrors[field] = issue.message;
+    });
+    res.status(422).json({
+      success: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid input',
+        fieldErrors,
+      },
+      traceId: req.traceId,
+    });
+    return;
+  }
+
+  req.log?.error(err);
+  res.status(500).json({
+    success: false,
+    error: {
+      code: 'INTERNAL_ERROR',
+      message: 'Something went wrong',
+    },
+    traceId: req.traceId,
+  });
+};


### PR DESCRIPTION
## Summary
- add request context middleware with pino logging
- serve built client after API routes and include SPA fallback
- finalize error handling middleware for API and validation errors

## Testing
- `npm test` (failed: jest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a6bda093e88332a4f46e05faecfc24