### PR TITLE
fix: avoid express-mongo-sanitize middleware

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -44,7 +44,15 @@ const corsOptions = {
 
 app.use(cors(corsOptions));
 app.use(helmet());
-app.use(mongoSanitize());
+// express-mongo-sanitize's built-in middleware attempts to reassign `req.query`,
+// which is a read-only getter in Express 5 and causes an error. Instead of
+// using the default middleware, manually sanitize request objects in-place.
+app.use((req, _res, next) => {
+  if (req.body) mongoSanitize.sanitize(req.body);
+  if (req.params) mongoSanitize.sanitize(req.params);
+  if (req.query) mongoSanitize.sanitize(req.query);
+  next();
+});
 // Use a regular expression to register the CORS preflight handler for all
 // routes. Express 5's path-to-regexp no longer supports the legacy "*" syntax
 // and "/*" can cause deployment issues, but /.*/ safely matches every path.


### PR DESCRIPTION
## Summary
- manually sanitize request objects instead of using express-mongo-sanitize middleware to avoid Express 5 `req.query` assignment error

## Testing
- `npm install --prefix server` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjsonwebtoken)*
- `npm run lint --prefix server`
- `npm test --prefix server` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c29f659728833289edb6809982bc07