### PR TITLE
Use env vars for Firebase admin credentials

### DIFF
--- a/server/lib/firebaseAdmin.js
+++ b/server/lib/firebaseAdmin.js
@@ -1,14 +1,14 @@
 const admin = require('firebase-admin');
 
 const serviceAccount = {
-  projectId: 'mana-city-98fa0',
-  clientEmail: 'firebase-adminsdk@mana-city-98fa0.iam.gserviceaccount.com',
-  privateKey: `-----BEGIN PRIVATE KEY-----\nFAKEPRIVATEKEY\n-----END PRIVATE KEY-----\n`
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+  privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
 };
 
 if (!admin.apps.length) {
   admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount)
+    credential: admin.credential.cert(serviceAccount),
   });
 }
 


### PR DESCRIPTION
## Summary
- Read Firebase project details from environment variables instead of hard-coded values
- Normalize private key newlines for Firebase Admin initialization

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase-admin)*

------
https://chatgpt.com/codex/tasks/task_e_68a97042080c8332b657a31a576c77a7