### PR TITLE
Return error string in event query failure

### DIFF
--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -38,7 +38,7 @@ exports.getAllEvents = async (req, res) => {
     const events = await cursor;
     res.json(events);
   } catch {
-    res.status(500).json({ error: "Failed to fetch events" });
+    res.status(500).json({ error: err.tostring });
   }
 };
 


### PR DESCRIPTION
## Summary
- expose error.tostring in getAllEvents catch block

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjsonwebtoken)*

------
https://chatgpt.com/codex/tasks/task_e_68c14bfac3608332919d6cc7c687fb8b