### PR TITLE
Implement business request flow for user profiles

### DIFF
--- a/client/src/api/profile.ts
+++ b/client/src/api/profile.ts
@@ -25,6 +25,7 @@ export interface BusinessRequest {
   location: string;
   address: string;
   description?: string;
+  image?: string;
 }
 
 export interface VerifyRequest {
@@ -54,7 +55,8 @@ export const updateMyVerified = async (data: VerifyRequest) => {
 };
 
 export const requestBusiness = async (data: BusinessRequest) => {
-  await http.post('/shops', data);
+  const res = await http.post('/shops', data);
+  return res.data;
 };
 
 export const getMyBusinessRequest = async () => {

--- a/client/src/pages/Profile/Profile.module.scss
+++ b/client/src/pages/Profile/Profile.module.scss
@@ -75,6 +75,23 @@
   cursor: pointer;
 }
 
+.editBtn[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.requestActions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.requestActions .editBtn {
+  margin-top: 0;
+}
+
 .actions {
   display: flex;
   flex-direction: column;
@@ -90,6 +107,11 @@
   background: var(--color-primary);
   color: var(--color-on-primary);
   cursor: pointer;
+}
+
+.businessPending {
+  background: var(--color-warning, #f59e0b);
+  color: var(--color-surface);
 }
 
 .modalContent {

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -13,4 +13,5 @@ export interface User {
   avatar?: string | null;
   avatarUrl?: string | null;
   preferences?: { theme: 'light' | 'dark' | 'colored' };
+  businessStatus?: 'none' | 'pending' | 'approved' | 'rejected';
 }

--- a/server/controllers/adminShopController.js
+++ b/server/controllers/adminShopController.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const Shop = require('../models/Shop');
 const Product = require('../models/Product');
+const User = require('../models/User');
 const AppError = require('../utils/AppError');
 
 const STATUS_TO_INTERNAL = {
@@ -324,6 +325,14 @@ const transitionShopStatus = async (req, res, next, status) => {
 
     shop.status = status;
     await shop.save();
+
+    if (shop.owner) {
+      const update = { businessStatus: status };
+      if (status === 'approved') {
+        update.role = 'business';
+      }
+      await User.findByIdAndUpdate(shop.owner, update);
+    }
 
     const [withOwner] = await Shop.aggregate([
       ...buildShopPipeline({ match: { _id: shop._id }, search: null }),

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -55,6 +55,11 @@ const userSchema = new mongoose.Schema(
     bio: { type: String, maxlength: 500 },
     avatarUrl: { type: String },
     preferences: { type: preferencesSchema, default: () => ({}) },
+    businessStatus: {
+      type: String,
+      enum: ["none", "pending", "approved", "rejected"],
+      default: "none",
+    },
   },
   { timestamps: true }
 );
@@ -87,6 +92,7 @@ userSchema.methods.toProfileJSON = function () {
     bio: this.bio ?? "",
     avatar: this.avatarUrl ?? null,
     avatarUrl: this.avatarUrl ?? null,
+    businessStatus: this.businessStatus ?? "none",
   };
 };
 

--- a/server/routes/shopRoutes.js
+++ b/server/routes/shopRoutes.js
@@ -3,6 +3,7 @@ const ctrl = require('../controllers/shopsController');
 const auth = require('../middleware/auth');
 
 r.get('/', ctrl.getAllShops);
+r.get('/my', auth, ctrl.getMyShops);
 r.get('/:id', ctrl.getShopById);
 r.get('/:id/products', ctrl.getProductsByShop);
 r.post('/', auth, ctrl.createShop);


### PR DESCRIPTION
## Summary
- add a Request Business modal on the profile page that validates required shop fields and posts requests
- surface pending business status on the user profile while disabling duplicate submissions
- persist business status on users and expose owner shop endpoints so admin approvals update roles correctly

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e36bd044788332867a1ab49fbaf535