### PR TITLE
Fix event model export and expose verified user routes

### DIFF
--- a/server/controllers/verifiedUserController.js
+++ b/server/controllers/verifiedUserController.js
@@ -52,6 +52,22 @@ exports.getAllVerifiedUsers = async (req, res) => {
   }
 };
 
+exports.getVerifiedUserById = async (req, res) => {
+  try {
+    const verified = await VerifiedUser.findOne({
+      _id: req.params.id,
+      status: "approved",
+    }).populate("user", "name phone location address");
+
+    if (!verified)
+      return res.status(404).json({ error: "Verified user not found" });
+
+    res.json(verified);
+  } catch (err) {
+    res.status(500).json({ error: "Failed to fetch verified user" });
+  }
+};
+
 exports.getMyRequests = async (req, res) => {
   try {
     const verified = await VerifiedUser.findOne({ user: req.user._id });

--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -30,6 +30,7 @@ const eventSchema = new Schema({
   registrationClosesAt: { type: Date, required: true },
   status: { type: String, enum: ['upcoming', 'active', 'ended', 'cancelled'], default: 'upcoming' },
   capacity: { type: Number, required: true },
+  registeredUsers: [{ type: Schema.Types.ObjectId, ref: 'User', default: [] }],
   registeredCount: { type: Number, default: 0 },
   organizerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
   location: { type: locationSchema, required: true },
@@ -47,6 +48,6 @@ eventSchema.index({ slug: 1 }, { unique: true });
 eventSchema.index({ status: 1, startAt: -1 });
 eventSchema.index({ category: 1, startAt: -1 });
 
-const EventModel = model('Event', eventSchema);
+const Event = model('Event', eventSchema);
 
-module.exports = { EventModel };
+module.exports = Event;

--- a/server/models/Event.ts
+++ b/server/models/Event.ts
@@ -48,6 +48,7 @@ export interface EventAttrs {
   registrationClosesAt: Date;
   status?: EventStatus;
   capacity: number;
+  registeredUsers?: Types.ObjectId[];
   registeredCount?: number;
   organizerId: Types.ObjectId;
   location: Location;
@@ -78,6 +79,7 @@ const eventSchema = new Schema<EventDoc>({
   registrationClosesAt: { type: Date, required: true },
   status: { type: String, enum: Object.values(EventStatus), default: EventStatus.UPCOMING },
   capacity: { type: Number, required: true },
+  registeredUsers: [{ type: Schema.Types.ObjectId, ref: 'User', default: [] }],
   registeredCount: { type: Number, default: 0 },
   organizerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
   location: { type: LocationSchema, required: true },

--- a/server/routes/verifiedUserRoutes.js
+++ b/server/routes/verifiedUserRoutes.js
@@ -5,17 +5,20 @@ const isAdmin = require("../middleware/isAdmin");
 const {
   applyForVerification,
   getAllVerifiedUsers,
+  getVerifiedUserById,
   getAcceptedProviders,
   getVerificationRequests,
   acceptVerificationRequest,
   rejectVerificationRequest,
 } = require("../controllers/verifiedUserController");
 
+router.get("/", getAllVerifiedUsers);
 router.post("/apply", protect, applyForVerification);
 router.get("/all", protect, isAdmin, getAllVerifiedUsers);
 router.get("/requests", protect, isAdmin, getVerificationRequests);
 router.post("/accept/:userId", protect, isAdmin, acceptVerificationRequest);
 router.post("/reject/:userId", protect, isAdmin, rejectVerificationRequest);
 router.get("/accepted", protect, getAcceptedProviders);
+router.get("/:id", getVerifiedUserById);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- fix Event mongoose model export and add registeredUsers field
- expose public routes to list verified users and fetch individual details

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c14160a83083328ff422cefe3fea85