### PR TITLE
feat: add phone-based OTP authentication

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,7 @@ const Signup = lazy(() => import('./pages/auth/Signup/Signup'));
 const OTP = lazy(() => import('./pages/auth/OTP/OTP'));
 const ForgotPassword = lazy(() => import('./pages/auth/ForgotPassword/ForgotPassword'));
 const SetNewPassword = lazy(() => import('./pages/auth/SetNewPassword/SetNewPassword'));
+const PhoneAuth = lazy(() => import('./pages/auth/PhoneAuth/PhoneAuth'));
 const Profile = lazy(() => import('./pages/Profile/Profile'));
 const Home = lazy(() => import('./pages/Home/Home'));
 const Shops = lazy(() => import('./pages/Shops/Shops'));
@@ -74,6 +75,7 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/otp" element={<OTP />} />
+        <Route path="/phone-auth" element={<PhoneAuth />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/set-new-password" element={<SetNewPassword />} />
         <Route path="/admin/login" element={<AdminLogin />} />

--- a/client/src/pages/auth/PhoneAuth/PhoneAuth.scss
+++ b/client/src/pages/auth/PhoneAuth/PhoneAuth.scss
@@ -1,0 +1,28 @@
+.phone-auth-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 320px;
+  padding: 2rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background-color: #fff;
+}
+
+.form-card input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.form-card .btn {
+  margin-top: 0.5rem;
+}

--- a/client/src/pages/auth/PhoneAuth/PhoneAuth.tsx
+++ b/client/src/pages/auth/PhoneAuth/PhoneAuth.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { motion } from 'framer-motion';
+import { createInvisibleRecaptcha, sendOtpToPhone, verifyOtpCode } from '../../../lib/firebase';
+import { loginSuccess, setOtpVerified, addPhoneNumber } from '../../../store/slices/authSlice';
+import type { AppDispatch, RootState } from '../../../store';
+import showToast from '../../../components/ui/Toast';
+import Loader from '../../../components/Loader';
+import './PhoneAuth.scss';
+
+const PhoneAuth = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const { user } = useSelector((state: RootState) => state.auth);
+  const [phone, setPhone] = useState('');
+  const [otp, setOtp] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [showOtpInput, setShowOtpInput] = useState(false);
+
+  useEffect(() => {
+    createInvisibleRecaptcha('recaptcha-container');
+  }, []);
+
+  const handleSendOtp = async () => {
+    if (!/^\d{10}$/.test(phone)) {
+      showToast('Enter a valid phone number', 'error');
+      return;
+    }
+    try {
+      setLoading(true);
+      const phoneE164 = `+91${phone}`;
+      dispatch(addPhoneNumber(phoneE164));
+      await sendOtpToPhone(phoneE164);
+      showToast(`OTP sent to ${phoneE164}`, 'success');
+      setShowOtpInput(true);
+    } catch (err: any) {
+      showToast(err?.message || 'Failed to send OTP', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerifyOtp = async () => {
+    if (otp.length !== 6) return;
+    try {
+      setLoading(true);
+      await verifyOtpCode(otp);
+      dispatch(loginSuccess({ phone: `+91${phone}` }));
+      dispatch(setOtpVerified(true));
+      showToast('OTP verified successfully', 'success');
+    } catch (err: any) {
+      showToast(err?.message || 'Invalid OTP', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="phone-auth-page">
+      <div id="recaptcha-container" />
+      {!user && (
+        <motion.div
+          className="form-card"
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7 }}
+        >
+          {!showOtpInput ? (
+            <>
+              <h2>Sign in with Phone</h2>
+              <label>
+                Phone Number
+                <input type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} />
+              </label>
+              <motion.button
+                className="btn btn-primary"
+                onClick={handleSendOtp}
+                disabled={loading}
+                whileHover={{ scale: 1.04 }}
+                whileTap={{ scale: 0.96 }}
+              >
+                {loading ? <Loader /> : 'Send OTP'}
+              </motion.button>
+            </>
+          ) : (
+            <>
+              <h2>Enter OTP</h2>
+              <label>
+                6-digit Code
+                <input type="text" value={otp} maxLength={6} onChange={(e) => setOtp(e.target.value.replace(/\D/g, ''))} />
+              </label>
+              <motion.button
+                className="btn btn-primary"
+                onClick={handleVerifyOtp}
+                disabled={loading}
+                whileHover={{ scale: 1.04 }}
+                whileTap={{ scale: 0.96 }}
+              >
+                {loading ? <Loader /> : 'Verify OTP'}
+              </motion.button>
+            </>
+          )}
+        </motion.div>
+      )}
+    </div>
+  );
+};
+
+export default PhoneAuth;

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -4,6 +4,7 @@ import cartReducer from './slices/cartSlice';
 import productReducer from './slices/productSlice';
 import settingsReducer from './slices/settingsSlice';
 import adminReducer from './slices/adminSlice';
+import authReducer from './slices/authSlice';
 
 export const store = configureStore({
   reducer: {
@@ -12,6 +13,7 @@ export const store = configureStore({
     products: productReducer,
     settings: settingsReducer,
     admin: adminReducer,
+    auth: authReducer,
   },
 });
 

--- a/client/src/store/slices/authSlice.ts
+++ b/client/src/store/slices/authSlice.ts
@@ -1,0 +1,37 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export interface AuthState {
+  user: any | null;
+  phone: string | null;
+  otpVerified: boolean;
+}
+
+const initialState: AuthState = {
+  user: JSON.parse(localStorage.getItem('user') || 'null'),
+  phone: null,
+  otpVerified: false,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    loginSuccess(state, action: PayloadAction<any>) {
+      state.user = action.payload;
+      localStorage.setItem('user', JSON.stringify(action.payload));
+    },
+    logoutSuccess(state) {
+      state.user = null;
+      localStorage.removeItem('user');
+    },
+    setOtpVerified(state, action: PayloadAction<boolean>) {
+      state.otpVerified = action.payload;
+    },
+    addPhoneNumber(state, action: PayloadAction<string | null>) {
+      state.phone = action.payload;
+    },
+  },
+});
+
+export const { loginSuccess, logoutSuccess, setOtpVerified, addPhoneNumber } = authSlice.actions;
+export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- add Redux auth slice for tracking phone-based login state
- implement PhoneAuth page with Firebase OTP flow
- wire new auth slice and route into app store and router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9795e330c833290b89afb7fdac02a