### PR TITLE
fix: standardize firebase phone OTP with recaptcha v2

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -15,6 +15,23 @@ VITE_FIREBASE_APP_ID=1:1011241089335:web:2ba85628781c7af1f502b2
 VITE_FIREBASE_MEASUREMENT_ID=G-JMXQCQ7FC8
 ```
 
+## Firebase Phone Auth prerequisites
+
+Before OTP can be sent from the client, ensure the Firebase project is configured:
+
+1. **Authentication → Sign-in method**
+   - Enable the **Phone** provider.
+   - Disable **reCAPTCHA Enterprise** for Web so the default reCAPTCHA v2 is used.
+2. **Authentication → Settings → Authorized domains**
+   - Add `localhost`, `127.0.0.1` and `manacity4-0-1.onrender.com`.
+3. **Project settings → General**
+   - Confirm the Web API key here matches the one in the client.
+4. **Google Cloud Console → APIs & Services**
+   - Ensure **Identity Toolkit API** is enabled.
+   - If the API key is restricted by HTTP referrer, allow:
+     - `http://localhost:5173/*`
+     - `https://manacity4-0-1.onrender.com/*`
+
 ## OTP flow
 
 **Signup**

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import { setUser } from './store/slices/userSlice';
 import { setAdminToken } from './store/slices/adminSlice';
 import type { AppDispatch } from './store';
 import Loader from './components/Loader';
+import { ensureInvisibleRecaptcha } from './lib/firebase';
 
 const Landing = lazy(() => import('./pages/Landing/Landing'));
 const Login = lazy(() => import('./pages/auth/Login/Login'));
@@ -65,6 +66,8 @@ function App() {
     if (adminToken) {
       dispatch(setAdminToken(adminToken));
     }
+
+    ensureInvisibleRecaptcha('recaptcha-container');
   }, [dispatch]);
 
   return (

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -22,6 +22,11 @@ export async function verifyOtp(payload: { phone: string; otp: string }): Promis
   await api.post('/auth/verify-otp', payload);
 }
 
+export async function verifyFirebase(payload: { idToken: string; purpose: string; signupDraft?: SignupDraft }): Promise<any> {
+  const res = await api.post('/auth/verify-firebase', payload);
+  return res.data;
+}
+
 export async function login(creds: Credentials): Promise<UserState> {
   const res = await api.post('/auth/login', creds);
   const { token, user } = res.data.data;

--- a/client/src/lib/firebaseErrors.ts
+++ b/client/src/lib/firebaseErrors.ts
@@ -1,15 +1,17 @@
 export function mapFirebaseError(code: string): string {
   switch (code) {
-    case 'auth/too-many-requests':
-      return 'Too many attempts. Please try again later.';
     case 'auth/invalid-phone-number':
-      return 'Please enter a valid phone number in international format.';
+      return 'Enter a valid phone number with country code (e.g., +91…).';
+    case 'auth/too-many-requests':
+      return 'Too many attempts. Try again in a few minutes.';
+    case 'auth/quota-exceeded':
+      return 'OTP quota exceeded. Try later.';
     case 'auth/code-expired':
-      return 'Code expired. Request a new one.';
-    case 'auth/network-request-failed':
-      return 'Network error. Please check your connection.';
+      return 'Code expired. Request a new OTP.';
     case 'auth/invalid-verification-code':
       return 'Invalid code. Please try again.';
+    case 'auth/network-request-failed':
+      return 'Network error. Please check your connection.';
     default:
       return 'Something went wrong. Please try again.';
   }


### PR DESCRIPTION
## Summary
- use invisible reCAPTCHA v2 for phone auth and expose helper utilities
- add user-friendly Firebase error mapping and integrate OTP helpers in signup/OTP flows
- document Firebase Phone Auth prerequisites

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden fetching firebase package)*
- `npm run build` *(fails: Cannot find module '@reduxjs/toolkit')*

------
https://chatgpt.com/codex/tasks/task_e_68b7e8ce81a88332812b595b1406f6af