### PR TITLE
Fix admin verification request status persistence

### DIFF
--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -291,12 +291,14 @@ export const fetchVerificationRequests = async (
   };
 };
 
-export const acceptVerification = async (id: string) => {
-  await adminApi.post(withAdminPrefix(`verified/${id}/approve`));
-};
-
-export const rejectVerification = async (id: string) => {
-  await adminApi.post(withAdminPrefix(`verified/${id}/reject`));
+export const updateVerificationRequest = async (
+  id: string,
+  status: 'pending' | 'approved' | 'rejected',
+) => {
+  return adminApi.patch(
+    withAdminPrefix(`verification-requests/${id}`),
+    { status },
+  );
 };
 
 export interface ShopQueryParams {

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -26,7 +26,10 @@ const {
   updateProduct: adminUpdateProduct,
   deleteProduct: adminDeleteProduct,
 } = require('../controllers/adminProductController');
-const { listVerificationRequests } = require('../controllers/verifiedController');
+const {
+  listVerificationRequests,
+  updateVerificationRequestStatus,
+} = require('../controllers/verifiedController');
 const protect = require('../middleware/authMiddleware');
 const isAdmin = require('../middleware/isAdmin');
 const validate = require('../middleware/validate');
@@ -75,5 +78,11 @@ router.put('/products/:id', protect, isAdmin, adminUpdateProduct);
 router.delete('/products/:id', protect, isAdmin, adminDeleteProduct);
 
 router.get('/verified/requests', protect, isAdmin, listVerificationRequests);
+router.patch(
+  '/verification-requests/:id',
+  protect,
+  isAdmin,
+  updateVerificationRequestStatus
+);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add a PATCH `/api/admin/verification-requests/:id` endpoint that persists verification request status changes and returns the updated request payload
- update the admin API client and verification requests table to use the new endpoint, refresh rows via `toItem`, and keep the status/toast in sync

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e36f26a60883329673732a4803af7d