### PR TITLE
Remove email from auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Create a `.env` inside the `server` directory with:
 ## Signup & Login
 
 - **Signup**: `POST /api/auth/signup`
-  - Body: `{ name, phone?, email?, password, location, role? }`
+  - Body: `{ name, phone, password, location, role? }`
 - **Login**: `POST /api/auth/login`
-  - Body: `{ phone? | email?, password }`
+  - Body: `{ phone, password }`
 
-Users authenticate directly with a phone number or email address and password. Successful login returns a JWT and the user profile.
+Users authenticate directly with a phone number and password. Successful login returns a JWT and the user profile.
 
 All API responses contain a `traceId` for debugging. Errors return `success: false` with an `error` object and `traceId`.

--- a/client/README.md
+++ b/client/README.md
@@ -10,7 +10,7 @@ VITE_API_URL=https://manacity4-0.onrender.com/api
 
 ## Auth flow
 
-Users sign up and log in with a phone number or email address and a password. Successful login stores the JWT token and user profile in `localStorage`.
+Users sign up and log in with a phone number and a password. Successful login stores the JWT token and user profile in `localStorage`.
 
 ## Backend API configuration
 

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -2,15 +2,13 @@ import api from './client';
 import type { UserState } from '../store/slices/userSlice';
 
 interface Credentials {
-  phone?: string;
-  email?: string;
+  phone: string;
   password: string;
 }
 
 export interface SignupDraft {
   name: string;
-  phone?: string;
-  email?: string;
+  phone: string;
   password: string;
   location: string;
   role?: string;

--- a/client/src/pages/auth/Login/Login.tsx
+++ b/client/src/pages/auth/Login/Login.tsx
@@ -14,24 +14,21 @@ import type { AppDispatch } from '../../../store';
 const Login = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
-  const [identifier, setIdentifier] = useState('');
+  const [phone, setPhone] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!identifier || !password) {
+    if (!phone || !password) {
       setError('Enter your credentials');
       return;
     }
     try {
       setLoading(true);
       setError('');
-      const creds = identifier.includes('@')
-        ? { email: identifier, password }
-        : { phone: identifier, password };
-      const user = await login(creds);
+      const user = await login({ phone, password });
       dispatch(setUser(user));
       navigate('/home');
       showToast('Logged in successfully', 'success');
@@ -63,13 +60,13 @@ const Login = () => {
 
         <form onSubmit={handleSubmit} noValidate>
           <label>
-            Phone or Email
+            Phone Number
             <input
               type="text"
-              name="identifier"
-              placeholder="Enter phone or email"
-              value={identifier}
-              onChange={(e) => setIdentifier(e.target.value)}
+              name="phone"
+              placeholder="Enter phone number"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
             />
           </label>
 

--- a/client/src/pages/auth/Signup/Signup.tsx
+++ b/client/src/pages/auth/Signup/Signup.tsx
@@ -14,14 +14,12 @@ const Signup = () => {
   const [form, setForm] = useState<SignupDraft>({
     name: '',
     phone: '',
-    email: '',
     password: '',
     location: '',
   });
   const [errors, setErrors] = useState<{
     name?: string;
     phone?: string;
-    email?: string;
     password?: string;
     location?: string;
     general?: string;
@@ -45,7 +43,6 @@ const Signup = () => {
     const newErrors: {
       name?: string;
       phone?: string;
-      email?: string;
       password?: string;
       location?: string;
     } = {};
@@ -53,10 +50,7 @@ const Signup = () => {
     const phoneE164 = form.phone ? normalizePhone(form.phone) : null;
     if (form.phone && !phoneE164)
       newErrors.phone = 'Enter a valid phone number with country code (e.g., +91…)';
-    if (!form.phone && !form.email)
-      newErrors.phone = 'Phone or email is required';
-    if (form.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email))
-      newErrors.email = 'Enter a valid email';
+    if (!form.phone) newErrors.phone = 'Phone is required';
     if (form.password.length < 6)
       newErrors.password = 'Password must be at least 6 characters';
     if (!form.location) newErrors.location = 'Location is required';
@@ -65,7 +59,7 @@ const Signup = () => {
 
     try {
       setLoading(true);
-      const payload = { ...form, phone: phoneE164 || undefined };
+      const payload = { ...form, phone: phoneE164! };
       await signup(payload);
       showToast('Account created. Please login.', 'success');
       navigate('/login');
@@ -100,12 +94,6 @@ const Signup = () => {
             Phone Number
             <input type="tel" name="phone" value={form.phone} onChange={handleChange} />
             {errors.phone && <span className="error">{errors.phone}</span>}
-          </label>
-
-          <label>
-            Email
-            <input type="email" name="email" value={form.email} onChange={handleChange} />
-            {errors.email && <span className="error">{errors.email}</span>}
           </label>
 
           <label>

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -42,7 +42,7 @@ erDiagram
 ## Top Access Patterns & Index Plan
 | # | Access pattern | Suggested index | Rationale |
 |---|----------------|-----------------|-----------|
-| 1 | Find user by email | `{ email: 1 }` unique | Login lookup |
+| 1 | Find user by phone | `{ phone: 1 }` unique | Login lookup |
 | 2 | List addresses for user | `{ userId: 1 }` | Frequent user detail lookup |
 | 3 | Fetch shop by slug | `{ slug: 1 }` unique | Public shop pages |
 | 4 | Query products by shop & slug | `{ shopId: 1, slug: 1 }` unique | Product pages within a shop |

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -5,25 +5,21 @@ const AppError = require("../utils/AppError");
 
 exports.signup = async (req, res, next) => {
   try {
-    const { name, phone, email, password, location, role } = req.body;
+    const { name, phone, password, location, role } = req.body;
 
-    if (!phone && !email) {
-      throw AppError.badRequest('MISSING_CONTACT', 'Phone or email is required');
+    if (!phone) {
+      throw AppError.badRequest('MISSING_CONTACT', 'Phone is required');
     }
 
-    const query = [];
-    if (phone) query.push({ phone });
-    if (email) query.push({ email });
-    const existingUser = await User.findOne({ $or: query });
+    const existingUser = await User.findOne({ phone });
     if (existingUser) {
-      throw AppError.conflict('USER_EXISTS', 'Phone or email already registered');
+      throw AppError.conflict('USER_EXISTS', 'Phone already registered');
     }
 
     const hashedPassword = await bcrypt.hash(password, 10);
     const user = await User.create({
       name,
       phone,
-      email,
       password: hashedPassword,
       location,
       role,
@@ -35,7 +31,6 @@ exports.signup = async (req, res, next) => {
       id: user._id,
       name: user.name,
       phone: user.phone,
-      email: user.email,
       location: user.location,
       address: user.address,
       role: user.role,
@@ -57,10 +52,9 @@ exports.signup = async (req, res, next) => {
 
 exports.login = async (req, res, next) => {
   try {
-    const { phone, email, password } = req.body;
+    const { phone, password } = req.body;
 
-    const query = phone ? { phone } : { email };
-    const user = await User.findOne(query);
+    const user = await User.findOne({ phone });
     if (!user) throw AppError.notFound('USER_NOT_FOUND', 'User not found');
 
     const isMatch = await bcrypt.compare(password, user.password);
@@ -78,7 +72,6 @@ exports.login = async (req, res, next) => {
       id: user._id,
       name: user.name,
       phone: user.phone,
-      email: user.email,
       role: user.role,
       location: user.location,
       address: user.address,

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -4,13 +4,6 @@ const userSchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
     phone: { type: String, unique: true, sparse: true },
-    email: {
-      type: String,
-      unique: true,
-      sparse: true,
-      lowercase: true,
-      trim: true,
-    },
     password: { type: String, required: true },
     location: { type: String, required: true },
     address: { type: String, default: "" },

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -50,7 +50,6 @@ interface Preferences {
 
 export interface UserAttrs {
   phone: string;
-  email?: string;
   name: string;
   avatarUrl?: string;
   roles: Role[];
@@ -122,13 +121,6 @@ const userSchema = new Schema<UserDoc>(
       required: true,
       unique: true,
     },
-    email: {
-      type: String,
-      unique: true,
-      sparse: true,
-      lowercase: true,
-      trim: true,
-    },
     name: { type: String, required: true },
     avatarUrl: { type: String },
     roles: {
@@ -159,7 +151,6 @@ const userSchema = new Schema<UserDoc>(
 );
 
 userSchema.index({ phone: 1 }, { unique: true });
-userSchema.index({ email: 1 }, { unique: true, sparse: true });
 userSchema.index({ roles: 1 });
 userSchema.index({ verificationStatus: 1 });
 userSchema.index({ 'location.city': 1, roles: 1 });

--- a/server/validators/authSchemas.js
+++ b/server/validators/authSchemas.js
@@ -6,29 +6,18 @@ const signupSchema = {
   body: z
     .object({
       name: z.string().min(2, 'Name is required'),
-      phone: phoneSchema.optional(),
-      email: z.string().email('Invalid email').optional(),
+      phone: phoneSchema,
       password: z.string().min(6, 'Password must be at least 6 characters'),
       location: z.string().min(2, 'Location is required'),
       role: z.string().optional(),
-    })
-    .refine((data) => data.phone || data.email, {
-      message: 'Phone or email is required',
-      path: ['phone'],
     }),
 };
 
 const loginSchema = {
-  body: z
-    .object({
-      phone: phoneSchema.optional(),
-      email: z.string().email('Invalid email').optional(),
-      password: z.string().min(6, 'Password must be at least 6 characters'),
-    })
-    .refine((data) => data.phone || data.email, {
-      message: 'Phone or email is required',
-      path: ['phone'],
-    }),
+  body: z.object({
+    phone: phoneSchema,
+    password: z.string().min(6, 'Password must be at least 6 characters'),
+  }),
 };
 
 module.exports = { signupSchema, loginSchema };


### PR DESCRIPTION
## Summary
- Drop email support from signup and login APIs
- Remove email fields from user model and validation schemas
- Simplify frontend auth pages and documentation for phone-only flow

## Testing
- `cd server && npm test` (fails: jest: not found)
- `cd client && npm test` (fails: missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc516d97048332b004e668b13affae