### PR TITLE
refactor: remove circular store dependency in http module

### DIFF
--- a/client/src/lib/http.ts
+++ b/client/src/lib/http.ts
@@ -1,7 +1,13 @@
 import axios from 'axios';
 import { API_BASE } from '@/config/api';
-import { store } from '@/store';
+import type { Store } from '@reduxjs/toolkit';
 import { logout } from '@/store/slices/authSlice';
+
+let store: Store | null = null;
+
+export const injectStore = (s: Store) => {
+  store = s;
+};
 
 export const http = axios.create({
   baseURL: API_BASE,
@@ -34,7 +40,7 @@ http.interceptors.response.use(
     }
     if (error.response?.status === 401) {
       localStorage.removeItem('token');
-      store.dispatch(logout());
+      store?.dispatch(logout());
       window.location.href = '/login';
     }
     return Promise.reject(

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -11,6 +11,7 @@ import verifiedReducer from './verified';
 import notifsReducer from './notifs';
 import ordersReducer from './orders';
 import userProfileReducer from './user';
+import { injectStore } from '@/lib/http';
 
 export const store = configureStore({
   reducer: {
@@ -28,6 +29,8 @@ export const store = configureStore({
     userProfile: userProfileReducer,
   },
 });
+
+injectStore(store);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Summary
- inject Redux store into http helper to avoid circular imports
- update store setup to provide store instance to http

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run typecheck`
- `npm test` (server, fails: jest not found)
- `npm install` (server, fails: 403 for @types/jsonwebtoken)


------
https://chatgpt.com/codex/tasks/task_e_68c27945a3c48332ad04f6231ea09909