### PR TITLE
Guard Firebase initialization to prevent duplicate app error

### DIFF
--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -1,7 +1,7 @@
-import { initializeApp } from "firebase/app";
+import { initializeApp, getApp, getApps } from "firebase/app";
 import { getAuth, RecaptchaVerifier, signInWithPhoneNumber } from "firebase/auth";
 
-const app = initializeApp({
+const firebaseConfig = {
   apiKey: "AIza...",
   authDomain: "mana-city-98fa0.firebaseapp.com",
   projectId: "mana-city-98fa0",
@@ -9,7 +9,10 @@ const app = initializeApp({
   messagingSenderId: "1011241089335",
   appId: "1:1011241089335:web:2ba85628781c7af1f502b2",
   measurementId: "G-JMXQCQ7FC8"
-});
+};
+
+// Avoid initializing Firebase multiple times in development (e.g. hot reload)
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
 


### PR DESCRIPTION
## Summary
- Avoid initializing Firebase multiple times in client by checking existing apps

## Testing
- `npm run lint --prefix client` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a974ad040083329651fb63894c50e8