### PR TITLE
Connect home endpoints to database and support upcoming events

### DIFF
--- a/client/src/components/ui/EventCard/EventCard.tsx
+++ b/client/src/components/ui/EventCard/EventCard.tsx
@@ -31,7 +31,9 @@ const EventCard = ({ event }: Props) => {
         <div className={styles.labels}>
           <span className={`${styles.badge} ${styles[event.type]}`}>{toLabel(event.type)}</span>
           <span className={styles.badge}>{toLabel(event.category)}</span>
-          <span className={`${styles.badge} ${styles.status}`}>{toLabel(event.status)}</span>
+          <span className={`${styles.badge} ${styles.status}`}>
+            {toLabel(event.lifecycleStatus || event.status)}
+          </span>
         </div>
       </div>
       <div className={styles.content}>

--- a/client/src/pages/Events/Events.tsx
+++ b/client/src/pages/Events/Events.tsx
@@ -14,7 +14,7 @@ const Events = () => {
 
   useEffect(() => {
     if (list.status === 'idle') {
-      dispatch(fetchEvents({ status: 'published' }));
+      dispatch(fetchEvents({ status: 'upcoming' }));
     }
   }, [list.status, dispatch]);
 
@@ -23,7 +23,7 @@ const Events = () => {
     return (
       <ErrorCard
         msg={list.error || 'Failed to load events'}
-        onRetry={() => dispatch(fetchEvents({ status: 'published' }))}
+        onRetry={() => dispatch(fetchEvents({ status: 'upcoming' }))}
       />
     );
   if (list.status === 'succeeded' && list.items.length === 0)
@@ -31,7 +31,7 @@ const Events = () => {
       <Empty
         msg="No events available right now."
         ctaText="Refresh"
-        onCta={() => dispatch(fetchEvents({ status: 'published' }))}
+        onCta={() => dispatch(fetchEvents({ status: 'upcoming' }))}
       />
     );
 

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -47,7 +47,7 @@ const Home = () => {
   useEffect(() => {
     if (shops.status === 'idle') d(fetchShops({ sort: '-createdAt', pageSize: 10 }));
     if (verified.status === 'idle') d(fetchVerified({ pageSize: 10 }));
-    if (events.status === 'idle') d(fetchEvents({ status: 'published', pageSize: 6 }));
+    if (events.status === 'idle') d(fetchEvents({ status: 'upcoming', pageSize: 6 }));
     if (products.status === 'idle') d(fetchSpecialProducts({ pageSize: 10 }));
   }, [shops.status, verified.status, events.status, products.status, d]);
 
@@ -103,7 +103,7 @@ const Home = () => {
         status={events.status}
         error={events.error}
         type="event"
-        onRetry={() => d(fetchEvents({ status: 'published', pageSize: 6 }))}
+        onRetry={() => d(fetchEvents({ status: 'upcoming', pageSize: 6 }))}
         navigate={navigate}
       />
       <Section

--- a/server/controllers/homeController.js
+++ b/server/controllers/homeController.js
@@ -1,3 +1,6 @@
+const Event = require('../models/Event');
+const User = require('../models/User');
+
 // Dummy static data for now — you’ll later fetch from DB
 exports.getBanner = async (req, res) => {
   res.json({
@@ -24,28 +27,309 @@ exports.getOffers = async (req, res) => {
   ]);
 };
 
-exports.getVerifiedUsers = async (req, res) => {
-  res.json([
-    { _id: "1", name: "Raju", profession: "Electrician" },
-    { _id: "2", name: "Priya", profession: "Tutor" },
-  ]);
+const toPositiveInt = (value, fallback, { min = 1, max = 50 } = {}) => {
+  const num = typeof value === 'number' ? value : parseInt(value, 10);
+  if (!Number.isFinite(num)) return fallback;
+  return Math.min(Math.max(num, min), max);
 };
 
-exports.getEvents = async (req, res) => {
-  res.json([
-    {
-      _id: "1",
-      name: "Cricket Tournament",
-      date: "2025-06-01",
-      time: "4:00 PM",
-    },
-    {
-      _id: "2",
-      name: "Job Fair",
-      date: "2025-06-05",
-      time: "10:00 AM",
-    },
-  ]);
+const buildLifecycleConditions = (lifecycleStatuses) => {
+  const now = new Date();
+  const conditions = [];
+  if (lifecycleStatuses.has('upcoming')) {
+    conditions.push({
+      $and: [
+        { startAt: { $gt: now } },
+        { status: { $nin: ['completed', 'canceled'] } },
+      ],
+    });
+  }
+  if (lifecycleStatuses.has('ongoing')) {
+    conditions.push({
+      $or: [
+        { status: 'ongoing' },
+        {
+          $and: [
+            { status: { $nin: ['completed', 'canceled'] } },
+            { startAt: { $lte: now } },
+            {
+              $or: [
+                { endAt: { $exists: false } },
+                { endAt: null },
+                { endAt: { $gte: now } },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  }
+  if (lifecycleStatuses.has('past')) {
+    conditions.push({
+      $or: [
+        { status: { $in: ['completed', 'canceled'] } },
+        { endAt: { $lt: now } },
+      ],
+    });
+  }
+  return conditions;
+};
+
+exports.getVerifiedUsers = async (req, res, next) => {
+  try {
+    const limit = toPositiveInt(req.query.limit ?? req.query.pageSize, 10, { max: 100 });
+    const search = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    const location = typeof req.query.location === 'string' ? req.query.location.trim() : '';
+    const statusParam = typeof req.query.status === 'string' ? req.query.status.trim() : '';
+
+    const matchStatus = (() => {
+      if (!statusParam || statusParam.toLowerCase() === 'approved') return 'approved';
+      if (['pending', 'rejected', 'all', 'any'].includes(statusParam.toLowerCase())) {
+        if (['all', 'any'].includes(statusParam.toLowerCase())) return null;
+        return statusParam.toLowerCase();
+      }
+      return statusParam;
+    })();
+
+    const searchRegex = search ? new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') : null;
+    const locationRegex = location ? new RegExp(location.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') : null;
+
+    const basePipeline = [
+      { $match: { isActive: { $ne: false }, role: { $ne: 'admin' } } },
+      {
+        $lookup: {
+          from: 'verifieds',
+          localField: '_id',
+          foreignField: 'user',
+          as: 'verifiedProfile',
+        },
+      },
+      {
+        $addFields: {
+          verifiedProfile: { $first: '$verifiedProfile' },
+          resolvedStatus: {
+            $ifNull: [
+              { $ifNull: ['$verifiedProfile.status', null] },
+              {
+                $cond: [
+                  { $eq: ['$isVerified', true] },
+                  'approved',
+                  { $ifNull: ['$verificationStatus', 'pending'] },
+                ],
+              },
+            ],
+          },
+          resolvedProfession: {
+            $ifNull: [
+              { $ifNull: ['$verifiedProfile.profession', null] },
+              { $ifNull: ['$profession', ''] },
+            ],
+          },
+          resolvedBio: {
+            $ifNull: [
+              { $ifNull: ['$verifiedProfile.bio', null] },
+              { $ifNull: ['$bio', ''] },
+            ],
+          },
+          resolvedPortfolio: {
+            $cond: [
+              { $isArray: '$verifiedProfile.portfolio' },
+              '$verifiedProfile.portfolio',
+              {
+                $cond: [
+                  { $isArray: '$portfolio' },
+                  '$portfolio',
+                  [],
+                ],
+              },
+            ],
+          },
+          resolvedRatingAvg: {
+            $ifNull: ['$verifiedProfile.ratingAvg', 0],
+          },
+          resolvedRatingCount: {
+            $ifNull: ['$verifiedProfile.ratingCount', 0],
+          },
+          cardId: {
+            $ifNull: ['$verifiedProfile._id', '$_id'],
+          },
+          cardCreatedAt: {
+            $ifNull: ['$verifiedProfile.createdAt', '$createdAt'],
+          },
+          cardUpdatedAt: {
+            $ifNull: ['$verifiedProfile.updatedAt', '$updatedAt'],
+          },
+          userId: '$_id',
+        },
+      },
+    ];
+
+    if (matchStatus) {
+      basePipeline.push({ $match: { resolvedStatus: matchStatus } });
+    }
+
+    if (searchRegex) {
+      basePipeline.push({
+        $match: {
+          $or: [
+            { resolvedProfession: searchRegex },
+            { resolvedBio: searchRegex },
+            { name: searchRegex },
+          ],
+        },
+      });
+    }
+
+    if (locationRegex) {
+      basePipeline.push({ $match: { location: locationRegex } });
+    }
+
+    const itemsPipeline = [
+      ...basePipeline,
+      { $sort: { cardUpdatedAt: -1, name: 1 } },
+      { $limit: limit },
+      {
+        $project: {
+          _id: '$cardId',
+          userId: 1,
+          name: 1,
+          phone: 1,
+          location: 1,
+          address: 1,
+          profession: '$resolvedProfession',
+          bio: '$resolvedBio',
+          portfolio: '$resolvedPortfolio',
+          status: '$resolvedStatus',
+          ratingAvg: '$resolvedRatingAvg',
+          ratingCount: '$resolvedRatingCount',
+          createdAt: '$cardCreatedAt',
+          updatedAt: '$cardUpdatedAt',
+        },
+      },
+    ];
+
+    const items = await User.aggregate(itemsPipeline);
+
+    const cards = items.map((doc) => ({
+      id: String(doc._id),
+      _id: String(doc._id),
+      user: {
+        _id: String(doc.userId),
+        name: doc.name,
+        phone: doc.phone,
+        location: doc.location || '',
+        address: doc.address || '',
+      },
+      profession: doc.profession || '',
+      bio: doc.bio || '',
+      portfolio: Array.isArray(doc.portfolio) ? doc.portfolio : [],
+      status: doc.status || 'pending',
+      ratingAvg: typeof doc.ratingAvg === 'number' ? doc.ratingAvg : 0,
+      ratingCount: typeof doc.ratingCount === 'number' ? doc.ratingCount : 0,
+      createdAt: doc.createdAt,
+      updatedAt: doc.updatedAt,
+    }));
+
+    res.json(cards);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.getEvents = async (req, res, next) => {
+  try {
+    const limit = toPositiveInt(req.query.limit ?? req.query.pageSize, 6, { max: 50 });
+    const statusParam = typeof req.query.status === 'string' ? req.query.status.trim() : '';
+    const category = typeof req.query.category === 'string' ? req.query.category.trim() : '';
+    const type = typeof req.query.type === 'string' ? req.query.type.trim() : '';
+
+    const visibilityFilter = {
+      $or: [
+        { visibility: 'public' },
+        { visibility: { $exists: false } },
+        { visibility: null },
+      ],
+    };
+
+    const conditions = [visibilityFilter];
+
+    if (category) conditions.push({ category });
+    if (type) conditions.push({ type });
+
+    if (statusParam) {
+      const tokens = statusParam
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean);
+
+      const lifecycleStatuses = new Set();
+      const eventStatuses = new Set();
+      let includeAll = false;
+
+      for (const token of tokens) {
+        if (['all', 'any'].includes(token)) {
+          includeAll = true;
+          continue;
+        }
+        if (['upcoming', 'ongoing', 'past'].includes(token)) {
+          lifecycleStatuses.add(token);
+        } else {
+          eventStatuses.add(token);
+        }
+      }
+
+      if (!includeAll && eventStatuses.size) {
+        const statusesArray = Array.from(eventStatuses);
+        conditions.push(
+          statusesArray.length === 1
+            ? { status: statusesArray[0] }
+            : { status: { $in: statusesArray } }
+        );
+      }
+
+      if (lifecycleStatuses.size) {
+        const lifecycleConditions = buildLifecycleConditions(lifecycleStatuses);
+        if (lifecycleConditions.length === 1) conditions.push(lifecycleConditions[0]);
+        else if (lifecycleConditions.length > 1)
+          conditions.push({ $or: lifecycleConditions });
+      }
+
+      if (!includeAll && !eventStatuses.size && !lifecycleStatuses.size) {
+        conditions.push({ status: statusParam });
+      }
+    } else {
+      conditions.push({ status: { $ne: 'draft' } });
+    }
+
+    const filter = conditions.length === 1 ? conditions[0] : { $and: conditions };
+
+    const events = await Event.find(filter)
+      .sort({ startAt: 1, createdAt: -1 })
+      .limit(limit);
+
+    const items = events.map((event) => {
+      const card = event.toCardJSON();
+      let derived = 'upcoming';
+      const now = new Date();
+      if (
+        event.status === 'canceled' ||
+        event.status === 'completed' ||
+        (event.endAt && event.endAt < now)
+      ) {
+        derived = 'past';
+      } else if (
+        event.status === 'ongoing' ||
+        (event.startAt <= now && (!event.endAt || event.endAt >= now))
+      ) {
+        derived = 'ongoing';
+      }
+      return { ...card, lifecycleStatus: derived };
+    });
+
+    res.json(items);
+  } catch (err) {
+    next(err);
+  }
 };
 
 exports.getSpecialProducts = async (req, res) => {


### PR DESCRIPTION
## Summary
- replace the placeholder home endpoints with database-backed queries for verified users and events, including lifecycle-aware filtering and sanitised pagination
- enhance the public events API so status filters understand lifecycle values (upcoming/ongoing/past) and attach a derived `lifecycleStatus` to each card
- allow verified listings and details to fall back to user records when a dedicated profile is missing and update the client to surface upcoming events using the new lifecycle status

## Testing
- `npm test` *(fails: jest command not available in environment)*
- `npm run build` *(fails: npm install blocked by registry access so dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8efbad18833281044fe48310874d