### PR TITLE
fix: adjust thunk parameter order

### DIFF
--- a/client/src/store/shops.ts
+++ b/client/src/store/shops.ts
@@ -45,7 +45,10 @@ const initial: St<Shop> = {
 
 export const fetchShops = createAsyncThunk(
   "shops/fetchAll",
-  async (params?: Record<string, any>, { rejectWithValue }) => {
+  async (
+    params: Record<string, any> | undefined,
+    { rejectWithValue }: { rejectWithValue: (value: any) => any }
+  ) => {
     try {
       const res = await http.get("/shops", { params });
       return toItems(res) as Shop[];

--- a/client/src/store/verified.ts
+++ b/client/src/store/verified.ts
@@ -48,7 +48,10 @@ const normalize = (data: any): VerifiedUser => ({
 
 export const fetchVerified = createAsyncThunk(
   "verified/fetchAll",
-  async (params?: any, { rejectWithValue }) => {
+  async (
+    params: any | undefined,
+    { rejectWithValue }: { rejectWithValue: (value: any) => any }
+  ) => {
     try {
       const res = await http.get("/verified", { params });
       return (toItems(res) as any[]).map(normalize);


### PR DESCRIPTION
## Summary
- fix optional parameter ordering for shop fetch thunk
- fix optional parameter ordering for verified fetch thunk

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '@reduxjs/toolkit' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b97fb8c88332a021a631948aef19