### PR TITLE
Fix admin panel types for business requests

### DIFF
--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -245,6 +245,7 @@ export const rejectShop = async (id: string) => {
 
 export interface VerificationRequestParams {
   page?: number;
+  pageSize?: number;
   status?: string;
   profession?: string;
 }

--- a/client/src/pages/AdminPanel/AdminPanel.tsx
+++ b/client/src/pages/AdminPanel/AdminPanel.tsx
@@ -18,8 +18,11 @@ const AdminPanel = () => {
   useEffect(() => {
     (async () => {
       try {
-        const data = await fetchBusinessRequests({ status: 'pending' });
-        setShops(data);
+        const result = await fetchBusinessRequests({ status: 'pending' });
+        const items = Array.isArray(result.items)
+          ? (result.items as Shop[])
+          : [];
+        setShops(items);
       } catch {
         setShops([]);
       } finally {


### PR DESCRIPTION
## Summary
- allow verification request pagination params to include page size in the admin API client
- safely map pending business request responses to the shop list in the admin panel

## Testing
- npm run build *(fails: missing type definition packages for several dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5200b0bc8332afc914fc5b1ce2f1