### PR TITLE
Handle nested shop API responses

### DIFF
--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -129,7 +129,7 @@ export interface ShopQueryParams {
 
 export const fetchShops = async (params: ShopQueryParams = {}) => {
   const res = await adminApi.get('/shops', { params });
-  return res.data;
+  return res.data?.data || res.data;
 };
 
 export const updateShop = async (
@@ -137,7 +137,7 @@ export const updateShop = async (
   data: Partial<{ name: string; category: string; location: string; status: string }>,
 ) => {
   const res = await adminApi.put(`/shops/${id}`, data);
-  return res.data;
+  return res.data?.data || res.data;
 };
 
 export const deleteShop = async (id: string) => {
@@ -158,7 +158,7 @@ export interface ProductQueryParams {
 
 export const fetchProducts = async (params: ProductQueryParams = {}) => {
   const res = await adminApi.get('/products', { params });
-  return res.data as { items: any[]; total: number };
+  return (res.data?.data || res.data) as { items: any[]; total: number };
 };
 
 export const updateProduct = async (
@@ -190,7 +190,7 @@ export interface EventQueryParams {
 
 export const fetchEvents = async (params: EventQueryParams = {}) => {
   const res = await adminApi.get('/events', { params });
-  return res.data as { items: any[]; total: number };
+  return (res.data?.data || res.data) as { items: any[]; total: number };
 };
 
 export const createEvent = async (data: {
@@ -200,7 +200,7 @@ export const createEvent = async (data: {
   capacity: number;
 }) => {
   const res = await adminApi.post('/events', data);
-  return res.data;
+  return res.data?.data || res.data;
 };
 
 export const updateEvent = async (
@@ -208,7 +208,7 @@ export const updateEvent = async (
   data: Partial<{ title: string; startAt: string; endAt: string; capacity: number }>,
 ) => {
   const res = await adminApi.put(`/events/${id}`, data);
-  return res.data;
+  return res.data?.data || res.data;
 };
 
 export const deleteEvent = async (id: string) => {

--- a/client/src/pages/ShopDetails/ShopDetails.tsx
+++ b/client/src/pages/ShopDetails/ShopDetails.tsx
@@ -43,9 +43,13 @@ const ShopDetails = () => {
     const load = async () => {
       try {
         const shopRes = await http.get(`/shops/${id}`);
-        setShop(shopRes.data);
+        setShop(shopRes.data?.data?.shop || shopRes.data?.shop || shopRes.data);
         const prodRes = await http.get(`/shops/${id}/products`);
-        setProducts(Array.isArray(prodRes.data) ? prodRes.data : []);
+        const items =
+          prodRes.data?.data?.items ||
+          prodRes.data?.items ||
+          (Array.isArray(prodRes.data) ? prodRes.data : []);
+        setProducts(items);
       } catch {
         setShop(null);
         setProducts([]);

--- a/client/src/store/shops.ts
+++ b/client/src/store/shops.ts
@@ -45,21 +45,29 @@ const initial: St<Shop> = {
 export const fetchShops = createAsyncThunk(
   "shops/fetchAll",
   async (params?: Record<string, any>) => {
-    const { data } = await http.get("/shops", { params });
-    return Array.isArray(data) ? { items: data } : data;
+    const res = await http.get("/shops", { params });
+    const items =
+      res.data?.data?.items ||
+      res.data?.items ||
+      (Array.isArray(res.data) ? res.data : []);
+    return { items };
   }
 );
 
 export const fetchShopById = createAsyncThunk("shops/fetchById", async (id: string) => {
-  const { data } = await http.get(`/shops/${id}`);
-  return data;
+  const res = await http.get(`/shops/${id}`);
+  return res.data?.data?.shop || res.data?.shop || res.data;
 });
 
 export const fetchProductsByShop = createAsyncThunk(
   "shops/fetchProducts",
   async (id: string) => {
-    const { data } = await http.get(`/shops/${id}/products`);
-    return { id, items: Array.isArray(data) ? data : data.items };
+    const res = await http.get(`/shops/${id}/products`);
+    const items =
+      res.data?.data?.items ||
+      res.data?.items ||
+      (Array.isArray(res.data) ? res.data : []);
+    return { id, items };
   }
 );
 
@@ -74,13 +82,7 @@ const shopsSlice = createSlice({
     });
     b.addCase(fetchShops.fulfilled, (s, a) => {
       s.status = "succeeded";
-      const payload: any = a.payload;
-      const arr = Array.isArray(payload?.items)
-        ? payload.items
-        : Array.isArray(payload)
-        ? payload
-        : [];
-      s.items = arr;
+      s.items = a.payload.items as Shop[];
     });
     b.addCase(fetchShops.rejected, (s, a) => {
       s.status = "failed";


### PR DESCRIPTION
## Summary
- Normalize shop endpoints to unpack nested `data` objects
- Adjust shop detail page to read nested shop and product data
- Unwrap admin API responses for shops, products, and events

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a5d085788332b3a5d7eb698eeb5e