### PR TITLE
handle missing jwt secret

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -27,9 +27,13 @@ exports.signup = async (req, res, next) => {
       isVerified: true,
     });
 
+    const jwtSecret = process.env.JWT_SECRET;
+    if (!jwtSecret) {
+      throw AppError.internal('JWT_SECRET_NOT_SET', 'JWT secret not configured');
+    }
     const token = jwt.sign(
       { userId: user._id, role: user.role },
-      process.env.JWT_SECRET,
+      jwtSecret,
       { expiresIn: "7d" }
     );
 
@@ -68,9 +72,13 @@ exports.login = async (req, res, next) => {
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) throw AppError.badRequest('INVALID_PASSWORD', 'Incorrect password');
 
+    const jwtSecret = process.env.JWT_SECRET;
+    if (!jwtSecret) {
+      throw AppError.internal('JWT_SECRET_NOT_SET', 'JWT secret not configured');
+    }
     const token = jwt.sign(
       { userId: user._id, role: user.role },
-      process.env.JWT_SECRET,
+      jwtSecret,
       {
         expiresIn: "7d",
       }
@@ -108,7 +116,11 @@ exports.adminLogin = async (req, res, next) => {
       email === process.env.ADMIN_EMAIL &&
       password === process.env.ADMIN_PASSWORD
     ) {
-      const token = jwt.sign({ role: "admin" }, process.env.JWT_SECRET, {
+      const jwtSecret = process.env.JWT_SECRET;
+      if (!jwtSecret) {
+        throw AppError.internal('JWT_SECRET_NOT_SET', 'JWT secret not configured');
+      }
+      const token = jwt.sign({ role: "admin" }, jwtSecret, {
         expiresIn: "7d",
       });
       return res.json({ ok: true, data: { token }, traceId: req.traceId });

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -1,6 +1,7 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const AppError = require('../utils/AppError');
 
 async function createUserIfNew({ name, phone, password, location }) {
   const existing = await User.findOne({ phone });
@@ -15,9 +16,13 @@ async function createUserIfNew({ name, phone, password, location }) {
     location,
     address: '',
   });
+  const jwtSecret = process.env.JWT_SECRET;
+  if (!jwtSecret) {
+    throw AppError.internal('JWT_SECRET_NOT_SET', 'JWT secret not configured');
+  }
   const token = jwt.sign(
     { userId: user._id, role: user.role },
-    process.env.JWT_SECRET,
+    jwtSecret,
     { expiresIn: '7d' }
   );
   const profile = {
@@ -42,9 +47,13 @@ async function issueResetTokenForPhone(phone) {
     err.status = 404;
     throw err;
   }
+  const jwtSecret = process.env.JWT_SECRET;
+  if (!jwtSecret) {
+    throw AppError.internal('JWT_SECRET_NOT_SET', 'JWT secret not configured');
+  }
   const token = jwt.sign(
     { userId: user._id, phone },
-    process.env.JWT_SECRET,
+    jwtSecret,
     { expiresIn: '10m' }
   );
   return token;


### PR DESCRIPTION
## Summary
- ensure JWT secret is present before signing tokens
- guard auth service and controller against missing JWT secret

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2912724b083329cbc70655263f2a7