### PR TITLE
fix: adjust CORS preflight handling

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -37,7 +37,10 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options("*", cors(corsOptions));
+// Use a regular expression to register the CORS preflight handler for all
+// routes. Express 5's path-to-regexp no longer supports the legacy "*" syntax
+// and "/*" can cause deployment issues, but /.*/ safely matches every path.
+app.options(/.*/, cors(corsOptions));
 app.use(express.json());
 app.use(context);
 


### PR DESCRIPTION
## Summary
- handle CORS preflight with a regex route to avoid Express 5 wildcard issues

## Testing
- `cd server && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log` *(fails: jest not found)*
- `npm install >/tmp/install.log && tail -n 20 /tmp/install.log` *(fails: 403 Forbidden for @types/jsonwebtoken)*

------
https://chatgpt.com/codex/tasks/task_e_68bc69233a088332a2c7ce389fe07eed