### PR TITLE
refactor: add Twilio OTP service wrapper

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -25,10 +25,15 @@ const AppError = require("./utils/AppError");
 
 const app = express();
 
+const allowedOrigins = [
+  'http://localhost:5173',
+  'https://manacity4-0-1.onrender.com',
+];
+
 const corsOptions = {
-  origin: process.env.CLIENT_URL || "http://localhost:5173",
-  methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "Authorization"],
+  origin: allowedOrigins,
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
   credentials: true,
 };
 

--- a/server/src/services/twilio.js
+++ b/server/src/services/twilio.js
@@ -1,0 +1,24 @@
+const twilio = require('twilio');
+
+const {
+  TWILIO_ACCOUNT_SID,
+  TWILIO_AUTH_TOKEN,
+  TWILIO_VERIFY_SERVICE_SID,
+  DEFAULT_COUNTRY_CODE = '+91',
+} = process.env;
+
+if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_VERIFY_SERVICE_SID) {
+  throw new Error('Twilio env vars missing');
+}
+
+const client = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+const verifyServiceSid = TWILIO_VERIFY_SERVICE_SID;
+
+const toE164 = (raw) => {
+  const trimmed = (raw || '').replace(/\s+/g, '');
+  if (!trimmed) return trimmed;
+  if (trimmed.startsWith('+')) return trimmed;
+  return `${DEFAULT_COUNTRY_CODE}${trimmed}`;
+};
+
+module.exports = { client, verifyServiceSid, toE164 };


### PR DESCRIPTION
## Summary
- centralize Twilio Verify configuration and phone normalization in a new service
- refactor OTP routes to use Twilio service for send and verify flows
- allow local and production frontend origins in CORS config

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9405c48288332a1d888cb46b8b8d4