### PR TITLE
fix: update wildcard routes for express 5

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -32,7 +32,7 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options("*", cors(corsOptions));
+app.options("/*", cors(corsOptions));
 app.use(express.json());
 app.use(context);
 
@@ -57,7 +57,7 @@ app.use("/api", (_req, _res, next) =>
 if (process.env.NODE_ENV === "production") {
   const clientPath = path.join(__dirname, "..", "client", "dist");
   app.use(express.static(clientPath));
-  app.get("*", (_req, res) => {
+  app.get("/*", (_req, res) => {
     res.sendFile(path.join(clientPath, "index.html"));
   });
 }


### PR DESCRIPTION
## Summary
- fix wildcard options and get routes to match Express 5's path-to-regexp syntax

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b82c7217d0833296b07998c32cfbcf