### PR TITLE
Handle shop rating sort safely

### DIFF
--- a/server/controllers/shopController.js
+++ b/server/controllers/shopController.js
@@ -79,7 +79,13 @@ exports.getAllShops = async (req, res) => {
           as: "products",
         },
       },
-      { $addFields: { productsCount: { $size: "$products" }, ownerName: "$owner.name" } },
+      {
+        $addFields: {
+          productsCount: { $size: "$products" },
+          ownerName: "$owner.name",
+          ratingAvg: { $cond: [{ $isNumber: "$ratingAvg" }, "$ratingAvg", 0] },
+        },
+      },
       { $project: { products: 0, owner: 0 } },
     );
 


### PR DESCRIPTION
## Summary
- Avoid server crashes when sorting shops by rating by ensuring `ratingAvg` is numeric in aggregation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05812a9f88332b5ee17e08700950b