### PR TITLE
Fix Firebase private key parsing

### DIFF
--- a/server/lib/firebaseAdmin.js
+++ b/server/lib/firebaseAdmin.js
@@ -2,7 +2,9 @@ const admin = require('firebase-admin');
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-const privateKey = process.env.FIREBASE_PRIVATE_KEY && process.env.FIREBASE_PRIVATE_KEY.replace(/\n/g, '\n');
+const privateKey = process.env.FIREBASE_PRIVATE_KEY
+  ? process.env.FIREBASE_PRIVATE_KEY.split('\\n').join('\n')
+  : undefined;
 
 if (!admin.apps.length) {
   admin.initializeApp({


### PR DESCRIPTION
## Summary
- ensure Firebase admin uses correctly formatted private key when newlines are escaped

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for firebase-admin)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cf4cdffc8332b5b456396d76604f