### PR TITLE
Fix admin navigation and harden admin API handling

### DIFF
--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -1,6 +1,143 @@
 import adminApi from './adminClient';
 import { http } from '@/lib/http';
 
+const trimPath = (path: string) => path.replace(/^\/+/, '');
+
+const withAdminPrefix = (path: string) => {
+  const trimmed = trimPath(path);
+  if (!trimmed) return 'admin';
+  if (trimmed.startsWith('auth/')) return trimmed;
+  if (trimmed.startsWith('admin/')) return trimmed;
+  return `admin/${trimmed}`;
+};
+
+const unwrapPayload = (payload: any) => {
+  let current = payload;
+  const visited = new Set<any>();
+  while (
+    current &&
+    typeof current === 'object' &&
+    !Array.isArray(current) &&
+    'data' in current &&
+    current.data !== current &&
+    !visited.has(current)
+  ) {
+    visited.add(current);
+    current = current.data;
+  }
+  return current;
+};
+
+const pickNumber = (...values: Array<any>) => {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const isNotFoundError = (error: any) =>
+  Boolean(error && typeof error === 'object' && error.response?.status === 404);
+
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  page?: number;
+  pages?: number;
+  pageSize?: number;
+}
+
+const extractPaginatedResult = <T>(
+  payload: any,
+  additionalKeys: string[] = [],
+): PaginatedResult<T> => {
+  const source = unwrapPayload(payload);
+  const result: PaginatedResult<T> = {
+    items: [],
+    total: 0,
+  };
+
+  if (Array.isArray(source)) {
+    result.items = source as T[];
+    result.total = source.length;
+    return result;
+  }
+
+  const keys = [
+    ...additionalKeys,
+    'items',
+    'data',
+    'requests',
+    'results',
+    'rows',
+    'docs',
+    'list',
+  ];
+
+  for (const key of keys) {
+    const value = (source as Record<string, unknown>)?.[key];
+    if (Array.isArray(value)) {
+      result.items = value as T[];
+      break;
+    }
+  }
+
+  result.total =
+    pickNumber(
+      (source as Record<string, unknown>)?.total,
+      (source as Record<string, unknown>)?.count,
+      (source as Record<string, unknown>)?.totalCount,
+      result.items.length,
+    ) ?? result.items.length;
+
+  const page = pickNumber(
+    (source as Record<string, unknown>)?.page,
+    (source as Record<string, unknown>)?.currentPage,
+  );
+  if (page !== undefined) {
+    result.page = page;
+  }
+
+  const pages = pickNumber(
+    (source as Record<string, unknown>)?.pages,
+    (source as Record<string, unknown>)?.totalPages,
+  );
+  if (pages !== undefined) {
+    result.pages = pages;
+  }
+
+  const pageSize = pickNumber(
+    (source as Record<string, unknown>)?.pageSize,
+    (source as Record<string, unknown>)?.limit,
+  );
+  if (pageSize !== undefined) {
+    result.pageSize = pageSize;
+  }
+
+  return result;
+};
+
+const extractEntity = <T>(payload: any): T => unwrapPayload(payload) as T;
+
+const resolvePage = (result: PaginatedResult<any>, fallback?: number) =>
+  result.page && result.page > 0 ? result.page : fallback ?? 1;
+
+const resolvePages = (
+  result: PaginatedResult<any>,
+  fallbackPageSize?: number,
+  fallbackTotal?: number,
+) => {
+  if (result.pages && result.pages > 0) {
+    return result.pages;
+  }
+  const candidateSize =
+    result.pageSize ?? fallbackPageSize ?? result.items.length;
+  const size = candidateSize || 1;
+  const total = result.total ?? fallbackTotal ?? result.items.length;
+  return size ? Math.max(1, Math.ceil(total / size)) : 1;
+};
+
 export interface AdminCreds {
   identifier: string;
   password: string;
@@ -37,18 +174,18 @@ export interface SeriesPoint {
 }
 
 export const fetchMetrics = async () => {
-  const res = await adminApi.get('/metrics');
-  return res.data as MetricsSummary;
+  const res = await adminApi.get(withAdminPrefix('metrics'));
+  return extractEntity<MetricsSummary>(res.data);
 };
 
 export const fetchMetricSeries = async (
   metric: 'orders' | 'signups' | 'gmv',
   period: string,
 ) => {
-  const res = await adminApi.get('/metrics/timeseries', {
+  const res = await adminApi.get(withAdminPrefix('metrics/timeseries'), {
     params: { metric, period },
   });
-  return res.data as SeriesPoint[];
+  return extractEntity<SeriesPoint[]>(res.data);
 };
 
 export interface UserQueryParams {
@@ -61,20 +198,20 @@ export interface UserQueryParams {
 }
 
 export const fetchUsers = async (params: UserQueryParams = {}) => {
-  const res = await adminApi.get('/users', { params });
-  return res.data as { items: any[]; total: number };
+  const res = await adminApi.get(withAdminPrefix('users'), { params });
+  return extractPaginatedResult<any>(res.data);
 };
 
 export const updateUserRole = async (id: string, role: string) => {
-  await adminApi.put(`/users/${id}/role`, { role });
+  await adminApi.put(withAdminPrefix(`users/${id}/role`), { role });
 };
 
 export const updateUserStatus = async (id: string, active: boolean) => {
-  await adminApi.put(`/users/${id}/status`, { active });
+  await adminApi.put(withAdminPrefix(`users/${id}/status`), { active });
 };
 
 export const deleteUser = async (id: string) => {
-  await adminApi.delete(`/users/${id}`);
+  await adminApi.delete(withAdminPrefix(`users/${id}`));
 };
 
 export interface BusinessRequestParams {
@@ -86,16 +223,24 @@ export interface BusinessRequestParams {
 export const fetchBusinessRequests = async (
   params: BusinessRequestParams = {},
 ) => {
-  const res = await adminApi.get('/shops/requests', { params });
-  return res.data;
+  try {
+    const res = await adminApi.get(withAdminPrefix('shops/requests'), { params });
+    return extractPaginatedResult<any>(res.data);
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error;
+    }
+    const res = await adminApi.get(trimPath('/shops/requests'), { params });
+    return extractPaginatedResult<any>(res.data);
+  }
 };
 
 export const approveShop = async (id: string) => {
-  await adminApi.post(`/shops/approve/${id}`);
+  await adminApi.post(withAdminPrefix(`shops/approve/${id}`));
 };
 
 export const rejectShop = async (id: string) => {
-  await adminApi.post(`/shops/reject/${id}`);
+  await adminApi.post(withAdminPrefix(`shops/reject/${id}`));
 };
 
 export interface VerificationRequestParams {
@@ -107,18 +252,50 @@ export interface VerificationRequestParams {
 export const fetchVerificationRequests = async (
   params: VerificationRequestParams = {},
 ) => {
-  const res = await http.get('/verified', {
-    params: { status: 'pending', ...params },
+  const query = { status: 'pending', ...params };
+  try {
+    const res = await adminApi.get(withAdminPrefix('verified/requests'), {
+      params: query,
+    });
+    const result = extractPaginatedResult<any>(res.data, ['requests']);
+    const page = resolvePage(result, params.page);
+    const pages = resolvePages(result, params.pageSize, result.total);
+    return {
+      requests: result.items,
+      total: result.total,
+      page,
+      pages,
+    };
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error;
+    }
+  }
+
+  const fallbackRes = await http.get('/verified', {
+    params: query,
   });
-  return res.data?.data || res.data;
+  const fallback = extractPaginatedResult<any>(fallbackRes.data, ['requests']);
+  const page = resolvePage(fallback, params.page);
+  const pages = resolvePages(
+    fallback,
+    params.pageSize ?? fallback.pageSize,
+    fallback.total,
+  );
+  return {
+    requests: fallback.items,
+    total: fallback.total,
+    page,
+    pages,
+  };
 };
 
 export const acceptVerification = async (id: string) => {
-  await adminApi.post(`/verified/${id}/approve`);
+  await adminApi.post(withAdminPrefix(`verified/${id}/approve`));
 };
 
 export const rejectVerification = async (id: string) => {
-  await adminApi.post(`/verified/${id}/reject`);
+  await adminApi.post(withAdminPrefix(`verified/${id}/reject`));
 };
 
 export interface ShopQueryParams {
@@ -131,20 +308,20 @@ export interface ShopQueryParams {
 }
 
 export const fetchShops = async (params: ShopQueryParams = {}) => {
-  const res = await adminApi.get('/shops', { params });
-  return res.data?.data || res.data;
+  const res = await adminApi.get(withAdminPrefix('shops'), { params });
+  return extractPaginatedResult<any>(res.data);
 };
 
 export const updateShop = async (
   id: string,
   data: Partial<{ name: string; category: string; location: string; status: string }>,
 ) => {
-  const res = await adminApi.put(`/shops/${id}`, data);
-  return res.data?.data || res.data;
+  const res = await adminApi.put(withAdminPrefix(`shops/${id}`), data);
+  return extractEntity<any>(res.data);
 };
 
 export const deleteShop = async (id: string) => {
-  await adminApi.delete(`/shops/${id}`);
+  await adminApi.delete(withAdminPrefix(`shops/${id}`));
 };
 
 export interface ProductQueryParams {
@@ -160,8 +337,8 @@ export interface ProductQueryParams {
 }
 
 export const fetchProducts = async (params: ProductQueryParams = {}) => {
-  const res = await adminApi.get('/products', { params });
-  return (res.data?.data || res.data) as { items: any[]; total: number };
+  const res = await adminApi.get(withAdminPrefix('products'), { params });
+  return extractPaginatedResult<any>(res.data);
 };
 
 export const updateProduct = async (
@@ -176,12 +353,12 @@ export const updateProduct = async (
     category: string;
   }>,
 ) => {
-  const res = await adminApi.put(`/products/${id}`, data);
-  return res.data;
+  const res = await adminApi.put(withAdminPrefix(`products/${id}`), data);
+  return extractEntity<any>(res.data);
 };
 
 export const deleteProduct = async (id: string) => {
-  await adminApi.delete(`/products/${id}`);
+  await adminApi.delete(withAdminPrefix(`products/${id}`));
 };
 
 export interface EventQueryParams {
@@ -192,8 +369,8 @@ export interface EventQueryParams {
 }
 
 export const fetchEvents = async (params: EventQueryParams = {}) => {
-  const res = await adminApi.get('/events', { params });
-  return (res.data?.data || res.data) as { items: any[]; total: number };
+  const res = await adminApi.get(withAdminPrefix('events'), { params });
+  return extractPaginatedResult<any>(res.data);
 };
 
 export const createEvent = async (data: {
@@ -202,18 +379,18 @@ export const createEvent = async (data: {
   endAt: string;
   capacity: number;
 }) => {
-  const res = await adminApi.post('/events', data);
-  return res.data?.data || res.data;
+  const res = await adminApi.post(withAdminPrefix('events'), data);
+  return extractEntity<any>(res.data);
 };
 
 export const updateEvent = async (
   id: string,
   data: Partial<{ title: string; startAt: string; endAt: string; capacity: number }>,
 ) => {
-  const res = await adminApi.put(`/events/${id}`, data);
-  return res.data?.data || res.data;
+  const res = await adminApi.put(withAdminPrefix(`events/${id}`), data);
+  return extractEntity<any>(res.data);
 };
 
 export const deleteEvent = async (id: string) => {
-  await adminApi.delete(`/events/${id}`);
+  await adminApi.delete(withAdminPrefix(`events/${id}`));
 };

--- a/client/src/layouts/AdminLayout.scss
+++ b/client/src/layouts/AdminLayout.scss
@@ -25,6 +25,46 @@
   text-decoration: none;
 }
 
+.admin-sidebar a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.admin-sidebar a:hover {
+  background: #e0e0e0;
+}
+
+.admin-sidebar a.active {
+  background: #333;
+  color: #fff;
+}
+
+.nav-group {
+  margin-top: 1rem;
+}
+
+.nav-group__label {
+  display: block;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+  color: #666;
+  padding: 0 0.25rem;
+}
+
+.nav-group ul {
+  list-style: none;
+  padding-left: 0.5rem;
+  margin: 0;
+}
+
+.nav-group ul li {
+  margin-bottom: 0.25rem;
+}
+
 .admin-content {
   flex: 1;
   display: flex;

--- a/client/src/layouts/AdminLayout.tsx
+++ b/client/src/layouts/AdminLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet } from 'react-router-dom';
+import { NavLink, Outlet } from 'react-router-dom';
 import './AdminLayout.scss';
 
 const AdminLayout = () => {
@@ -7,14 +7,41 @@ const AdminLayout = () => {
       <aside className="admin-sidebar">
         <nav>
           <ul>
-            <li><Link to="/admin">Dashboard</Link></li>
-            <li><Link to="/admin/requests/business">Business Requests</Link></li>
-            <li><Link to="/admin/requests/verification">Verification Requests</Link></li>
-            <li><Link to="/admin/shops">Shops</Link></li>
-            <li><Link to="/admin/products">Products</Link></li>
-            <li><span>Events</span></li>
-            <li><Link to="/admin/users">Users</Link></li>
-            <li><Link to="/admin/analytics">Analytics</Link></li>
+            <li>
+              <NavLink to="/admin" end>
+                Dashboard
+              </NavLink>
+            </li>
+            <li className="nav-group">
+              <span className="nav-group__label">Requests</span>
+              <ul>
+                <li>
+                  <NavLink to="/admin/requests/business">
+                    Business Requests
+                  </NavLink>
+                </li>
+                <li>
+                  <NavLink to="/admin/requests/verification">
+                    Verification Requests
+                  </NavLink>
+                </li>
+              </ul>
+            </li>
+            <li>
+              <NavLink to="/admin/shops">Shops</NavLink>
+            </li>
+            <li>
+              <NavLink to="/admin/products">Products</NavLink>
+            </li>
+            <li>
+              <NavLink to="/admin/events">Events</NavLink>
+            </li>
+            <li>
+              <NavLink to="/admin/users">Users</NavLink>
+            </li>
+            <li>
+              <NavLink to="/admin/analytics">Analytics</NavLink>
+            </li>
           </ul>
         </nav>
       </aside>

--- a/client/src/pages/AdminDashboard/index.tsx
+++ b/client/src/pages/AdminDashboard/index.tsx
@@ -16,7 +16,8 @@ const AdminDashboard = () => {
     (async () => {
       try {
         const data = await fetchUsers();
-        setUsers(data.items as User[]);
+        const items = Array.isArray(data.items) ? (data.items as User[]) : [];
+        setUsers(items);
       } catch {
         // ignore
       }

--- a/client/src/pages/AdminProducts/AdminProducts.tsx
+++ b/client/src/pages/AdminProducts/AdminProducts.tsx
@@ -69,8 +69,9 @@ const AdminProducts = () => {
         pageSize,
       };
       const data = await fetchProducts(params);
-      setProducts(data.items as Product[]);
-      setTotal(data.total);
+      const items = Array.isArray(data.items) ? (data.items as Product[]) : [];
+      setProducts(items);
+      setTotal(typeof data.total === 'number' ? data.total : items.length);
     } catch {
       showToast('Failed to load products', 'error');
     } finally {

--- a/client/src/pages/AdminShops/AdminShops.tsx
+++ b/client/src/pages/AdminShops/AdminShops.tsx
@@ -49,8 +49,9 @@ const AdminShops = () => {
         pageSize,
       };
       const data = await fetchShops(params);
-      setShops(data.items);
-      setTotal(data.total);
+      const items = Array.isArray(data.items) ? (data.items as Shop[]) : [];
+      setShops(items);
+      setTotal(typeof data.total === 'number' ? data.total : items.length);
     } catch {
       showToast('Failed to load shops', 'error');
     } finally {

--- a/client/src/pages/AdminUsers/AdminUsers.tsx
+++ b/client/src/pages/AdminUsers/AdminUsers.tsx
@@ -46,8 +46,9 @@ const AdminUsers = () => {
         pageSize,
       };
       const data = await fetchUsers(params);
-      setUsers(data.items as User[]);
-      setTotal(data.total);
+      const items = Array.isArray(data.items) ? (data.items as User[]) : [];
+      setUsers(items);
+      setTotal(typeof data.total === 'number' ? data.total : items.length);
     } catch {
       showToast('Failed to load users', 'error');
     } finally {

--- a/client/src/pages/VerificationRequests/VerificationRequests.tsx
+++ b/client/src/pages/VerificationRequests/VerificationRequests.tsx
@@ -61,6 +61,8 @@ const VerificationRequests = () => {
         setTotal(data.total);
       } catch {
         setRequests([]);
+        setTotal(0);
+        showToast('Failed to load verification requests', 'error');
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- add active NavLink-based admin sidebar with working event link and grouped request navigation
- route admin API calls through consistent /admin endpoints and normalize list responses for resilient data handling
- guard admin tables and modals against missing data so business, verification, shop, product, and event management stay stable

## Testing
- `npm run lint --prefix client` *(fails: missing dev dependencies because registry access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c91a42251483329244a89f6604d30a