### PR TITLE
Fix visibility filtering for events and verified lists

### DIFF
--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -146,11 +146,18 @@ exports.listEvents = async (req, res, next) => {
 
     const pageNumber = Math.max(Number(page) || 1, 1);
     const limit = Math.max(Math.min(Number(pageSize) || 12, 50), 1);
-    const filter = { visibility: 'public', status: { $ne: 'draft' } };
+    const filter = {};
 
     if (category) filter.category = category;
     if (type) filter.type = type;
     if (status) filter.status = status;
+    else filter.status = { $ne: 'draft' };
+
+    filter.$or = [
+      { visibility: 'public' },
+      { visibility: { $exists: false } },
+      { visibility: null },
+    ];
     if (from || to) {
       filter.startAt = {};
       if (from) filter.startAt.$gte = new Date(from);

--- a/server/controllers/verifiedController.js
+++ b/server/controllers/verifiedController.js
@@ -61,7 +61,15 @@ exports.listVerified = async (req, res, next) => {
     const skip = (pageNum - 1) * limit;
 
     const match = {};
-    if (status) match.status = status;
+    if (status === 'approved') {
+      match.$or = [
+        { status: 'approved' },
+        { status: { $exists: false } },
+        { status: null },
+      ];
+    } else if (status) {
+      match.status = status;
+    }
 
     const searchRegex = q ? new RegExp(q, 'i') : null;
     const locationRegex = location ? new RegExp(location, 'i') : null;


### PR DESCRIPTION
## Summary
- include legacy public events without an explicit visibility flag in event listings
- surface approved verified professionals even when older records lack a status field

## Testing
- npm test *(fails: jest not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cce45ef6908332bf00bb1b2b5a8bcd