### PR TITLE
fix: correct AppError import path

### DIFF
--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -1,6 +1,6 @@
 const Order = require('../models/Order');
 const User = require('../models/User');
-const AppError = require('../utils/appError');
+const AppError = require('../utils/AppError');
 
 // POST /api/orders - create order from cart
 exports.createOrder = async (req, res, next) => {

--- a/server/controllers/proController.js
+++ b/server/controllers/proController.js
@@ -1,6 +1,6 @@
 const User = require('../models/User');
 const Order = require('../models/Order');
-const AppError = require('../utils/appError');
+const AppError = require('../utils/AppError');
 
 exports.listProfessionals = async (req, res, next) => {
   try {


### PR DESCRIPTION
## Summary
- fix case sensitivity in AppError imports within controllers to align with file name

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching dependencies)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68c2778e64048332b4aa6e33b3e12988