### PR TITLE
Fix admin login token parsing

### DIFF
--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -11,7 +11,7 @@ export const adminLogin = async ({ identifier, password }: AdminCreds) => {
     email: identifier,
     password,
   });
-  const { token } = res.data;
+  const token = res.data?.data?.token;
   if (token) {
     localStorage.setItem('manacity_admin_token', token);
   }


### PR DESCRIPTION
## Summary
- fix admin login API to read token from `data.token`

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8014f7ab08332937e8920073d9a6f