### PR TITLE
feat: expose detailed API errors

### DIFF
--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -3,11 +3,23 @@ module.exports = (err, req, res, _next) => {
 
   const status = err.statusCode || 500;
   const code = err.code || 'INTERNAL_ERROR';
-  const isProd = process.env.NODE_ENV === 'production';
+
+  const error = {
+    code,
+    message: err.message || 'Error',
+    stack: err.stack,
+  };
+
+  if (err.details) {
+    error.details = err.details;
+  }
+  if (err.fieldErrors) {
+    error.fieldErrors = err.fieldErrors;
+  }
 
   return res.status(status).json({
     ok: false,
-    error: { code, message: isProd ? 'Something went wrong' : (err.message || 'Error') },
+    error,
     traceId: req.traceId,
   });
 };

--- a/server/tests/errorHandler.test.js
+++ b/server/tests/errorHandler.test.js
@@ -1,0 +1,21 @@
+const request = require('supertest');
+const express = require('express');
+const errorHandler = require('../middleware/error');
+const AppError = require('../utils/AppError');
+
+describe('error handler', () => {
+  it('returns detailed errors', async () => {
+    const app = express();
+    app.get('/err', () => {
+      throw AppError.internal('INTERNAL_ERROR', 'Test failure');
+    });
+    app.use(errorHandler);
+
+    const res = await request(app).get('/err');
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+    expect(res.body.error.message).toBe('Test failure');
+    expect(res.body.error.stack).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- send full error details including message and stack in API responses
- add unit test verifying error handler exposes detailed errors

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjsonwebtoken)*

------
https://chatgpt.com/codex/tasks/task_e_68c29d8c93908332a366182730f62251