### PR TITLE
feat: enhance admin event management ui

### DIFF
--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -366,6 +366,7 @@ export interface EventQueryParams {
   page?: number;
   pageSize?: number;
   sort?: string;
+  query?: string;
 }
 
 export const fetchEvents = async (params: EventQueryParams = {}) => {

--- a/client/src/pages/AdminEvents/AdminEvents.scss
+++ b/client/src/pages/AdminEvents/AdminEvents.scss
@@ -1,128 +1,382 @@
 .admin-events {
-  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-5);
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 
-.admin-events .filters {
+.admin-events .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.admin-events__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.admin-events__header h2 {
+  font-size: var(--font-size-xl);
+  color: var(--color-text);
+}
+
+.admin-events__subtitle {
+  margin-top: var(--space-1);
+  max-width: 560px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
+}
+
+.summary-grid {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.summary-card {
+  background: var(--color-surface);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.summary-card h3 {
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.summary-card p {
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.summary-card__progress {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--gray-200);
+  overflow: hidden;
+}
+
+.summary-card__progress div {
+  height: 100%;
+  background: var(--color-primary);
+  transition: width 0.3s ease;
+}
+
+.admin-events__filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: var(--space-3);
+  align-items: center;
 }
 
-.events-table {
-  width: 100%;
-  border-collapse: collapse;
+.filters__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
 }
 
-.events-table th,
-.events-table td {
-  border: 1px solid #ddd;
-  padding: 0.5rem;
-  text-align: left;
+.filters__search,
+.admin-events select {
+  min-width: 180px;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.status-chip {
-  display: inline-block;
-  padding: 0.125rem 0.5rem;
-  border-radius: 4px;
-  color: #fff;
-  font-size: 0.875rem;
+.filters__search:focus,
+.admin-events select:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(27, 99, 217, 0.12);
+  outline: none;
+}
+
+.filters__cta {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: none;
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+@media (min-width: 768px) {
+  .filters__cta {
+    margin-left: auto;
+  }
+}
+
+.filters__cta:hover {
+  background: var(--color-primary-hover);
+  box-shadow: var(--shadow-sm);
+}
+
+.event-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.event-title__name {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.event-title__meta {
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}
+
+.event-schedule {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: var(--font-size-sm);
+}
+
+.event-schedule__arrow {
+  color: var(--color-muted);
+  font-size: var(--font-size-xs);
+}
+
+.registration-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.registration-cell__value {
   font-weight: 600;
 }
 
-.status-upcoming {
-  background: #2563eb;
+.registration-progress {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--gray-200);
+  overflow: hidden;
 }
 
-.status-ongoing {
-  background: #16a34a;
+.registration-progress__bar {
+  position: absolute;
+  inset: 0;
+  background: var(--color-primary);
+  transition: width 0.3s ease;
 }
 
-.status-past {
-  background: #6b7280;
-}
-
-/* Keep header visible while scrolling */
-.events-table thead th {
-  position: sticky;
-  top: 0;
-  background: #fff;
-  z-index: 1;
-}
-
-.actions button {
-  margin-right: 0.25rem;
-}
-
-.pagination {
-  margin-top: 1rem;
+.admin-events .actions {
   display: flex;
-  gap: 1rem;
-  align-items: center;
+  gap: var(--space-1);
 }
 
-.modal {
+.admin-events .actions button,
+.admin-events .detail-actions button {
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--gray-200);
+  background: var(--color-surface);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.admin-events .actions button:hover,
+.admin-events .detail-actions button:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.admin-events .actions button:last-child,
+.admin-events .detail-actions button:nth-child(2) {
+  border-color: rgba(220, 38, 38, 0.25);
+  color: var(--color-danger);
+}
+
+.admin-events .actions button:last-child:hover,
+.admin-events .detail-actions button:nth-child(2):hover {
+  border-color: var(--color-danger);
+  background: rgba(220, 38, 38, 0.05);
+}
+
+.admin-events .modal {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  inset: 0;
+  background: var(--overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--space-4);
+  z-index: 1000;
 }
 
-.modal-content {
-  background: #fff;
-  padding: 1rem;
-  border-radius: 4px;
-  min-width: 300px;
-}
-
-.modal-actions {
+.admin-events .modal-content {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-5);
+  width: min(440px, 100%);
   display: flex;
-  gap: 0.5rem;
-  justify-content: flex-end;
-  margin-top: 1rem;
+  flex-direction: column;
+  gap: var(--space-4);
 }
 
-/* Mobile card view */
+.admin-events .modal-content h3 {
+  font-size: var(--font-size-lg);
+  color: var(--color-text);
+}
+
+.modal-content--form {
+  width: min(420px, 100%);
+}
+
+.admin-events .modal-content--detail {
+  gap: var(--space-3);
+}
+
+.admin-events .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.admin-events .form-field label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.admin-events .form-field input {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-alt);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-events .form-field input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(27, 99, 217, 0.12);
+  outline: none;
+}
+
+.admin-events .form-field-grid {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.admin-events .field-error {
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+}
+
+.admin-events .modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.admin-events .modal-actions button {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: none;
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-events .modal-actions button[type='button'] {
+  background: var(--gray-100);
+  color: var(--color-text);
+}
+
+.admin-events .modal-actions button:hover {
+  box-shadow: var(--shadow-sm);
+}
+
+.admin-events .modal-actions button[type='button']:hover {
+  background: var(--gray-200);
+}
+
+.admin-events .modal-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.admin-events .event-detail {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-3);
+}
+
+.admin-events .event-detail dt {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.admin-events .event-detail dd {
+  margin: 0;
+  font-size: var(--font-size-md);
+  color: var(--color-text);
+}
+
+.admin-events .detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
 @media (max-width: 768px) {
-  .events-table,
-  .events-table thead,
-  .events-table tbody,
-  .events-table th,
-  .events-table td,
-  .events-table tr {
-    display: block;
+  .admin-events {
+    padding: var(--space-4);
   }
 
-  .events-table thead {
-    display: none;
+  .admin-events__header {
+    gap: var(--space-3);
   }
 
-  .events-table tr {
-    margin-bottom: 1rem;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  .admin-events__filters {
+    flex-direction: column;
+    align-items: stretch;
   }
 
-  .events-table td {
-    border: none;
-    border-bottom: 1px solid #eee;
-    display: flex;
-    justify-content: space-between;
-    gap: 0.5rem;
+  .filters__group,
+  .filters__cta {
+    width: 100%;
   }
 
-  .events-table td::before {
-    content: attr(data-label);
-    font-weight: bold;
+  .filters__cta {
+    text-align: center;
   }
 
-  .events-table td:last-child {
-    border-bottom: none;
+  .admin-events .modal {
+    padding: var(--space-3);
   }
 }

--- a/client/src/pages/AdminEvents/AdminEvents.tsx
+++ b/client/src/pages/AdminEvents/AdminEvents.tsx
@@ -9,8 +9,10 @@ import {
 import DataTable, { type Column } from '../../components/admin/DataTable';
 import StatusChip from '../../components/ui/StatusChip';
 import showToast from '../../components/ui/Toast';
-import './AdminEvents.scss';
+import useDebounce from '../../hooks/useDebounce';
 import useFocusTrap from '../../hooks/useFocusTrap';
+import EventForm, { type EventFormErrors, type EventFormValues } from './EventForm';
+import './AdminEvents.scss';
 
 interface EventItem {
   _id: string;
@@ -24,24 +26,73 @@ interface EventItem {
 
 type EventRow = EventItem & { actions?: string };
 
-interface FormState {
-  title: string;
-  startAt: string;
-  endAt: string;
-  capacity: number;
-}
-
-const emptyForm: FormState = {
+const emptyForm: EventFormValues = {
   title: '',
   startAt: '',
   endAt: '',
-  capacity: 0,
+  capacity: '',
+};
+
+const toLocalDateTimeInput = (value?: string | Date | null) => {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const offset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
+};
+
+const toISO = (value: string) => new Date(value).toISOString();
+
+const formatDateTime = (value: string) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString();
+};
+
+const getRegistrationProgress = (event: EventItem) => {
+  const capacity = Number.isFinite(event.capacity) ? event.capacity : 0;
+  if (!capacity) return 0;
+  const registered = Math.max(0, Math.min(capacity, event.registered ?? 0));
+  return Math.round((registered / capacity) * 100);
+};
+
+const validateForm = (values: EventFormValues): EventFormErrors => {
+  const errors: EventFormErrors = {};
+  if (!values.title.trim()) {
+    errors.title = 'Title is required';
+  }
+
+  const startDate = values.startAt ? new Date(values.startAt) : null;
+  if (!startDate || Number.isNaN(startDate.getTime())) {
+    errors.startAt = 'Choose a valid start date';
+  }
+
+  const endDate = values.endAt ? new Date(values.endAt) : null;
+  if (!endDate || Number.isNaN(endDate.getTime())) {
+    errors.endAt = 'Choose a valid end date';
+  }
+
+  if (!errors.startAt && !errors.endAt && startDate && endDate && startDate >= endDate) {
+    errors.endAt = 'End must be after start';
+  }
+
+  const capacity = Number(values.capacity);
+  if (!values.capacity.trim()) {
+    errors.capacity = 'Capacity is required';
+  } else if (!Number.isFinite(capacity) || capacity < 1) {
+    errors.capacity = 'Capacity must be at least 1';
+  }
+
+  return errors;
 };
 
 const AdminEvents = () => {
   const [events, setEvents] = useState<EventItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState('');
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query.trim(), 400);
   const [sort, setSort] = useState('-startAt');
   const [page, setPage] = useState(1);
   const [total, setTotal] = useState(0);
@@ -49,13 +100,30 @@ const AdminEvents = () => {
 
   const [createOpen, setCreateOpen] = useState(false);
   const [edit, setEdit] = useState<EventItem | null>(null);
-  const [form, setForm] = useState<FormState>(emptyForm);
+  const [detail, setDetail] = useState<EventItem | null>(null);
+  const [form, setForm] = useState<EventFormValues>(emptyForm);
+  const [errors, setErrors] = useState<EventFormErrors>({});
   const [saving, setSaving] = useState(false);
 
   const createRef = useRef<HTMLFormElement>(null);
   const editRef = useRef<HTMLFormElement>(null);
-  useFocusTrap<HTMLFormElement>(createRef, createOpen, () => setCreateOpen(false));
-  useFocusTrap<HTMLFormElement>(editRef, !!edit, () => setEdit(null));
+  const detailRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(createRef, createOpen, () => {
+    setCreateOpen(false);
+    setForm(emptyForm);
+    setErrors({});
+  });
+  useFocusTrap(editRef, !!edit, () => {
+    setEdit(null);
+    setForm(emptyForm);
+    setErrors({});
+  });
+  useFocusTrap(detailRef, !!detail, () => setDetail(null));
+
+  const resetForm = () => {
+    setForm(emptyForm);
+    setErrors({});
+  };
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -65,6 +133,7 @@ const AdminEvents = () => {
         sort,
         page,
         pageSize,
+        query: debouncedQuery || undefined,
       };
       const data = await fetchEvents(params);
       const items = Array.isArray(data.items) ? (data.items as EventItem[]) : [];
@@ -75,29 +144,87 @@ const AdminEvents = () => {
     } finally {
       setLoading(false);
     }
-  }, [status, sort, page, pageSize]);
+  }, [status, sort, page, pageSize, debouncedQuery]);
 
   useEffect(() => {
     load();
   }, [load]);
 
-  const handleCreate = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (new Date(form.startAt) >= new Date(form.endAt)) {
-      showToast('startAt must be before endAt', 'error');
+  useEffect(() => {
+    if (detail && !events.some((event) => event._id === detail._id)) {
+      setDetail(null);
+    }
+  }, [detail, events]);
+
+  const summary = (() => {
+    const base = {
+      visible: events.length,
+      upcoming: 0,
+      ongoing: 0,
+      past: 0,
+      registered: 0,
+      capacity: 0,
+    };
+    for (const event of events) {
+      const statusKey = event.status as 'upcoming' | 'ongoing' | 'past';
+      if (statusKey === 'upcoming') base.upcoming += 1;
+      else if (statusKey === 'ongoing') base.ongoing += 1;
+      else base.past += 1;
+      base.registered += Number.isFinite(event.registered) ? event.registered : 0;
+      base.capacity += Number.isFinite(event.capacity) ? event.capacity : 0;
+    }
+    const fillRate = base.capacity
+      ? Math.min(100, Math.round((base.registered / base.capacity) * 100))
+      : 0;
+    return { ...base, fillRate };
+  })();
+
+  const openCreate = () => {
+    setEdit(null);
+    setDetail(null);
+    resetForm();
+    setCreateOpen(true);
+  };
+
+  const openEdit = (event: EventItem) => {
+    setCreateOpen(false);
+    setDetail(null);
+    setEdit(event);
+    setForm({
+      title: event.title,
+      startAt: toLocalDateTimeInput(event.startAt),
+      endAt: toLocalDateTimeInput(event.endAt),
+      capacity: String(event.capacity ?? ''),
+    });
+    setErrors({});
+  };
+
+  const handleCreate = async (values: EventFormValues) => {
+    const validationErrors = validateForm(values);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
       return;
     }
+
     setSaving(true);
+    setErrors({});
     try {
-      const created = await apiCreateEvent(form);
+      const payload = {
+        title: values.title.trim(),
+        startAt: toISO(values.startAt),
+        endAt: toISO(values.endAt),
+        capacity: Number(values.capacity),
+      };
+      const created = await apiCreateEvent(payload);
       if (!created || typeof created !== 'object') {
         await load();
       } else {
         setEvents((prev) => [created as EventItem, ...prev]);
         setTotal((t) => t + 1);
       }
+      showToast('Event created', 'success');
       setCreateOpen(false);
-      setForm(emptyForm);
+      resetForm();
     } catch {
       showToast('Failed to create event', 'error');
     } finally {
@@ -105,34 +232,32 @@ const AdminEvents = () => {
     }
   };
 
-  const openEdit = (ev: EventItem) => {
-    setEdit(ev);
-    setForm({
-      title: ev.title,
-      startAt: ev.startAt.slice(0, 16),
-      endAt: ev.endAt.slice(0, 16),
-      capacity: ev.capacity,
-    });
-  };
-
-  const handleUpdate = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleUpdate = async (values: EventFormValues) => {
     if (!edit) return;
-    if (new Date(form.startAt) >= new Date(form.endAt)) {
-      showToast('startAt must be before endAt', 'error');
+    const validationErrors = validateForm(values);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
       return;
     }
+
     setSaving(true);
+    setErrors({});
     try {
-      const updated = await apiUpdateEvent(edit._id, form);
+      const payload = {
+        title: values.title.trim(),
+        startAt: toISO(values.startAt),
+        endAt: toISO(values.endAt),
+        capacity: Number(values.capacity),
+      };
+      const updated = await apiUpdateEvent(edit._id, payload);
       if (!updated || typeof updated !== 'object') {
         await load();
       } else {
-        setEvents((prev) =>
-          prev.map((ev) => (ev._id === edit._id ? (updated as EventItem) : ev)),
-        );
+        setEvents((prev) => prev.map((event) => (event._id === edit._id ? (updated as EventItem) : event)));
       }
+      showToast('Event updated', 'success');
       setEdit(null);
+      resetForm();
     } catch {
       showToast('Failed to update event', 'error');
     } finally {
@@ -140,45 +265,75 @@ const AdminEvents = () => {
     }
   };
 
-  const handleDelete = async (id: string) => {
-    if (!window.confirm('Delete this event?')) return;
+  const handleDelete = async (id: string, title?: string) => {
+    if (!window.confirm(`Delete ${title ?? 'this event'}?`)) return;
     try {
       await apiDeleteEvent(id);
-      setEvents((prev) => prev.filter((ev) => ev._id !== id));
+      setEvents((prev) => prev.filter((event) => event._id !== id));
       setTotal((t) => Math.max(0, t - 1));
+      setDetail((current) => (current?._id === id ? null : current));
+      showToast('Event deleted', 'success');
     } catch {
       showToast('Failed to delete event', 'error');
     }
   };
 
   const columns: Column<EventRow>[] = [
-    { key: 'title', label: 'Title' },
     {
-      key: 'startAt',
-      label: 'Start',
-      render: (ev) => new Date(ev.startAt).toLocaleString(),
+      key: 'title',
+      label: 'Event',
+      render: (event) => (
+        <div className="event-title">
+          <span className="event-title__name">{event.title}</span>
+          <span className="event-title__meta">Starts {formatDateTime(event.startAt)}</span>
+        </div>
+      ),
     },
     {
-      key: 'endAt',
-      label: 'End',
-      render: (ev) => new Date(ev.endAt).toLocaleString(),
+      key: 'startAt',
+      label: 'Schedule',
+      render: (event) => (
+        <div className="event-schedule">
+          <span>{formatDateTime(event.startAt)}</span>
+          <span aria-hidden className="event-schedule__arrow">→</span>
+          <span>{formatDateTime(event.endAt)}</span>
+        </div>
+      ),
     },
     {
       key: 'status',
       label: 'Status',
-      render: (ev) => <StatusChip status={ev.status as any} />,
+      render: (event) => <StatusChip status={(event.status as any) ?? 'upcoming'} />,
     },
-    { key: 'capacity', label: 'Capacity' },
-    { key: 'registered', label: 'Registered' },
+    {
+      key: 'registered',
+      label: 'Registrations',
+      render: (event) => (
+        <div className="registration-cell">
+          <span className="registration-cell__value">
+            {event.registered ?? 0} / {event.capacity ?? 0}
+          </span>
+          <div className="registration-progress" aria-hidden>
+            <div
+              className="registration-progress__bar"
+              style={{ width: `${getRegistrationProgress(event)}%` }}
+            />
+          </div>
+        </div>
+      ),
+    },
     {
       key: 'actions',
-      label: '',
-      render: (ev) => (
+      label: 'Actions',
+      render: (event) => (
         <div className="actions" data-label="Actions">
-          <button aria-label={`Edit ${ev.title}`} onClick={() => openEdit(ev)}>
+          <button type="button" onClick={() => setDetail(event)}>
+            View
+          </button>
+          <button type="button" onClick={() => openEdit(event)}>
             Edit
           </button>
-          <button aria-label={`Delete ${ev.title}`} onClick={() => handleDelete(ev._id)}>
+          <button type="button" onClick={() => handleDelete(event._id, event.title)}>
             Delete
           </button>
         </div>
@@ -188,20 +343,95 @@ const AdminEvents = () => {
 
   return (
     <div className="admin-events">
-      <h2>Events</h2>
-      <div className="filters">
-        <select value={status} onChange={(e) => setStatus(e.target.value)}>
-          <option value="">All</option>
-          <option value="upcoming">Upcoming</option>
-          <option value="ongoing">Ongoing</option>
-          <option value="past">Past</option>
-        </select>
-        <select value={sort} onChange={(e) => setSort(e.target.value)}>
-          <option value="-startAt">Newest</option>
-          <option value="startAt">Oldest</option>
-        </select>
-        <button onClick={() => setCreateOpen(true)}>Add Event</button>
+      <header className="admin-events__header">
+        <div>
+          <h2>Events</h2>
+          <p className="admin-events__subtitle">
+            Review upcoming activities, keep schedules accurate, and monitor registrations in real time.
+          </p>
+        </div>
+        <div className="summary-grid" role="status" aria-live="polite">
+          <article className="summary-card">
+            <h3>Visible</h3>
+            <p>{summary.visible}</p>
+          </article>
+          <article className="summary-card">
+            <h3>Upcoming</h3>
+            <p>{summary.upcoming}</p>
+          </article>
+          <article className="summary-card">
+            <h3>Ongoing</h3>
+            <p>{summary.ongoing}</p>
+          </article>
+          <article className="summary-card">
+            <h3>Registrations</h3>
+            <p>
+              {summary.registered} / {summary.capacity || '—'}
+            </p>
+            <div className="summary-card__progress" aria-hidden>
+              <div style={{ width: `${summary.fillRate}%` }} />
+            </div>
+          </article>
+        </div>
+      </header>
+
+      <div className="admin-events__filters">
+        <div className="filters__group">
+          <label htmlFor="event-search" className="sr-only">
+            Search events
+          </label>
+          <input
+            id="event-search"
+            className="filters__search"
+            placeholder="Search title"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setPage(1);
+            }}
+          />
+        </div>
+        <div className="filters__group">
+          <label htmlFor="event-status" className="sr-only">
+            Filter by status
+          </label>
+          <select
+            id="event-status"
+            value={status}
+            onChange={(e) => {
+              setStatus(e.target.value);
+              setPage(1);
+            }}
+          >
+            <option value="">All statuses</option>
+            <option value="upcoming">Upcoming</option>
+            <option value="ongoing">Ongoing</option>
+            <option value="past">Past</option>
+          </select>
+        </div>
+        <div className="filters__group">
+          <label htmlFor="event-sort" className="sr-only">
+            Sort events
+          </label>
+          <select
+            id="event-sort"
+            value={sort}
+            onChange={(e) => {
+              setSort(e.target.value);
+              setPage(1);
+            }}
+          >
+            <option value="-startAt">Start: Newest first</option>
+            <option value="startAt">Start: Oldest first</option>
+            <option value="-endAt">End: Newest first</option>
+            <option value="endAt">End: Oldest first</option>
+          </select>
+        </div>
+        <button type="button" className="filters__cta" onClick={openCreate}>
+          Add event
+        </button>
       </div>
+
       <DataTable<EventRow>
         columns={columns}
         rows={events as EventRow[]}
@@ -214,115 +444,80 @@ const AdminEvents = () => {
 
       {createOpen && (
         <div className="modal" role="dialog" aria-modal="true">
-          <form
+          <EventForm
             ref={createRef}
-            className="modal-content"
+            heading="Create event"
+            values={form}
+            errors={errors}
+            saving={saving}
+            submitLabel="Create"
+            onChange={(changes) => setForm((prev) => ({ ...prev, ...changes }))}
             onSubmit={handleCreate}
-          >
-            <h3>Create Event</h3>
-            <label>
-              Title
-              <input
-                value={form.title}
-                onChange={(e) => setForm({ ...form, title: e.target.value })}
-              />
-            </label>
-            <label>
-              Start
-              <input
-                type="datetime-local"
-                value={form.startAt}
-                onChange={(e) => setForm({ ...form, startAt: e.target.value })}
-              />
-            </label>
-            <label>
-              End
-              <input
-                type="datetime-local"
-                value={form.endAt}
-                onChange={(e) => setForm({ ...form, endAt: e.target.value })}
-              />
-            </label>
-            <label>
-              Capacity
-              <input
-                type="number"
-                value={form.capacity}
-                onChange={(e) =>
-                  setForm({ ...form, capacity: Number(e.target.value) })
-                }
-              />
-            </label>
-            <div className="modal-actions">
-              <button type="submit" disabled={saving}>
-                {saving ? 'Saving...' : 'Create'}
-              </button>
-              <button
-                type="button"
-                onClick={() => setCreateOpen(false)}
-                disabled={saving}
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
+            onCancel={() => {
+              setCreateOpen(false);
+              resetForm();
+            }}
+          />
         </div>
       )}
 
       {edit && (
         <div className="modal" role="dialog" aria-modal="true">
-          <form
+          <EventForm
             ref={editRef}
-            className="modal-content"
+            heading="Edit event"
+            values={form}
+            errors={errors}
+            saving={saving}
+            submitLabel="Save changes"
+            onChange={(changes) => setForm((prev) => ({ ...prev, ...changes }))}
             onSubmit={handleUpdate}
-          >
-            <h3>Edit Event</h3>
-            <label>
-              Title
-              <input
-                value={form.title}
-                onChange={(e) => setForm({ ...form, title: e.target.value })}
-              />
-            </label>
-            <label>
-              Start
-              <input
-                type="datetime-local"
-                value={form.startAt}
-                onChange={(e) => setForm({ ...form, startAt: e.target.value })}
-              />
-            </label>
-            <label>
-              End
-              <input
-                type="datetime-local"
-                value={form.endAt}
-                onChange={(e) => setForm({ ...form, endAt: e.target.value })}
-              />
-            </label>
-            <label>
-              Capacity
-              <input
-                type="number"
-                value={form.capacity}
-                onChange={(e) =>
-                  setForm({ ...form, capacity: Number(e.target.value) })
-                }
-              />
-            </label>
-            <div className="modal-actions">
-              <button type="submit" disabled={saving}>
-                {saving ? 'Saving...' : 'Save'}
+            onCancel={() => {
+              setEdit(null);
+              resetForm();
+            }}
+          />
+        </div>
+      )}
+
+      {detail && (
+        <div className="modal" role="dialog" aria-modal="true">
+          <div ref={detailRef} className="modal-content modal-content--detail">
+            <h3>{detail.title}</h3>
+            <dl className="event-detail">
+              <div>
+                <dt>Status</dt>
+                <dd>
+                  <StatusChip status={(detail.status as any) ?? 'upcoming'} />
+                </dd>
+              </div>
+              <div>
+                <dt>Starts</dt>
+                <dd>{formatDateTime(detail.startAt)}</dd>
+              </div>
+              <div>
+                <dt>Ends</dt>
+                <dd>{formatDateTime(detail.endAt)}</dd>
+              </div>
+              <div>
+                <dt>Registrations</dt>
+                <dd>
+                  {detail.registered ?? 0} / {detail.capacity ?? 0}
+                </dd>
+              </div>
+            </dl>
+            <div className="detail-actions">
+              <button type="button" onClick={() => openEdit(detail)}>
+                Edit
               </button>
-              <button
-                type="button"
-                onClick={() => setEdit(null)}
-                disabled={saving}
-              >
-                Cancel
+              <button type="button" onClick={() => handleDelete(detail._id, detail.title)}>
+                Delete
+              </button>
+              <button type="button" onClick={() => setDetail(null)}>
+                Close
               </button>
             </div>
-          </form>
+          </div>
         </div>
       )}
     </div>

--- a/client/src/pages/AdminEvents/EventForm.tsx
+++ b/client/src/pages/AdminEvents/EventForm.tsx
@@ -1,0 +1,137 @@
+import { forwardRef } from 'react';
+
+export interface EventFormValues {
+  title: string;
+  startAt: string;
+  endAt: string;
+  capacity: string;
+}
+
+export type EventFormErrors = Partial<Record<keyof EventFormValues, string>>;
+
+interface EventFormProps {
+  heading: string;
+  values: EventFormValues;
+  errors: EventFormErrors;
+  saving: boolean;
+  submitLabel: string;
+  onChange: (changes: Partial<EventFormValues>) => void;
+  onSubmit: (values: EventFormValues) => void;
+  onCancel: () => void;
+}
+
+const EventForm = forwardRef<HTMLFormElement, EventFormProps>(
+  (
+    {
+      heading,
+      values,
+      errors,
+      saving,
+      submitLabel,
+      onChange,
+      onSubmit,
+      onCancel,
+    },
+    ref,
+  ) => {
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      onSubmit(values);
+    };
+
+    return (
+      <form ref={ref} className="modal-content modal-content--form" onSubmit={handleSubmit}>
+        <h3>{heading}</h3>
+        <div className="form-field">
+          <label htmlFor="event-title">Title</label>
+          <input
+            id="event-title"
+            value={values.title}
+            onChange={(e) => onChange({ title: e.target.value })}
+            placeholder="Community meetup"
+            aria-invalid={Boolean(errors.title)}
+            aria-describedby={errors.title ? 'event-title-error' : undefined}
+            autoComplete="off"
+            required
+          />
+          {errors.title ? (
+            <p id="event-title-error" className="field-error">
+              {errors.title}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="form-field-grid">
+          <div className="form-field">
+            <label htmlFor="event-start">Start</label>
+            <input
+              id="event-start"
+              type="datetime-local"
+              value={values.startAt}
+              onChange={(e) => onChange({ startAt: e.target.value })}
+              aria-invalid={Boolean(errors.startAt)}
+              aria-describedby={errors.startAt ? 'event-start-error' : undefined}
+              required
+            />
+            {errors.startAt ? (
+              <p id="event-start-error" className="field-error">
+                {errors.startAt}
+              </p>
+            ) : null}
+          </div>
+          <div className="form-field">
+            <label htmlFor="event-end">End</label>
+            <input
+              id="event-end"
+              type="datetime-local"
+              value={values.endAt}
+              onChange={(e) => onChange({ endAt: e.target.value })}
+              aria-invalid={Boolean(errors.endAt)}
+              aria-describedby={errors.endAt ? 'event-end-error' : undefined}
+              required
+            />
+            {errors.endAt ? (
+              <p id="event-end-error" className="field-error">
+                {errors.endAt}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="form-field">
+          <label htmlFor="event-capacity">Capacity</label>
+          <input
+            id="event-capacity"
+            type="number"
+            min={1}
+            step={1}
+            inputMode="numeric"
+            value={values.capacity}
+            onChange={(e) => onChange({ capacity: e.target.value })}
+            aria-invalid={Boolean(errors.capacity)}
+            aria-describedby={errors.capacity ? 'event-capacity-error' : undefined}
+            required
+          />
+          {errors.capacity ? (
+            <p id="event-capacity-error" className="field-error">
+              {errors.capacity}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="modal-actions">
+          <button type="submit" disabled={saving}>
+            {saving ? 'Saving…' : submitLabel}
+          </button>
+          <button type="button" onClick={onCancel} disabled={saving}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    );
+  },
+);
+
+EventForm.displayName = 'EventForm';
+
+export default EventForm;

--- a/server/controllers/adminEventController.js
+++ b/server/controllers/adminEventController.js
@@ -49,7 +49,7 @@ const computeLifecycleStatus = (start, end, currentStatus) => {
 
 exports.listEvents = async (req, res, next) => {
   try {
-    const { status, page = 1, pageSize = 10, sort = '-startAt' } = req.query;
+    const { status, page = 1, pageSize = 10, sort = '-startAt', query } = req.query;
     const pageNumber = Math.max(1, parseInt(page, 10) || 1);
     const size = Math.min(
       MAX_PAGE_SIZE,
@@ -88,6 +88,10 @@ exports.listEvents = async (req, res, next) => {
         { status: { $in: ['completed', 'canceled'] } },
         { endAt: { $lt: now } },
       ];
+    }
+
+    if (typeof query === 'string' && query.trim()) {
+      filter.title = { $regex: query.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), $options: 'i' };
     }
 
     const [events, total] = await Promise.all([


### PR DESCRIPTION
## Summary
- redesign the admin events screen with search, richer metrics, detail view, and better focus management for the modals
- extract a reusable event form with inline validation for creating and editing events
- allow querying events by title through the admin API so the search field works

## Testing
- npm ci *(fails: registry returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c92854d5808332a9a35cc31a1d1cd2