### PR TITLE
Add admin event management endpoints

### DIFF
--- a/server/controllers/adminEventController.js
+++ b/server/controllers/adminEventController.js
@@ -1,0 +1,240 @@
+const Event = require('../models/Event');
+const EventRegistration = require('../models/EventRegistration');
+const EventUpdate = require('../models/EventUpdate');
+const AppError = require('../utils/AppError');
+
+const MAX_PAGE_SIZE = 50;
+
+const toDate = (value) => {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const deriveStatus = (event) => {
+  const now = Date.now();
+  if (event.status === 'canceled') return 'past';
+  if (event.status === 'completed') return 'past';
+  const start = toDate(event.startAt);
+  const end = toDate(event.endAt);
+  if (end && end.getTime() < now) return 'past';
+  if (event.status === 'ongoing') return 'ongoing';
+  if (start && start.getTime() <= now && (!end || end.getTime() >= now)) {
+    return 'ongoing';
+  }
+  return 'upcoming';
+};
+
+const mapEvent = (event) => ({
+  _id: event._id,
+  title: event.title,
+  startAt: event.startAt,
+  endAt: event.endAt ?? null,
+  status: deriveStatus(event),
+  capacity: event.maxParticipants ?? event.capacity ?? 0,
+  registered: event.registeredCount ?? 0,
+});
+
+const computeLifecycleStatus = (start, end, currentStatus) => {
+  if (currentStatus === 'canceled') return currentStatus;
+  const startDate = toDate(start);
+  const endDate = toDate(end);
+  const now = Date.now();
+  if (endDate && endDate.getTime() < now) return 'completed';
+  if (startDate && startDate.getTime() <= now && (!endDate || endDate.getTime() >= now)) {
+    return 'ongoing';
+  }
+  return 'published';
+};
+
+exports.listEvents = async (req, res, next) => {
+  try {
+    const { status, page = 1, pageSize = 10, sort = '-startAt' } = req.query;
+    const pageNumber = Math.max(1, parseInt(page, 10) || 1);
+    const size = Math.min(
+      MAX_PAGE_SIZE,
+      Math.max(1, parseInt(pageSize, 10) || 10),
+    );
+
+    const sortKey = typeof sort === 'string' && sort.startsWith('-') ? sort.slice(1) : sort || 'startAt';
+    const sortDir = typeof sort === 'string' && sort.startsWith('-') ? -1 : 1;
+    const sortObj = { [sortKey]: sortDir };
+
+    const now = new Date();
+    const filter = {};
+
+    if (status === 'upcoming') {
+      filter.status = { $nin: ['canceled', 'completed'] };
+      filter.startAt = { $gt: now };
+    } else if (status === 'ongoing') {
+      filter.$or = [
+        { status: 'ongoing' },
+        {
+          $and: [
+            { status: { $nin: ['completed', 'canceled'] } },
+            { startAt: { $lte: now } },
+            {
+              $or: [
+                { endAt: { $exists: false } },
+                { endAt: null },
+                { endAt: { $gte: now } },
+              ],
+            },
+          ],
+        },
+      ];
+    } else if (status === 'past') {
+      filter.$or = [
+        { status: { $in: ['completed', 'canceled'] } },
+        { endAt: { $lt: now } },
+      ];
+    }
+
+    const [events, total] = await Promise.all([
+      Event.find(filter)
+        .sort(sortObj)
+        .skip((pageNumber - 1) * size)
+        .limit(size)
+        .lean(),
+      Event.countDocuments(filter),
+    ]);
+
+    res.json({
+      ok: true,
+      data: {
+        items: events.map(mapEvent),
+        total,
+        page: pageNumber,
+        pageSize: size,
+      },
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.createEvent = async (req, res, next) => {
+  try {
+    const startAt = toDate(req.body.startAt);
+    const endAt = toDate(req.body.endAt);
+
+    if (!startAt || !endAt) {
+      throw AppError.badRequest('INVALID_DATES', 'Invalid event dates');
+    }
+
+    const createdBy = req.user?._id;
+    if (!createdBy) {
+      throw AppError.unauthorized('UNAUTHORIZED', 'Admin authentication required');
+    }
+
+    const lifecycle = computeLifecycleStatus(startAt, endAt);
+
+    const event = await Event.create({
+      title: req.body.title,
+      type: 'activity',
+      category: 'general',
+      format: 'single_match',
+      teamSize: 1,
+      maxParticipants: req.body.capacity,
+      registrationOpenAt: startAt,
+      registrationCloseAt: endAt,
+      startAt,
+      endAt,
+      mode: 'online',
+      createdBy,
+      status: lifecycle,
+    });
+
+    res.status(201).json({
+      ok: true,
+      data: mapEvent(event),
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.updateEvent = async (req, res, next) => {
+  try {
+    const event = await Event.findById(req.params.id);
+    if (!event) {
+      throw AppError.notFound('EVENT_NOT_FOUND', 'Event not found');
+    }
+
+    if (req.body.title !== undefined) {
+      event.title = req.body.title;
+    }
+
+    let startAt = event.startAt;
+    let endAt = event.endAt;
+
+    if (req.body.startAt !== undefined) {
+      const startDate = toDate(req.body.startAt);
+      if (!startDate) {
+        throw AppError.badRequest('INVALID_START', 'Invalid startAt');
+      }
+      startAt = startDate;
+      event.startAt = startDate;
+      event.registrationOpenAt = startDate;
+    }
+
+    if (req.body.endAt !== undefined) {
+      const endDate = toDate(req.body.endAt);
+      if (!endDate) {
+        throw AppError.badRequest('INVALID_END', 'Invalid endAt');
+      }
+      endAt = endDate;
+      event.endAt = endDate;
+      event.registrationCloseAt = endDate;
+    }
+
+    if (req.body.capacity !== undefined) {
+      const registeredCount = event.registeredCount ?? 0;
+      if (
+        typeof req.body.capacity === 'number' &&
+        req.body.capacity < registeredCount
+      ) {
+        throw AppError.badRequest(
+          'CAPACITY_TOO_LOW',
+          'Capacity cannot be less than registered count',
+        );
+      }
+      event.maxParticipants = req.body.capacity;
+    }
+
+    if (event.status !== 'canceled') {
+      event.status = computeLifecycleStatus(startAt, endAt, event.status);
+    }
+
+    await event.save();
+
+    res.json({
+      ok: true,
+      data: mapEvent(event),
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.deleteEvent = async (req, res, next) => {
+  try {
+    const event = await Event.findById(req.params.id);
+    if (!event) {
+      throw AppError.notFound('EVENT_NOT_FOUND', 'Event not found');
+    }
+
+    await Promise.all([
+      EventRegistration.deleteMany({ event: event._id }),
+      EventUpdate.deleteMany({ event: event._id }),
+      event.deleteOne(),
+    ]);
+
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/routes/adminEventRoutes.js
+++ b/server/routes/adminEventRoutes.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const {
+  listEvents,
+  createEvent,
+  updateEvent,
+  deleteEvent,
+} = require('../controllers/adminEventController');
+const protect = require('../middleware/authMiddleware');
+const isAdmin = require('../middleware/isAdmin');
+const validate = require('../middleware/validate');
+const { createEventSchema, updateEventSchema } = require('../validators/eventSchemas');
+
+const router = express.Router();
+
+router.use(protect, isAdmin);
+
+router.get('/', listEvents);
+router.post('/', validate(createEventSchema), createEvent);
+router.put('/:id', validate(updateEventSchema), updateEvent);
+router.delete('/:id', deleteEvent);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -24,6 +24,7 @@ const orderRoutes = require("./routes/orderRoutes");
 const adminRoutes = require("./routes/adminRoutes");
 const productRoutes = require("./routes/productRoutes");
 const adminUserRoutes = require("./routes/adminUserRoutes");
+const adminEventRoutes = require("./routes/adminEventRoutes");
 const proRoutes = require("./routes/proRoutes");
 const AppError = require("./utils/AppError");
 
@@ -81,6 +82,7 @@ app.use("/api/events", eventRoutes);
 app.use("/api/special", specialRoutes);
 app.use("/api/notifications", notificationRoutes);
 app.use("/api/orders", orderRoutes);
+app.use("/api/admin/events", adminEventRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/products", productRoutes);
 app.use("/api/admin/users", adminUserRoutes);

--- a/server/tests/adminEventController.test.js
+++ b/server/tests/adminEventController.test.js
@@ -1,0 +1,243 @@
+jest.mock('../models/Event', () => ({
+  find: jest.fn(),
+  countDocuments: jest.fn(),
+  create: jest.fn(),
+  findById: jest.fn(),
+}));
+
+jest.mock('../models/EventRegistration', () => ({
+  deleteMany: jest.fn(),
+}));
+
+jest.mock('../models/EventUpdate', () => ({
+  deleteMany: jest.fn(),
+}));
+
+const Event = require('../models/Event');
+const EventRegistration = require('../models/EventRegistration');
+const EventUpdate = require('../models/EventUpdate');
+const controller = require('../controllers/adminEventController');
+
+describe('adminEventController', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listEvents', () => {
+    it('returns paginated events with derived fields', async () => {
+      const eventDoc = {
+        _id: '1',
+        title: 'Launch',
+        startAt: new Date('2099-01-01T10:00:00Z'),
+        endAt: new Date('2099-01-01T12:00:00Z'),
+        maxParticipants: 100,
+        registeredCount: 10,
+        status: 'published',
+      };
+      const lean = jest.fn().mockResolvedValue([eventDoc]);
+      const limit = jest.fn().mockReturnValue({ lean });
+      const skip = jest.fn().mockReturnValue({ limit });
+      const sort = jest.fn().mockReturnValue({ skip });
+      Event.find.mockReturnValue({ sort });
+      Event.countDocuments.mockResolvedValue(1);
+
+      const req = {
+        query: { status: 'upcoming', page: '1', pageSize: '5', sort: '-startAt' },
+        traceId: 'trace',
+      };
+      const res = { json: jest.fn() };
+
+      await controller.listEvents(req, res, jest.fn());
+
+      expect(Event.find).toHaveBeenCalled();
+      expect(Event.countDocuments).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({
+        ok: true,
+        data: {
+          items: [
+            expect.objectContaining({
+              _id: '1',
+              title: 'Launch',
+              status: 'upcoming',
+              capacity: 100,
+              registered: 10,
+            }),
+          ],
+          total: 1,
+          page: 1,
+          pageSize: 5,
+        },
+        traceId: 'trace',
+      });
+    });
+  });
+
+  describe('createEvent', () => {
+    it('creates an event with defaults and returns mapped payload', async () => {
+      const start = new Date(Date.now() + 3600000);
+      const end = new Date(Date.now() + 7200000);
+      const created = {
+        _id: 'evt1',
+        title: 'Gala',
+        startAt: start,
+        endAt: end,
+        maxParticipants: 50,
+        registeredCount: 0,
+        status: 'published',
+      };
+      Event.create.mockResolvedValue(created);
+      const req = {
+        body: {
+          title: 'Gala',
+          startAt: start.toISOString(),
+          endAt: end.toISOString(),
+          capacity: 50,
+        },
+        user: { _id: 'admin-user' },
+        traceId: 'trace',
+      };
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+      const next = jest.fn();
+
+      await controller.createEvent(req, res, next);
+
+      expect(Event.create).toHaveBeenCalled();
+      const payload = Event.create.mock.calls[0][0];
+      expect(payload).toMatchObject({
+        title: 'Gala',
+        maxParticipants: 50,
+        createdBy: 'admin-user',
+        status: 'published',
+      });
+      expect(payload.startAt).toBeInstanceOf(Date);
+      expect(payload.endAt).toBeInstanceOf(Date);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        ok: true,
+        data: expect.objectContaining({
+          _id: 'evt1',
+          title: 'Gala',
+          status: 'upcoming',
+          capacity: 50,
+        }),
+        traceId: 'trace',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateEvent', () => {
+    it('updates fields and recalculates status', async () => {
+      const start = new Date(Date.now() + 3600000);
+      const end = new Date(Date.now() + 7200000);
+      const event = {
+        _id: 'evt',
+        title: 'Original',
+        startAt: new Date('2025-01-01T00:00:00Z'),
+        endAt: new Date('2025-01-02T00:00:00Z'),
+        registrationOpenAt: new Date('2025-01-01T00:00:00Z'),
+        registrationCloseAt: new Date('2025-01-02T00:00:00Z'),
+        maxParticipants: 100,
+        registeredCount: 5,
+        status: 'published',
+        save: jest.fn().mockResolvedValue(),
+      };
+      Event.findById.mockResolvedValue(event);
+
+      const req = {
+        params: { id: 'evt' },
+        body: {
+          title: 'Updated',
+          startAt: start.toISOString(),
+          endAt: end.toISOString(),
+          capacity: 60,
+        },
+        traceId: 'trace',
+      };
+      const res = { json: jest.fn() };
+
+      await controller.updateEvent(req, res, jest.fn());
+
+      expect(event.title).toBe('Updated');
+      expect(event.startAt.toISOString()).toBe(start.toISOString());
+      expect(event.endAt.toISOString()).toBe(end.toISOString());
+      expect(event.registrationOpenAt.toISOString()).toBe(start.toISOString());
+      expect(event.registrationCloseAt.toISOString()).toBe(end.toISOString());
+      expect(event.maxParticipants).toBe(60);
+      expect(event.status).toBe('published');
+      expect(event.save).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({
+        ok: true,
+        data: expect.objectContaining({
+          _id: 'evt',
+          title: 'Updated',
+          status: 'upcoming',
+          capacity: 60,
+        }),
+        traceId: 'trace',
+      });
+    });
+
+    it('rejects capacity lower than registrations', async () => {
+      const event = {
+        _id: 'evt',
+        title: 'Original',
+        startAt: new Date(),
+        endAt: new Date(Date.now() + 3600000),
+        registrationOpenAt: new Date(),
+        registrationCloseAt: new Date(Date.now() + 3600000),
+        registeredCount: 10,
+        status: 'published',
+      };
+      Event.findById.mockResolvedValue(event);
+      const req = {
+        params: { id: 'evt' },
+        body: { capacity: 5 },
+        traceId: 'trace',
+      };
+      const res = { json: jest.fn() };
+      const next = jest.fn();
+
+      await controller.updateEvent(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+      const error = next.mock.calls[0][0];
+      expect(error.code).toBe('CAPACITY_TOO_LOW');
+    });
+  });
+
+  describe('deleteEvent', () => {
+    it('removes event and related data', async () => {
+      const event = {
+        _id: 'evt',
+        deleteOne: jest.fn().mockResolvedValue(),
+      };
+      Event.findById.mockResolvedValue(event);
+      EventRegistration.deleteMany.mockResolvedValue();
+      EventUpdate.deleteMany.mockResolvedValue();
+
+      const req = { params: { id: 'evt' } };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await controller.deleteEvent(req, res, jest.fn());
+
+      expect(EventRegistration.deleteMany).toHaveBeenCalledWith({ event: 'evt' });
+      expect(EventUpdate.deleteMany).toHaveBeenCalledWith({ event: 'evt' });
+      expect(event.deleteOne).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalledWith();
+    });
+
+    it('passes error when event missing', async () => {
+      Event.findById.mockResolvedValue(null);
+      const next = jest.fn();
+      await controller.deleteEvent({ params: { id: 'missing' } }, { status: jest.fn() }, next);
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+      const error = next.mock.calls[0][0];
+      expect(error.code).toBe('EVENT_NOT_FOUND');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement admin event controller to list, create, update and delete events with derived lifecycle metadata
- expose the handlers via protected /api/admin/events routes with validation middleware
- cover the new controller behaviour with dedicated jest unit tests

## Testing
- npm test -- --runTestsByPath tests/adminEventController.test.js *(fails: jest not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c92350f6148332a9299a5e616a889e