### PR TITLE
Fix API path handling across HTTP clients

### DIFF
--- a/client/src/api/adminClient.ts
+++ b/client/src/api/adminClient.ts
@@ -1,7 +1,10 @@
 import axios from 'axios';
+import { API_BASE } from '@/config/api';
 
 const adminApi = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: API_BASE,
+  withCredentials: false,
+  timeout: 20000,
 });
 
 adminApi.interceptors.request.use((config) => {
@@ -9,6 +12,9 @@ adminApi.interceptors.request.use((config) => {
   if (token) {
     config.headers = config.headers || {};
     config.headers.Authorization = `Bearer ${token}`;
+  }
+  if (config.url?.startsWith('/')) {
+    config.url = config.url.slice(1);
   }
   return config;
 });

--- a/client/src/lib/http.ts
+++ b/client/src/lib/http.ts
@@ -23,6 +23,9 @@ http.interceptors.request.use((config) => {
     config.headers = config.headers ?? {};
     config.headers.Authorization = `Bearer ${token}`;
   }
+  if (config.url?.startsWith('/')) {
+    config.url = config.url.slice(1);
+  }
   return config;
 });
 


### PR DESCRIPTION
## Summary
- Strip leading slashes from request URLs so API_BASE is respected
- Align admin API client with shared base URL and request normalization

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ad1c70288332a91282285607bc9d