### PR TITLE
Fix route patterns incompatible with Express 5

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -38,7 +38,7 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options("/(.*)", cors(corsOptions));
+app.options('*', cors(corsOptions));
 app.use(express.json());
 app.use(context);
 
@@ -57,14 +57,14 @@ app.use("/api/admin", adminRoutes);
 app.use("/api/products", productRoutes);
 app.use("/api/users", adminUserRoutes);
 
-app.use("/api/(.*)", (_req, _res, next) =>
+app.use('/api/*', (_req, _res, next) =>
   next(AppError.notFound("ROUTE_NOT_FOUND", "API route not found"))
 );
 
 if (process.env.NODE_ENV === "production") {
   const clientPath = path.join(__dirname, "..", "client", "dist");
   app.use(express.static(clientPath));
-  app.get("/(.*)", (_req, res) => {
+  app.get('*', (_req, res) => {
     res.sendFile(path.join(clientPath, "index.html"));
   });
 }


### PR DESCRIPTION
## Summary
- replace regex-style route strings with wildcard paths to avoid path-to-regexp errors in Express 5

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install --no-fund --no-audit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjsonwebtoken)*

------
https://chatgpt.com/codex/tasks/task_e_68b950c503348332a1256388d9cc9d01