### PR TITLE
Fix wildcard routes for Express 5 compatibility

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -55,14 +55,18 @@ app.use("/api/admin", adminRoutes);
 app.use("/api/products", productRoutes);
 app.use("/api/users", adminUserRoutes);
 
-app.use("/api/*", (_req, _res, next) =>
-  next(AppError.notFound("ROUTE_NOT_FOUND", "API route not found"))
+// Catch-all for undefined API routes. Express 5 requires a named wildcard.
+app.use(
+  "/api/*path",
+  (_req, _res, next) =>
+    next(AppError.notFound("ROUTE_NOT_FOUND", "API route not found"))
 );
 
 if (process.env.NODE_ENV === "production") {
   const clientPath = path.join(__dirname, "..", "client", "dist");
   app.use(express.static(clientPath));
-  app.get("*", (_req, res) => {
+  // Serve index.html for any non-API request in production
+  app.get("/*path", (_req, res) => {
     res.sendFile(path.join(clientPath, "index.html"));
   });
 }


### PR DESCRIPTION
## Summary
- add named wildcard parameter for unmatched API routes
- adjust production catch-all to use named wildcard

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc63f62ff08332bcdbc917d41e96fb