### PR TITLE
Fix shop rating sort

### DIFF
--- a/server/controllers/shopController.js
+++ b/server/controllers/shopController.js
@@ -85,12 +85,18 @@ exports.getAllShops = async (req, res) => {
 
     const basePipeline = [...pipeline];
 
-    const sortField = typeof sort === "string" && sort.startsWith("-") ? sort.slice(1) : sort;
-    const sortDir = typeof sort === "string" && sort.startsWith("-") ? -1 : 1;
+    const sortField =
+      typeof sort === "string" && sort.startsWith("-") ? sort.slice(1) : sort;
+    const sortDir =
+      typeof sort === "string" && sort.startsWith("-") ? -1 : 1;
+
+    // Map client friendly sort fields to database field names
+    const sortFieldMap = { rating: "ratingAvg" };
+    const mappedSortField = sortFieldMap[sortField] || sortField;
 
     const resultPipeline = [
       ...basePipeline,
-      { $sort: { [sortField]: sortDir } },
+      { $sort: { [mappedSortField]: sortDir } },
       { $skip: (Number(page) - 1) * Number(pageSize) },
       { $limit: Number(pageSize) },
     ];


### PR DESCRIPTION
## Summary
- map `sort=rating` query to `ratingAvg` field so shop list sorting works

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04eedfd6c8332bceb57a146d430cc