### PR TITLE
fix: update wildcard routes for express 5

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -37,7 +37,7 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options("/(.*)", cors(corsOptions));
+app.options("*", cors(corsOptions));
 app.use(express.json());
 app.use(context);
 
@@ -55,14 +55,14 @@ app.use("/api/admin", adminRoutes);
 app.use("/api/products", productRoutes);
 app.use("/api/users", adminUserRoutes);
 
-app.use("/api/(.*)", (_req, _res, next) =>
+app.use("/api/*", (_req, _res, next) =>
   next(AppError.notFound("ROUTE_NOT_FOUND", "API route not found"))
 );
 
 if (process.env.NODE_ENV === "production") {
   const clientPath = path.join(__dirname, "..", "client", "dist");
   app.use(express.static(clientPath));
-  app.get("/(.*)", (_req, res) => {
+  app.get("*", (_req, res) => {
     res.sendFile(path.join(clientPath, "index.html"));
   });
 }


### PR DESCRIPTION
## Summary
- update wildcard route patterns for Express 5 compatibility

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjsonwebtoken)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4b4356f88332b23a87ee704a476a