### PR TITLE
Fix login auth payload parsing and API base fallback

### DIFF
--- a/client/src/config/api.ts
+++ b/client/src/config/api.ts
@@ -1,2 +1,5 @@
-const base = import.meta.env.VITE_API_URL || '';
+const raw = import.meta.env.VITE_API_URL;
+const normalized = typeof raw === 'string' ? raw.trim() : '';
+const base = normalized || '/api';
+
 export const API_BASE = base.endsWith('/') ? base : `${base}/`;

--- a/client/src/lib/response.ts
+++ b/client/src/lib/response.ts
@@ -19,6 +19,15 @@ export const toItem = (res: any): any => {
   const d = res?.data ?? res;
   if (d && typeof d === 'object') {
     if (d.data && typeof d.data === 'object') {
+      const dataObj = d.data as Record<string, any>;
+      if (
+        typeof dataObj.token === 'string' &&
+        dataObj.token &&
+        dataObj.user &&
+        typeof dataObj.user === 'object'
+      ) {
+        return dataObj;
+      }
       if (d.data.shop && typeof d.data.shop === 'object') return d.data.shop;
       if (d.data.verified && typeof d.data.verified === 'object')
         return d.data.verified;

--- a/client/src/store/slices/authSlice.ts
+++ b/client/src/store/slices/authSlice.ts
@@ -17,6 +17,20 @@ interface AuthResponse {
   token: string;
 }
 
+const ensureAuthResponse = (payload: unknown): AuthResponse => {
+  if (
+    !payload ||
+    typeof payload !== 'object' ||
+    typeof (payload as { token?: unknown }).token !== 'string' ||
+    !(payload as { token?: string }).token ||
+    typeof (payload as { user?: unknown }).user !== 'object' ||
+    (payload as { user?: unknown }).user === null
+  ) {
+    throw new Error('Invalid auth response');
+  }
+  return payload as AuthResponse;
+};
+
 interface AuthState {
   user: User | null;
   token: string | null;
@@ -41,7 +55,7 @@ export const login = createAsyncThunk(
   ) => {
     try {
       const res = await http.post('/auth/login', creds);
-      return toItem(res) as AuthResponse;
+      return ensureAuthResponse(toItem(res));
     } catch (err) {
       return rejectWithValue(toErrorMessage(err));
     }
@@ -53,7 +67,7 @@ export const signup = createAsyncThunk(
   async (payload: SignupDraft, { rejectWithValue }) => {
     try {
       const res = await http.post('/auth/signup', payload);
-      return toItem(res) as AuthResponse;
+      return ensureAuthResponse(toItem(res));
     } catch (err) {
       return rejectWithValue(toErrorMessage(err));
     }


### PR DESCRIPTION
## Summary
- ensure the response helper returns the full auth payload so tokens persist after login
- validate auth API responses before updating state to avoid storing invalid credentials
- default the frontend API base URL to `/api` when no environment override is provided

## Testing
- npm install *(fails: 403 Forbidden fetching prettier)*
- npm run lint *(fails: missing @eslint/js because dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ccdd8d680883329662c9e098b91c26