### PR TITLE
feat: revamp user domain

### DIFF
--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -1,5 +1,6 @@
 import { http } from '@/lib/http';
-import type { AuthUser, SignupDraft } from '@/store/slices/authSlice';
+import type { SignupDraft } from '@/store/slices/authSlice';
+import type { User } from '@/types/user';
 
 export interface Credentials {
   phone: string;
@@ -8,17 +9,17 @@ export interface Credentials {
 
 export async function signup(data: SignupDraft) {
   const res = await http.post('/auth/signup', data);
-  return res.data.data as { user: AuthUser; token: string };
+  return res.data.data as { user: User; token: string };
 }
 
 export async function login(creds: Credentials) {
   const res = await http.post('/auth/login', creds);
-  return res.data.data as { user: AuthUser; token: string };
+  return res.data.data as { user: User; token: string };
 }
 
 export async function fetchMe() {
   const res = await http.get('/auth/me');
-  return res.data.data.user as AuthUser;
+  return res.data.data.user as User;
 }
 
 export async function logoutApi() {

--- a/client/src/api/profile.ts
+++ b/client/src/api/profile.ts
@@ -1,4 +1,5 @@
 import { http } from '@/lib/http';
+import type { User } from '@/types/user';
 
 export interface ProductData {
   _id?: string;
@@ -9,8 +10,13 @@ export interface ProductData {
 
 export interface UpdateProfileData {
   name?: string;
+  email?: string;
   location?: string;
+  address?: string;
+  profession?: string;
+  bio?: string;
   avatarUrl?: string;
+  preferences?: { theme?: 'light' | 'dark' | 'colored' };
 }
 
 export interface BusinessRequest {
@@ -28,13 +34,13 @@ export interface VerifyRequest {
 }
 
 export const getCurrentUser = async () => {
-  const res = await http.get('/users/me');
-  return res.data.data.user;
+  const res = await http.get('/auth/me');
+  return res.data.data.user as User;
 };
 
 export const updateProfile = async (data: UpdateProfileData) => {
   const res = await http.patch('/users/me', data);
-  return res.data.data.user;
+  return res.data.data.user as User;
 };
 
 export const requestVerification = async (data: VerifyRequest) => {

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -16,32 +16,59 @@ const Profile = () => {
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({
     name: user.name,
+    email: user.email || '',
     location: user.location,
+    address: user.address || '',
+    profession: user.profession || '',
+    bio: user.bio || '',
     avatarUrl: user.avatarUrl || '',
+    theme: user.preferences?.theme || 'light',
   });
 
   useEffect(() => {
     setForm({
       name: user.name,
+      email: user.email || '',
       location: user.location,
+      address: user.address || '',
+      profession: user.profession || '',
+      bio: user.bio || '',
       avatarUrl: user.avatarUrl || '',
+      theme: user.preferences?.theme || 'light',
     });
   }, [user]);
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
   ) => {
     const { name, value } = e.target;
     setForm((f) => ({ ...f, [name]: value }));
   };
 
   const handleSave = async () => {
-    if (!form.name.trim() || !form.location.trim()) {
-      showToast('Name and location are required', 'error');
+    if (!form.name.trim()) {
+      showToast('Name is required', 'error');
+      return;
+    }
+    if (form.email && !/^\S+@\S+\.\S+$/.test(form.email)) {
+      showToast('Invalid email', 'error');
+      return;
+    }
+    if (form.bio.length > 500) {
+      showToast('Bio too long', 'error');
       return;
     }
     try {
-      await updateProfile(form);
+      await updateProfile({
+        name: form.name,
+        email: form.email || undefined,
+        location: form.location,
+        address: form.address,
+        profession: form.profession,
+        bio: form.bio,
+        avatarUrl: form.avatarUrl,
+        preferences: { theme: form.theme },
+      });
       const refreshed = await getCurrentUser();
       dispatch(setUser(refreshed));
       showToast('Profile updated', 'success');
@@ -65,7 +92,7 @@ const Profile = () => {
       { label: 'Received Orders', path: '/orders/received' }
     );
   }
-  if (user.isVerified || user.role === 'verified') {
+  if (user.isVerified) {
     actions.push({ label: 'Service Orders', path: '/orders/service' });
   }
   if (actions.length === 0) {
@@ -83,7 +110,11 @@ const Profile = () => {
         <div className={styles.info}>
           <h2>{user.name}</h2>
           <p className={styles.phone}>{user.phone}</p>
-          <p>{user.location}</p>
+          {user.email && <p>{user.email}</p>}
+          {user.location && <p>{user.location}</p>}
+          {user.address && <p>{user.address}</p>}
+          {user.profession && <p>{user.profession}</p>}
+          {user.bio && <p>{user.bio}</p>}
         </div>
         <div className={styles.roles}>
           <span className={styles.role}>{user.role}</span>
@@ -124,13 +155,54 @@ const Profile = () => {
               />
             </label>
             <label>
+              Email
+              <input
+                name="email"
+                value={form.email}
+                onChange={handleChange}
+                type="email"
+              />
+            </label>
+            <label>
               Location
               <input
                 name="location"
                 value={form.location}
                 onChange={handleChange}
-                required
               />
+            </label>
+            <label>
+              Address
+              <input
+                name="address"
+                value={form.address}
+                onChange={handleChange}
+              />
+            </label>
+            <label>
+              Profession
+              <input
+                name="profession"
+                value={form.profession}
+                onChange={handleChange}
+              />
+            </label>
+            <label>
+              Bio
+              <textarea
+                name="bio"
+                value={form.bio}
+                onChange={handleChange}
+                maxLength={500}
+              />
+            </label>
+            <label>
+              Theme
+              <select name="theme" value={form.theme} onChange={handleChange}>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="colored">Colored</option>
+              </select>
             </label>
             <label>
               Avatar URL

--- a/client/src/pages/auth/Signup/Signup.tsx
+++ b/client/src/pages/auth/Signup/Signup.tsx
@@ -19,12 +19,14 @@ const Signup = () => {
     phone: '',
     password: '',
     location: '',
+    email: '',
   });
   const [errors, setErrors] = useState<{
     name?: string;
     phone?: string;
     password?: string;
     location?: string;
+    email?: string;
     general?: string;
   }>({});
   const [loading, setLoading] = useState(false);
@@ -48,6 +50,7 @@ const Signup = () => {
       phone?: string;
       password?: string;
       location?: string;
+      email?: string;
     } = {};
     if (!form.name.trim()) newErrors.name = 'Name is required';
     const phoneE164 = form.phone ? normalizePhone(form.phone) : null;
@@ -57,12 +60,13 @@ const Signup = () => {
     if (form.password.length < 6)
       newErrors.password = 'Password must be at least 6 characters';
     if (!form.location) newErrors.location = 'Location is required';
+    if (form.email && !/^\S+@\S+\.\S+$/.test(form.email)) newErrors.email = 'Invalid email';
     setErrors(newErrors);
     if (Object.keys(newErrors).length > 0) return;
 
     try {
       setLoading(true);
-      const payload = { ...form, phone: phoneE164! };
+      const payload = { ...form, phone: phoneE164!, email: form.email || undefined };
       await dispatch(signupThunk(payload)).unwrap();
       showToast('Account created.', 'success');
       navigate('/home');
@@ -97,6 +101,12 @@ const Signup = () => {
             Phone Number
             <input type="tel" name="phone" value={form.phone} onChange={handleChange} />
             {errors.phone && <span className="error">{errors.phone}</span>}
+          </label>
+
+          <label>
+            Email (optional)
+            <input type="email" name="email" value={form.email || ''} onChange={handleChange} />
+            {errors.email && <span className="error">{errors.email}</span>}
           </label>
 
           <label>

--- a/client/src/store/slices/authSlice.ts
+++ b/client/src/store/slices/authSlice.ts
@@ -1,36 +1,23 @@
 import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit';
 import { http } from '@/lib/http';
-
-export interface AuthUser {
-  id?: string;
-  name: string;
-  phone: string;
-  location: string;
-  role: string;
-  address?: string;
-  isVerified?: boolean;
-  verificationStatus?: string;
-  profession?: string;
-  bio?: string;
-  avatar?: string;
-  avatarUrl?: string;
-}
+import type { User } from '@/types/user';
 
 export interface SignupDraft {
   name: string;
   phone: string;
   password: string;
-  location: string;
-  role?: string;
+  location?: string;
+  role?: 'customer' | 'business';
+  email?: string;
 }
 
 interface AuthResponse {
-  user: AuthUser;
+  user: User;
   token: string;
 }
 
 interface AuthState {
-  user: AuthUser | null;
+  user: User | null;
   token: string | null;
   status: 'idle' | 'loading' | 'succeeded' | 'failed';
   error: string | null;
@@ -39,7 +26,7 @@ interface AuthState {
 const storedUser = localStorage.getItem('user');
 
 const initialState: AuthState = {
-  user: storedUser ? (JSON.parse(storedUser) as AuthUser) : null,
+  user: storedUser ? (JSON.parse(storedUser) as User) : null,
   token: localStorage.getItem('token'),
   status: 'idle',
   error: null,
@@ -63,14 +50,14 @@ export const signup = createAsyncThunk(
 
 export const fetchMe = createAsyncThunk('auth/me', async () => {
   const res = await http.get('/auth/me');
-  return res.data.data.user as AuthUser;
+  return res.data.data.user as User;
 });
 
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    setUser(state, action: PayloadAction<AuthUser>) {
+    setUser(state, action: PayloadAction<User>) {
       state.user = action.payload;
       localStorage.setItem('user', JSON.stringify(action.payload));
     },

--- a/client/src/store/user.ts
+++ b/client/src/store/user.ts
@@ -1,14 +1,6 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { http } from "@/lib/http";
-
-export interface UserProfile {
-  _id: string;
-  name: string;
-  phone?: string;
-  location?: string;
-  role?: string;
-  avatar?: string;
-}
+import type { User } from "@/types/user";
 
 type St<T> = {
   items: T[];
@@ -17,7 +9,7 @@ type St<T> = {
   error: string | null;
 };
 
-const initial: St<UserProfile> = {
+const initial: St<User> = {
   items: [],
   item: null,
   status: "idle",
@@ -25,15 +17,15 @@ const initial: St<UserProfile> = {
 };
 
 export const fetchProfile = createAsyncThunk("user/fetchProfile", async () => {
-  const { data } = await http.get("/users/me");
-  return data.data.user as UserProfile;
+  const { data } = await http.get("/auth/me");
+  return data.data.user as User;
 });
 
 export const updateProfile = createAsyncThunk(
   "user/updateProfile",
-  async (payload: Partial<UserProfile>) => {
+  async (payload: Partial<User>) => {
     const { data } = await http.patch("/users/me", payload);
-    return data.data.user as UserProfile;
+    return data.data.user as User;
   }
 );
 
@@ -48,14 +40,14 @@ const userSlice = createSlice({
     });
     b.addCase(fetchProfile.fulfilled, (s, a) => {
       s.status = "succeeded";
-      s.item = a.payload as UserProfile;
+      s.item = a.payload as User;
     });
     b.addCase(fetchProfile.rejected, (s, a) => {
       s.status = "failed";
       s.error = (a.error as any)?.message || "Failed to load";
     });
     b.addCase(updateProfile.fulfilled, (s, a) => {
-      s.item = a.payload as UserProfile;
+      s.item = a.payload as User;
     });
   },
 });

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -1,0 +1,16 @@
+export interface User {
+  id: string;
+  name: string;
+  phone: string;
+  email?: string | null;
+  role: 'customer' | 'business' | 'admin';
+  location: string;
+  address: string;
+  isVerified: boolean;
+  verificationStatus: 'none' | 'pending' | 'approved' | 'rejected';
+  profession?: string;
+  bio?: string;
+  avatar?: string | null;
+  avatarUrl?: string | null;
+  preferences?: { theme: 'light' | 'dark' | 'colored' };
+}

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,41 +1,93 @@
 const User = require("../models/User");
 const AppError = require("../utils/AppError");
 
-const buildProfile = (user) => ({
-  id: user._id,
-  name: user.name,
-  phone: user.phone,
-  location: user.location,
-  role: user.role,
-  avatarUrl: user.avatarUrl,
-  isVerified: user.isVerified,
-  verificationStatus: user.verificationStatus,
-});
-
-exports.getMe = async (req, res, next) => {
+exports.updateMe = async (req, res, next) => {
   try {
-    if (!req.user) throw AppError.unauthorized('UNAUTHORIZED', 'Unauthorized');
-    res.json({ ok: true, data: { user: buildProfile(req.user) }, traceId: req.traceId });
+    const allowed = [
+      "name",
+      "location",
+      "address",
+      "profession",
+      "bio",
+      "avatarUrl",
+    ];
+
+    allowed.forEach((field) => {
+      if (req.body[field] !== undefined) req.user[field] = req.body[field];
+    });
+
+    if (req.body.email !== undefined) {
+      const email = req.body.email === "" ? undefined : req.body.email.toLowerCase();
+      if (email) {
+        const exists = await User.findOne({ email, _id: { $ne: req.user._id } });
+        if (exists) throw AppError.conflict('EMAIL_EXISTS', 'Email already registered');
+      }
+      req.user.email = email;
+    }
+
+    if (req.body.preferences?.theme) {
+      req.user.preferences = req.user.preferences || {};
+      req.user.preferences.theme = req.body.preferences.theme;
+    }
+
+    const updatedUser = await req.user.save();
+    res.json({
+      ok: true,
+      data: { user: updatedUser.toProfileJSON() },
+      traceId: req.traceId,
+    });
   } catch (err) {
     next(err);
   }
 };
 
-exports.updateMe = async (req, res, next) => {
+exports.adminUpdate = async (req, res, next) => {
   try {
-    const { name, location, avatarUrl } = req.body;
-    if (name !== undefined) req.user.name = name;
-    if (location !== undefined) req.user.location = location;
-    if (avatarUrl !== undefined) req.user.avatarUrl = avatarUrl;
+    const { id } = req.params;
+    const user = await User.findById(id);
+    if (!user) return next(AppError.notFound('USER_NOT_FOUND', 'User not found'));
 
-    const updatedUser = await req.user.save();
-    res.json({
-      ok: true,
-      data: { user: buildProfile(updatedUser) },
-      traceId: req.traceId,
+    const fields = [
+      "name",
+      "phone",
+      "location",
+      "address",
+      "profession",
+      "bio",
+      "avatarUrl",
+      "role",
+      "isVerified",
+      "verificationStatus",
+    ];
+    fields.forEach((f) => {
+      if (req.body[f] !== undefined) user[f] = req.body[f];
     });
+
+    if (req.body.email !== undefined) {
+      const email = req.body.email === "" ? undefined : req.body.email.toLowerCase();
+      if (email) {
+        const exists = await User.findOne({ email, _id: { $ne: user._id } });
+        if (exists) throw AppError.conflict('EMAIL_EXISTS', 'Email already registered');
+      }
+      user.email = email;
+    }
+
+    if (req.body.phone !== undefined) {
+      const phone = String(req.body.phone);
+      const exists = await User.findOne({ phone, _id: { $ne: user._id } });
+      if (exists) throw AppError.conflict('PHONE_EXISTS', 'Phone already registered');
+      user.phone = phone;
+    }
+
+    if (req.body.preferences?.theme) {
+      user.preferences = user.preferences || {};
+      user.preferences.theme = req.body.preferences.theme;
+    }
+
+    const updated = await user.save();
+    res.json({ ok: true, data: { user: updated.toProfileJSON() }, traceId: req.traceId });
   } catch (err) {
-    next(AppError.internal('PROFILE_UPDATE_FAILED', 'Failed to update profile'));
+    next(err);
   }
 };
 

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,29 +1,91 @@
 const mongoose = require("mongoose");
 
+const preferencesSchema = new mongoose.Schema(
+  {
+    theme: {
+      type: String,
+      enum: ["light", "dark", "colored"],
+      default: "light",
+    },
+  },
+  { _id: false }
+);
+
 const userSchema = new mongoose.Schema(
   {
-    name: { type: String, required: true },
-    phone: { type: String, unique: true, sparse: true },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      minlength: 2,
+      maxlength: 80,
+    },
+    phone: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      match: /^\d{10,14}$/,
+    },
+    email: {
+      type: String,
+      unique: true,
+      sparse: true,
+      lowercase: true,
+      trim: true,
+      match: /^(?:[a-zA-Z0-9_'^&\/+{}\-]+(?:\.[a-zA-Z0-9_'^&\/+{}\-]+)*|"(?:[\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*")@(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-zA-Z-]*[a-zA-Z]:[\001-\011\013\014\016-\177]+)\])$/,
+    },
     password: { type: String, required: true, select: false },
-    location: { type: String, required: true },
-    address: { type: String, default: "" },
     role: {
       type: String,
-      enum: ["customer", "verified", "business", "admin"],
+      enum: ["customer", "business", "admin"],
       default: "customer",
     },
+    location: { type: String },
+    address: { type: String },
     isVerified: { type: Boolean, default: false },
-    isActive: { type: Boolean, default: true },
     verificationStatus: {
       type: String,
-      enum: ["pending", "verified", "rejected"],
+      enum: ["none", "pending", "approved", "rejected"],
+      default: "none",
     },
-    profession: { type: String, default: "" },
-    bio: { type: String, default: "" },
+    profession: { type: String },
+    bio: { type: String, maxlength: 500 },
+    avatarUrl: { type: String },
+    preferences: { type: preferencesSchema, default: () => ({}) },
   },
   { timestamps: true }
 );
 
-userSchema.index({ role: 1 });
+userSchema.index({ phone: 1 }, { unique: true });
+userSchema.index({ email: 1 }, { unique: true, sparse: true });
+
+userSchema.pre("save", function (next) {
+  if (this.phone) {
+    this.phone = this.phone.replace(/\D/g, "");
+  }
+  if (this.email === "") {
+    this.email = undefined;
+  }
+  next();
+});
+
+userSchema.methods.toProfileJSON = function () {
+  return {
+    id: this._id,
+    name: this.name,
+    phone: this.phone,
+    email: this.email ?? null,
+    role: this.role,
+    location: this.location ?? "",
+    address: this.address ?? "",
+    isVerified: !!this.isVerified,
+    verificationStatus: this.verificationStatus,
+    profession: this.profession ?? "",
+    bio: this.bio ?? "",
+    avatar: this.avatarUrl ?? null,
+    avatarUrl: this.avatarUrl ?? null,
+  };
+};
 
 module.exports = mongoose.model("User", userSchema);

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -7,6 +7,7 @@ const {
   verifyUser,
   getAllOrders,
 } = require('../controllers/adminController');
+const { adminUpdate } = require('../controllers/userController');
 const { getAdminMessages } = require('../controllers/adminMessageController');
 const protect = require('../middleware/authMiddleware');
 const isAdmin = require('../middleware/isAdmin');
@@ -20,6 +21,7 @@ const router = express.Router();
 
 router.get('/messages', getAdminMessages);
 router.get('/users', protect, isAdmin, getUsers);
+router.patch('/users/:id', protect, isAdmin, adminUpdate);
 router.put(
   '/users/:id/role',
   protect,

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -1,10 +1,9 @@
 const express = require("express");
 const protect = require("../middleware/authMiddleware");
-const { getMe, updateMe } = require("../controllers/userController");
+const { updateMe } = require("../controllers/userController");
 
 const router = express.Router();
 
-router.get("/me", protect, getMe);
 router.patch("/me", protect, updateMe);
 
 module.exports = router;

--- a/server/scripts/backfillUsers.js
+++ b/server/scripts/backfillUsers.js
@@ -1,0 +1,48 @@
+const mongoose = require('mongoose');
+const User = require('../models/User');
+require('dotenv').config();
+
+async function run() {
+  const uri = process.env.MONGO_URI || process.env.MONGODB_URI || 'mongodb://localhost:27017/test';
+  await mongoose.connect(uri);
+
+  const users = await User.find({});
+  for (const user of users) {
+    let modified = false;
+    if (user.verificationStatus === undefined) {
+      user.verificationStatus = 'none';
+      modified = true;
+    }
+    if (user.isVerified === undefined) {
+      user.isVerified = false;
+      modified = true;
+    }
+    if (user.email) {
+      const lower = user.email.toLowerCase();
+      if (user.email !== lower) {
+        user.email = lower;
+        modified = true;
+      }
+      const conflict = await User.findOne({ email: user.email, _id: { $ne: user._id } });
+      if (conflict) {
+        console.log(`Email conflict for ${user._id}: ${user.email}`);
+        user.email = undefined;
+        modified = true;
+      }
+    }
+    if (modified) {
+      try {
+        await user.save();
+      } catch (err) {
+        console.error('Failed to save user', user._id, err.message);
+      }
+    }
+  }
+  await mongoose.disconnect();
+  console.log('Backfill complete');
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/server/validators/authSchemas.js
+++ b/server/validators/authSchemas.js
@@ -1,16 +1,16 @@
 const { z } = require('zod');
 
-const phoneSchema = z.string().regex(/^\+?\d{10,15}$/, 'Invalid phone');
+const phoneSchema = z.string().regex(/^\d{10,14}$/, 'Invalid phone');
 
 const signupSchema = {
-  body: z
-    .object({
-      name: z.string().min(2, 'Name is required'),
-      phone: phoneSchema,
-      password: z.string().min(6, 'Password must be at least 6 characters'),
-      location: z.string().min(2, 'Location is required'),
-      role: z.string().optional(),
-    }),
+  body: z.object({
+    name: z.string().min(2).max(80),
+    phone: phoneSchema,
+    password: z.string().min(6, 'Password must be at least 6 characters'),
+    location: z.string().min(2).optional(),
+    role: z.enum(['customer', 'business']).optional(),
+    email: z.string().email().optional().or(z.literal('')),
+  }),
 };
 
 const loginSchema = {


### PR DESCRIPTION
## Summary
- redesign User schema with optional email, profile projection, and indexes
- align auth and user controllers plus routes for new profile fields and admin patch
- extend frontend types, store, and profile UI to manage new user fields

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` *(fails: Missing script test)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e03f8f5483328c3dea1991c68a79