### PR TITLE
fix: update wildcard routes for express 5

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -32,7 +32,7 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options("/*", cors(corsOptions));
+app.options("*", cors(corsOptions));
 app.use(express.json());
 app.use(context);
 
@@ -57,7 +57,7 @@ app.use("/api", (_req, _res, next) =>
 if (process.env.NODE_ENV === "production") {
   const clientPath = path.join(__dirname, "..", "client", "dist");
   app.use(express.static(clientPath));
-  app.get("/*", (_req, res) => {
+  app.get("*", (_req, res) => {
     res.sendFile(path.join(clientPath, "index.html"));
   });
 }


### PR DESCRIPTION
## Summary
- replace path `/*` with `*` for CORS preflight handler
- serve SPA with `app.get('*')` to avoid path-to-regexp errors

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase-admin)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b82e51284c8332b7172109f25f9982