### PR TITLE
Add admin analytics, shop, and product APIs

### DIFF
--- a/server/controllers/adminMetricsController.js
+++ b/server/controllers/adminMetricsController.js
@@ -1,0 +1,241 @@
+const mongoose = require('mongoose');
+const User = require('../models/User');
+const Shop = require('../models/Shop');
+const Order = require('../models/Order');
+const Event = require('../models/Event');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ORDER_EXCLUDED_STATUSES = ['cancelled', 'draft'];
+
+const startOfDay = (date) => {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+const parsePeriod = (period) => {
+  if (!period || typeof period !== 'string') return 30;
+  const trimmed = period.trim().toLowerCase();
+  if (!trimmed) return 30;
+  const match = trimmed.match(/^(\d+)([dwm])$/);
+  if (!match) return 30;
+  const value = Number(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return 30;
+  const unit = match[2];
+  if (unit === 'd') return Math.min(value, 365);
+  if (unit === 'w') return Math.min(value * 7, 365);
+  if (unit === 'm') return Math.min(value * 30, 365);
+  return 30;
+};
+
+const buildDateBuckets = (days) => {
+  const today = startOfDay(new Date());
+  const buckets = [];
+  for (let i = days - 1; i >= 0; i -= 1) {
+    const date = new Date(today.getTime() - i * DAY_MS);
+    const iso = date.toISOString().slice(0, 10);
+    buckets.push({ date, iso });
+  }
+  return buckets;
+};
+
+const orderStatusFilter = { status: { $nin: ORDER_EXCLUDED_STATUSES } };
+
+exports.getMetricsSummary = async (req, res, next) => {
+  try {
+    const now = new Date();
+    const todayStart = startOfDay(now);
+    const last7d = new Date(now.getTime() - 6 * DAY_MS);
+    last7d.setHours(0, 0, 0, 0);
+    const last30d = new Date(now.getTime() - 29 * DAY_MS);
+    last30d.setHours(0, 0, 0, 0);
+
+    const [
+      users,
+      shops,
+      ordersToday,
+      orders7d,
+      orders30d,
+      gmvAgg,
+      activeEvents,
+      signups30d,
+      distinctOrderUsers,
+      topShopsAgg,
+      topProductsAgg,
+    ] = await Promise.all([
+      User.countDocuments({}),
+      Shop.countDocuments({ status: 'approved' }),
+      Order.countDocuments({
+        ...orderStatusFilter,
+        createdAt: { $gte: todayStart },
+      }),
+      Order.countDocuments({
+        ...orderStatusFilter,
+        createdAt: { $gte: last7d },
+      }),
+      Order.countDocuments({
+        ...orderStatusFilter,
+        createdAt: { $gte: last30d },
+      }),
+      Order.aggregate([
+        { $match: orderStatusFilter },
+        { $group: { _id: null, total: { $sum: '$grandTotal' } } },
+      ]),
+      Event.countDocuments({ status: { $in: ['draft', 'published', 'ongoing'] } }),
+      User.countDocuments({ createdAt: { $gte: last30d } }),
+      Order.distinct('user', {
+        ...orderStatusFilter,
+        createdAt: { $gte: last30d },
+      }),
+      Order.aggregate([
+        {
+          $match: {
+            ...orderStatusFilter,
+            createdAt: { $gte: last30d },
+          },
+        },
+        { $group: { _id: '$shop', orders: { $sum: 1 } } },
+        { $sort: { orders: -1 } },
+        { $limit: 5 },
+        {
+          $lookup: {
+            from: 'shops',
+            localField: '_id',
+            foreignField: '_id',
+            as: 'shop',
+          },
+        },
+        { $unwind: '$shop' },
+        {
+          $project: {
+            _id: 0,
+            id: '$shop._id',
+            name: '$shop.name',
+            orders: 1,
+          },
+        },
+      ]),
+      Order.aggregate([
+        {
+          $match: {
+            ...orderStatusFilter,
+            createdAt: { $gte: last30d },
+          },
+        },
+        { $unwind: '$items' },
+        {
+          $group: {
+            _id: '$items.product',
+            orders: { $sum: '$items.qty' },
+            name: { $last: '$items.productSnapshot.name' },
+          },
+        },
+        { $sort: { orders: -1 } },
+        { $limit: 5 },
+      ]),
+    ]);
+
+    const gmv = Number(gmvAgg?.[0]?.total || 0);
+    const conversionBase = signups30d || users || 1;
+    const conversions = Math.round(
+      (distinctOrderUsers.length / conversionBase) * 100,
+    );
+
+    const topShops = topShopsAgg.map((item) => ({
+      id: item.id.toString(),
+      name: item.name,
+      orders: item.orders,
+    }));
+
+    const topProducts = topProductsAgg.map((item) => ({
+      id: item._id instanceof mongoose.Types.ObjectId ? item._id.toString() : String(item._id),
+      name: item.name || 'Unknown Product',
+      orders: item.orders,
+    }));
+
+    res.json({
+      ok: true,
+      data: {
+        users,
+        shops,
+        gmv,
+        ordersToday,
+        orders7d,
+        orders30d,
+        activeEvents,
+        conversions,
+        topShops,
+        topProducts,
+      },
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.getMetricSeries = async (req, res, next) => {
+  try {
+    const metric = req.query.metric;
+    const periodDays = parsePeriod(req.query.period);
+    const from = new Date(Date.now() - (periodDays - 1) * DAY_MS);
+    from.setHours(0, 0, 0, 0);
+
+    let seriesMap = new Map();
+
+    if (metric === 'signups') {
+      const rows = await User.aggregate([
+        { $match: { createdAt: { $gte: from } } },
+        {
+          $group: {
+            _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } },
+            value: { $sum: 1 },
+          },
+        },
+      ]);
+      seriesMap = new Map(rows.map((row) => [row._id, row.value]));
+    } else if (metric === 'gmv') {
+      const rows = await Order.aggregate([
+        {
+          $match: {
+            ...orderStatusFilter,
+            createdAt: { $gte: from },
+          },
+        },
+        {
+          $group: {
+            _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } },
+            value: { $sum: '$grandTotal' },
+          },
+        },
+      ]);
+      seriesMap = new Map(rows.map((row) => [row._id, Number(row.value || 0)]));
+    } else {
+      const rows = await Order.aggregate([
+        {
+          $match: {
+            ...orderStatusFilter,
+            createdAt: { $gte: from },
+          },
+        },
+        {
+          $group: {
+            _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } },
+            value: { $sum: 1 },
+          },
+        },
+      ]);
+      seriesMap = new Map(rows.map((row) => [row._id, row.value]));
+    }
+
+    const buckets = buildDateBuckets(periodDays);
+    const data = buckets.map(({ iso }) => ({
+      date: iso,
+      value: Number(seriesMap.get(iso) || 0),
+    }));
+
+    res.json({ ok: true, data, traceId: req.traceId });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/controllers/adminProductController.js
+++ b/server/controllers/adminProductController.js
@@ -1,0 +1,267 @@
+const mongoose = require('mongoose');
+const Product = require('../models/Product');
+const AppError = require('../utils/AppError');
+
+const STATUS_TO_INTERNAL = {
+  active: 'active',
+  inactive: 'archived',
+  archived: 'archived',
+};
+
+const parseSort = (raw, fallback = '-updatedAt') => {
+  const sort = typeof raw === 'string' && raw.trim() ? raw.trim() : fallback;
+  const direction = sort.startsWith('-') ? -1 : 1;
+  const key = sort.startsWith('-') ? sort.slice(1) : sort;
+  return { [key || 'updatedAt']: direction };
+};
+
+const sanitizeRegex = (value) => {
+  if (!value || typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(escaped, 'i');
+};
+
+const normalizeProduct = (doc) => {
+  const rawImages = Array.isArray(doc.images) ? doc.images : [];
+  const images = rawImages.filter((img) => typeof img === 'string' && img.trim());
+  const primaryImage = doc.image || images[0] || null;
+  if (!images.length && primaryImage) {
+    images.push(primaryImage);
+  }
+  const id =
+    doc._id instanceof mongoose.Types.ObjectId
+      ? doc._id.toString()
+      : String(doc._id);
+  const shopIdValue = doc.shop?._id || doc.shop;
+  const shopId =
+    shopIdValue instanceof mongoose.Types.ObjectId
+      ? shopIdValue.toString()
+      : shopIdValue
+      ? String(shopIdValue)
+      : undefined;
+  return {
+    _id: id,
+    id,
+    name: doc.name,
+    shopId,
+    shopName: doc.shop?.name || undefined,
+    category: doc.category,
+    price: doc.price,
+    mrp: doc.mrp,
+    discount: doc.discount,
+    stock: doc.stock,
+    status: doc.status,
+    image: primaryImage,
+    images,
+    updatedAt: doc.updatedAt,
+  };
+};
+
+exports.listProducts = async (req, res, next) => {
+  try {
+    const {
+      shopId,
+      query,
+      category,
+      status,
+      minPrice,
+      maxPrice,
+      sort = '-updatedAt',
+      page = 1,
+      pageSize = 10,
+    } = req.query;
+
+    const match = { isDeleted: { $ne: true } };
+    if (shopId && mongoose.Types.ObjectId.isValid(shopId)) {
+      match.shop = new mongoose.Types.ObjectId(shopId);
+    }
+    if (category) match.category = category;
+    if (status) {
+      const mapped = STATUS_TO_INTERNAL[status] || status;
+      match.status = mapped;
+    }
+    const hasMin = minPrice !== undefined && String(minPrice).trim() !== '';
+    const hasMax = maxPrice !== undefined && String(maxPrice).trim() !== '';
+    if (hasMin || hasMax) {
+      match.price = {};
+      if (hasMin) {
+        const value = Number(minPrice);
+        if (Number.isFinite(value)) {
+          match.price.$gte = value;
+        }
+      }
+      if (hasMax) {
+        const value = Number(maxPrice);
+        if (Number.isFinite(value)) {
+          match.price.$lte = value;
+        }
+      }
+      if (!Object.keys(match.price).length) {
+        delete match.price;
+      }
+    }
+    const search = sanitizeRegex(query);
+    if (search) {
+      match.name = search;
+    }
+
+    const sortObj = parseSort(sort, '-updatedAt');
+    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(pageSize, 10) || 10));
+    const skip = (pageNum - 1) * limit;
+
+    const pipeline = [
+      { $match: match },
+      {
+        $lookup: {
+          from: 'shops',
+          localField: 'shop',
+          foreignField: '_id',
+          as: 'shop',
+        },
+      },
+      { $unwind: '$shop' },
+      { $sort: sortObj },
+      { $skip: skip },
+      { $limit: limit },
+    ];
+
+    const [items, totalAgg] = await Promise.all([
+      Product.aggregate(pipeline),
+      Product.aggregate([
+        { $match: match },
+        { $count: 'count' },
+      ]),
+    ]);
+
+    const total = totalAgg[0]?.count || 0;
+
+    res.json({
+      ok: true,
+      data: {
+        items: items.map(normalizeProduct),
+        total,
+        page: pageNum,
+        pageSize: limit,
+      },
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.updateProduct = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw AppError.badRequest('INVALID_PRODUCT_ID', 'Invalid product id');
+    }
+
+    const product = await Product.findOne({ _id: id, isDeleted: { $ne: true } });
+    if (!product) {
+      throw AppError.notFound('PRODUCT_NOT_FOUND', 'Product not found');
+    }
+
+    const {
+      name,
+      price,
+      mrp,
+      stock,
+      status,
+      category,
+      images,
+      image,
+    } = req.body || {};
+
+    if (name !== undefined) product.name = name;
+    if (category !== undefined) product.category = category;
+    if (price !== undefined) {
+      const value = Number(price);
+      if (!(Number.isFinite(value) && value > 0)) {
+        throw AppError.badRequest('INVALID_PRICE', 'Price must be greater than zero');
+      }
+      product.price = value;
+    }
+    if (mrp !== undefined) {
+      const value = Number(mrp);
+      if (!(Number.isFinite(value) && value > 0)) {
+        throw AppError.badRequest('INVALID_MRP', 'MRP must be greater than zero');
+      }
+      product.mrp = value;
+    }
+    if (stock !== undefined) {
+      const value = Number(stock);
+      if (!Number.isFinite(value) || value < 0) {
+        throw AppError.badRequest('INVALID_STOCK', 'Stock must be a positive number');
+      }
+      product.stock = value;
+    }
+    if (status !== undefined) {
+      const mapped = STATUS_TO_INTERNAL[status] || status;
+      if (mapped) product.status = mapped;
+    }
+    if (image !== undefined) {
+      product.image = image;
+      if (image && (!Array.isArray(product.images) || !product.images.length)) {
+        product.images = [image];
+      }
+    }
+    if (images !== undefined) {
+      const list = Array.isArray(images)
+        ? images.filter((img) => typeof img === 'string' && img.trim())
+        : [];
+      product.images = list;
+      if (list.length) {
+        product.image = list[0];
+      } else if (!image) {
+        product.image = product.image || null;
+      }
+    }
+
+    if (req.user?._id) {
+      product.updatedBy = req.user._id;
+    }
+
+    await product.save();
+
+    const populated = await Product.findById(product._id)
+      .populate('shop', 'name')
+      .lean();
+
+    res.json({
+      ok: true,
+      data: normalizeProduct(populated || product.toObject()),
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.deleteProduct = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw AppError.badRequest('INVALID_PRODUCT_ID', 'Invalid product id');
+    }
+
+    const product = await Product.findOne({ _id: id, isDeleted: { $ne: true } });
+    if (!product) {
+      throw AppError.notFound('PRODUCT_NOT_FOUND', 'Product not found');
+    }
+
+    product.isDeleted = true;
+    product.deletedAt = new Date();
+    if (req.user?._id) {
+      product.updatedBy = req.user._id;
+    }
+    await product.save();
+
+    res.json({ ok: true, data: { message: 'Product deleted' }, traceId: req.traceId });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/controllers/adminShopController.js
+++ b/server/controllers/adminShopController.js
@@ -1,0 +1,344 @@
+const mongoose = require('mongoose');
+const Shop = require('../models/Shop');
+const Product = require('../models/Product');
+const AppError = require('../utils/AppError');
+
+const STATUS_TO_INTERNAL = {
+  active: 'approved',
+  approved: 'approved',
+  pending: 'pending',
+  suspended: 'rejected',
+  rejected: 'rejected',
+};
+
+const STATUS_TO_EXTERNAL = {
+  approved: 'active',
+  pending: 'pending',
+  rejected: 'suspended',
+};
+
+const toIdString = (value) => {
+  if (!value) return undefined;
+  if (value instanceof mongoose.Types.ObjectId) return value.toString();
+  return String(value);
+};
+
+const parseSort = (raw, fallback = '-createdAt') => {
+  const sort = typeof raw === 'string' && raw.trim() ? raw.trim() : fallback;
+  const direction = sort.startsWith('-') ? -1 : 1;
+  const key = sort.startsWith('-') ? sort.slice(1) : sort;
+  return { [key || 'createdAt']: direction };
+};
+
+const sanitizeRegex = (value) => {
+  if (!value || typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(escaped, 'i');
+};
+
+const mapShop = (doc) => {
+  const id = toIdString(doc._id);
+  const ownerId = toIdString(doc.owner?._id || doc.owner);
+  return {
+    _id: id,
+    id,
+    name: doc.name,
+    owner: doc.owner?.name || '',
+    ownerId,
+    category: doc.category,
+    location: doc.location,
+    status: STATUS_TO_EXTERNAL[doc.status] || doc.status,
+    productsCount: doc.productsCount ?? 0,
+    createdAt: doc.createdAt,
+  };
+};
+
+const mapRequest = (doc) => {
+  const id = toIdString(doc._id);
+  return {
+    _id: id,
+    id,
+    name: doc.name,
+    category: doc.category,
+    location: doc.location,
+    address: doc.address || '',
+    status: doc.status,
+    createdAt: doc.createdAt,
+    owner: doc.owner
+      ? {
+          _id: toIdString(doc.owner._id),
+          name: doc.owner.name,
+          phone: doc.owner.phone,
+        }
+      : null,
+  };
+};
+
+const buildShopPipeline = ({ match, search, withOwner = true }) => {
+  const pipeline = [{ $match: match }];
+
+  if (withOwner) {
+    pipeline.push(
+      {
+        $lookup: {
+          from: 'users',
+          localField: 'owner',
+          foreignField: '_id',
+          as: 'owner',
+        },
+      },
+      { $unwind: '$owner' },
+    );
+  }
+
+  if (search) {
+    pipeline.push({
+      $match: {
+        $or: [
+          { name: search },
+          ...(withOwner
+            ? [
+                { 'owner.name': search },
+                { 'owner.phone': search },
+              ]
+            : []),
+        ],
+      },
+    });
+  }
+
+  pipeline.push({
+    $lookup: {
+      from: 'products',
+      let: { shopId: '$_id' },
+      pipeline: [
+        {
+          $match: {
+            $expr: {
+              $and: [
+                { $eq: ['$shop', '$$shopId'] },
+                { $ne: ['$isDeleted', true] },
+              ],
+            },
+          },
+        },
+        { $count: 'count' },
+      ],
+      as: 'productsStats',
+    },
+  });
+
+  pipeline.push({
+    $addFields: {
+      productsCount: {
+        $ifNull: [{ $arrayElemAt: ['$productsStats.count', 0] }, 0],
+      },
+    },
+  });
+
+  pipeline.push({ $project: { productsStats: 0 } });
+
+  return pipeline;
+};
+
+exports.listShopRequests = async (req, res, next) => {
+  try {
+    const {
+      status = 'pending',
+      category,
+      location,
+      sort = '-createdAt',
+      page = 1,
+      pageSize = 10,
+    } = req.query;
+
+    const match = {};
+    if (status) {
+      const mappedStatus = STATUS_TO_INTERNAL[status] || status;
+      match.status = mappedStatus;
+    }
+    if (category) match.category = category;
+    if (location) match.location = location;
+
+    const sortObj = parseSort(sort, '-createdAt');
+    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(pageSize, 10) || 10));
+    const skip = (pageNum - 1) * limit;
+
+    const pipelineBase = buildShopPipeline({ match, search: null });
+
+    const [items, totalAgg] = await Promise.all([
+      Shop.aggregate([...pipelineBase, { $sort: sortObj }, { $skip: skip }, { $limit: limit }]),
+      Shop.aggregate([...pipelineBase, { $count: 'count' }]),
+    ]);
+
+    const total = totalAgg[0]?.count || 0;
+    const requests = items.map(mapRequest);
+
+    res.json({
+      ok: true,
+      data: {
+        items: requests,
+        requests,
+        total,
+        page: pageNum,
+        pageSize: limit,
+      },
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.listShops = async (req, res, next) => {
+  try {
+    const {
+      query,
+      status,
+      category,
+      sort = '-createdAt',
+      page = 1,
+      pageSize = 10,
+    } = req.query;
+
+    const match = {};
+    if (status) {
+      const mappedStatus = STATUS_TO_INTERNAL[status] || status;
+      match.status = mappedStatus;
+    }
+    if (category) match.category = category;
+
+    const search = sanitizeRegex(query);
+
+    const sortObj = parseSort(sort, '-createdAt');
+    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(pageSize, 10) || 10));
+    const skip = (pageNum - 1) * limit;
+
+    const pipelineBase = buildShopPipeline({ match, search });
+
+    const [items, totalAgg] = await Promise.all([
+      Shop.aggregate([...pipelineBase, { $sort: sortObj }, { $skip: skip }, { $limit: limit }]),
+      Shop.aggregate([...pipelineBase, { $count: 'count' }]),
+    ]);
+
+    const total = totalAgg[0]?.count || 0;
+    const shops = items.map(mapShop);
+
+    res.json({
+      ok: true,
+      data: {
+        items: shops,
+        total,
+        page: pageNum,
+        pageSize: limit,
+      },
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.updateShop = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw AppError.badRequest('INVALID_SHOP_ID', 'Invalid shop id');
+    }
+
+    const shop = await Shop.findById(id);
+    if (!shop) {
+      throw AppError.notFound('SHOP_NOT_FOUND', 'Shop not found');
+    }
+
+    const { name, category, location, status } = req.body || {};
+    if (name !== undefined) shop.name = name;
+    if (category !== undefined) shop.category = category;
+    if (location !== undefined) shop.location = location;
+    if (status !== undefined) {
+      const normalizedStatus =
+        typeof status === 'string' ? status.toLowerCase() : status;
+      const mappedStatus =
+        STATUS_TO_INTERNAL[normalizedStatus] || STATUS_TO_INTERNAL[status] || normalizedStatus;
+      if (mappedStatus && ['pending', 'approved', 'rejected'].includes(mappedStatus)) {
+        shop.status = mappedStatus;
+      }
+    }
+
+    await shop.save();
+
+    const [withOwner] = await Shop.aggregate([
+      ...buildShopPipeline({ match: { _id: shop._id }, search: null }),
+      { $limit: 1 },
+    ]);
+
+    res.json({
+      ok: true,
+      data: { shop: mapShop(withOwner || shop) },
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.deleteShop = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw AppError.badRequest('INVALID_SHOP_ID', 'Invalid shop id');
+    }
+
+    const shop = await Shop.findById(id);
+    if (!shop) {
+      throw AppError.notFound('SHOP_NOT_FOUND', 'Shop not found');
+    }
+
+    await Product.updateMany(
+      { shop: shop._id },
+      { $set: { isDeleted: true, deletedAt: new Date() } },
+    );
+    await shop.deleteOne();
+
+    res.json({ ok: true, data: { message: 'Shop deleted' }, traceId: req.traceId });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const transitionShopStatus = async (req, res, next, status) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw AppError.badRequest('INVALID_SHOP_ID', 'Invalid shop id');
+    }
+
+    const shop = await Shop.findById(id);
+    if (!shop) {
+      throw AppError.notFound('SHOP_NOT_FOUND', 'Shop not found');
+    }
+
+    shop.status = status;
+    await shop.save();
+
+    const [withOwner] = await Shop.aggregate([
+      ...buildShopPipeline({ match: { _id: shop._id }, search: null }),
+      { $limit: 1 },
+    ]);
+
+    res.json({
+      ok: true,
+      data: { shop: mapShop(withOwner || shop) },
+      traceId: req.traceId,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.approveShop = (req, res, next) => transitionShopStatus(req, res, next, 'approved');
+exports.rejectShop = (req, res, next) => transitionShopStatus(req, res, next, 'rejected');

--- a/server/models/Product.js
+++ b/server/models/Product.js
@@ -9,6 +9,7 @@ const productSchema = new Schema(
     mrp: { type: Number, required: true },
     discount: { type: Number, default: 0 },
     image: { type: String },
+    images: { type: [String], default: [] },
     category: { type: String, required: true },
     stock: { type: Number, default: 0 },
     available: { type: Boolean, default: true },

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -38,12 +38,13 @@ const userSchema = new mongoose.Schema(
     password: { type: String, required: true, select: false },
     role: {
       type: String,
-      enum: ["customer", "business", "admin"],
+      enum: ["customer", "verified", "business", "admin"],
       default: "customer",
     },
     location: { type: String },
     address: { type: String },
     isVerified: { type: Boolean, default: false },
+    isActive: { type: Boolean, default: true },
     verificationStatus: {
       type: String,
       enum: ["none", "pending", "approved", "rejected"],

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -9,7 +9,24 @@ const {
 } = require('../controllers/adminController');
 const { adminUpdate } = require('../controllers/userController');
 const { getAdminMessages } = require('../controllers/adminMessageController');
-const { approveShop, rejectShop } = require('../controllers/shopsController');
+const {
+  getMetricsSummary,
+  getMetricSeries,
+} = require('../controllers/adminMetricsController');
+const {
+  listShopRequests,
+  listShops,
+  updateShop,
+  deleteShop,
+  approveShop,
+  rejectShop,
+} = require('../controllers/adminShopController');
+const {
+  listProducts,
+  updateProduct: adminUpdateProduct,
+  deleteProduct: adminDeleteProduct,
+} = require('../controllers/adminProductController');
+const { listVerificationRequests } = require('../controllers/verifiedController');
 const protect = require('../middleware/authMiddleware');
 const isAdmin = require('../middleware/isAdmin');
 const validate = require('../middleware/validate');
@@ -41,7 +58,22 @@ router.delete('/users/:id', protect, isAdmin, deleteUser);
 router.put('/user/:id/verify', protect, isAdmin, verifyUser);
 router.get('/orders', protect, isAdmin, getAllOrders);
 
+router.get('/metrics', protect, isAdmin, getMetricsSummary);
+router.get('/metrics/timeseries', protect, isAdmin, getMetricSeries);
+
+router.get('/shops/requests', protect, isAdmin, listShopRequests);
+router.get('/shops', protect, isAdmin, listShops);
+router.put('/shops/:id', protect, isAdmin, updateShop);
+router.delete('/shops/:id', protect, isAdmin, deleteShop);
+router.post('/shops/approve/:id', protect, isAdmin, approveShop);
 router.post('/shops/:id/approve', protect, isAdmin, approveShop);
+router.post('/shops/reject/:id', protect, isAdmin, rejectShop);
 router.post('/shops/:id/reject', protect, isAdmin, rejectShop);
+
+router.get('/products', protect, isAdmin, listProducts);
+router.put('/products/:id', protect, isAdmin, adminUpdateProduct);
+router.delete('/products/:id', protect, isAdmin, adminDeleteProduct);
+
+router.get('/verified/requests', protect, isAdmin, listVerificationRequests);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add admin analytics controller for summary metrics and time-series data
- add admin shop and product controllers plus routes for managing pending requests, listings, and updates
- extend verification, user, and product models/controllers to support new admin capabilities and fix admin login tokens

## Testing
- npm test *(fails: jest not installed)*
- npm install *(fails: registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68cace87c53883329efdbac9e53c44fc