### PR TITLE
fix: handle wildcard routes in production

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -59,7 +59,7 @@ app.use("/api", (_req, _res, next) =>
 if (process.env.NODE_ENV === "production") {
   const clientPath = path.join(__dirname, "..", "client", "dist");
   app.use(express.static(clientPath));
-  app.get("*", (_req, res) => {
+  app.use((_req, res) => {
     res.sendFile(path.join(clientPath, "index.html"));
   });
 }


### PR DESCRIPTION
## Summary
- replace deprecated `app.get("*")` wildcard route with catch-all middleware to serve `index.html`

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b923fa1ce4833288cabefaf365030e