### PR TITLE
Allow admin login via env credentials

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -116,8 +116,13 @@ exports.adminLogin = async (req, res, next) => {
       const matchesEnv =
         normalizedEmail === String(process.env.ADMIN_EMAIL || '').toLowerCase() &&
         password === process.env.ADMIN_PASSWORD;
+
       if (matchesEnv) {
         adminUser = await User.findOne({ role: 'admin' }).select('_id');
+
+        if (!adminUser) {
+          adminUser = { role: 'admin' };
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- allow the admin login endpoint to accept ADMIN_EMAIL/ADMIN_PASSWORD even when no admin user record exists
- fall back to an in-memory admin placeholder so the JWT can still be issued

## Testing
- `npm test -- --runTestsByPath tests/auth.test.js` *(fails: jest not installed prior to npm install)*
- `npm install` *(fails: 403 fetching @types/jsonwebtoken from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcca97ec48332b4cb7dadbf7e7bf2