### PR TITLE
Serve SPA index for unmatched routes in production

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -91,6 +91,9 @@ app.use("/api/pros", proRoutes);
 if (process.env.NODE_ENV === "production") {
   const clientPath = path.join(__dirname, "..", "client", "dist");
   app.use(express.static(clientPath));
+  app.get(/^(?!\/api).*/, (_req, res) => {
+    res.sendFile(path.join(clientPath, "index.html"));
+  });
 }
 
 app.use((req, _res, next) => {


### PR DESCRIPTION
## Summary
- serve the built client index.html for non-API routes in production so the root path resolves correctly

## Testing
- npm test *(fails: jest not found because npm install was unable to download @types/jsonwebtoken due to 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe3ed01748332a1c69445461263fa