### PR TITLE
Standardize list page loading/error states

### DIFF
--- a/client/src/components/common/Empty.tsx
+++ b/client/src/components/common/Empty.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import EmptyState from '../ui/EmptyState';
 
 interface Props {
   msg: string;
@@ -6,15 +6,8 @@ interface Props {
   onCta?: () => void;
 }
 
-const Empty: React.FC<Props> = ({ msg, ctaText, onCta }) => (
-  <div className="empty-state" style={{ textAlign: "center", padding: "2rem" }}>
-    <p>{msg}</p>
-    {ctaText && onCta && (
-      <button onClick={onCta} className="btn" style={{ marginTop: "1rem" }}>
-        {ctaText}
-      </button>
-    )}
-  </div>
+const Empty = ({ msg, ctaText, onCta }: Props) => (
+  <EmptyState message={msg} ctaLabel={ctaText} onCtaClick={onCta} />
 );
 
 export default Empty;

--- a/client/src/components/common/ErrorCard.tsx
+++ b/client/src/components/common/ErrorCard.tsx
@@ -1,19 +1,22 @@
-import React from "react";
+import type { ReactNode } from 'react';
+import ErrorCard from '../ui/ErrorCard';
 
 interface Props {
   msg: string;
   onRetry?: () => void;
+  title?: string;
+  retryLabel?: string;
+  actions?: ReactNode;
 }
 
-const ErrorCard: React.FC<Props> = ({ msg, onRetry }) => (
-  <div className="error-card" style={{ textAlign: "center", padding: "2rem" }}>
-    <p>{msg}</p>
-    {onRetry && (
-      <button onClick={onRetry} className="btn" style={{ marginTop: "1rem" }}>
-        Retry
-      </button>
-    )}
-  </div>
+const LegacyErrorCard = ({ msg, onRetry, title, retryLabel, actions }: Props) => (
+  <ErrorCard
+    title={title}
+    message={msg}
+    retryLabel={retryLabel}
+    onRetry={onRetry}
+    actions={actions}
+  />
 );
 
-export default ErrorCard;
+export default LegacyErrorCard;

--- a/client/src/components/ui/EmptyState.module.scss
+++ b/client/src/components/ui/EmptyState.module.scss
@@ -1,23 +1,47 @@
 .empty {
   text-align: center;
-  padding: var(--space-6) 0;
-  color: var(--color-text-secondary);
+  padding: 2.5rem 1.5rem;
+  color: var(--color-text-secondary, #64748b);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--space-4);
+  gap: 1rem;
+  border-radius: 1.25rem;
+  border: 1px dashed var(--color-border, #d1d5db);
+  background: var(--color-surface, #ffffff);
 }
 
 .image {
-  width: 160px;
+  width: 180px;
   height: auto;
 }
 
+.title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text, #0f172a);
+}
+
+.message {
+  margin: 0;
+  max-width: 480px;
+  line-height: 1.6;
+}
+
 .cta {
-  padding: var(--space-3) var(--space-5);
-  background: var(--color-primary);
-  color: var(--color-on-primary);
+  padding: 0.6rem 1.5rem;
+  background: var(--color-primary, #2563eb);
+  color: var(--color-on-primary, #ffffff);
   border: none;
-  border-radius: var(--radius-sm);
+  border-radius: 999px;
   cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.cta:hover,
+.cta:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.2);
 }

--- a/client/src/components/ui/EmptyState.tsx
+++ b/client/src/components/ui/EmptyState.tsx
@@ -1,16 +1,18 @@
 import styles from './EmptyState.module.scss';
 
 interface EmptyStateProps {
+  title?: string;
   message: string;
   image?: string;
   ctaLabel?: string;
   onCtaClick?: () => void;
 }
 
-const EmptyState = ({ message, image, ctaLabel, onCtaClick }: EmptyStateProps) => (
+const EmptyState = ({ title, message, image, ctaLabel, onCtaClick }: EmptyStateProps) => (
   <div className={styles.empty}>
     {image && <img src={image} alt="" className={styles.image} />}
-    <p>{message}</p>
+    {title && <h3 className={styles.title}>{title}</h3>}
+    <p className={styles.message}>{message}</p>
     {ctaLabel && onCtaClick && (
       <button type="button" className={styles.cta} onClick={onCtaClick}>
         {ctaLabel}

--- a/client/src/components/ui/ErrorCard.module.scss
+++ b/client/src/components/ui/ErrorCard.module.scss
@@ -1,0 +1,53 @@
+.card {
+  padding: 1.75rem;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--color-surface, #ffffff);
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text, #0f172a);
+}
+
+.message {
+  margin: 0;
+  color: var(--color-text-secondary, #64748b);
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.retry {
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--color-primary, #2563eb);
+  color: var(--color-on-primary, #ffffff);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.retry:focus-visible,
+.retry:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.25);
+}
+
+.retry:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  box-shadow: none;
+}

--- a/client/src/components/ui/ErrorCard.tsx
+++ b/client/src/components/ui/ErrorCard.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import styles from './ErrorCard.module.scss';
+
+interface ErrorCardProps {
+  title?: string;
+  message: string;
+  retryLabel?: string;
+  onRetry?: () => void;
+  actions?: ReactNode;
+}
+
+const ErrorCard = ({
+  title = 'Something went wrong',
+  message,
+  retryLabel = 'Retry',
+  onRetry,
+  actions,
+}: ErrorCardProps) => (
+  <div className={styles.card} role="alert">
+    {title && <h3 className={styles.title}>{title}</h3>}
+    <p className={styles.message}>{message}</p>
+    {(onRetry || actions) && (
+      <div className={styles.actions}>
+        {onRetry && (
+          <button type="button" className={styles.retry} onClick={onRetry}>
+            {retryLabel}
+          </button>
+        )}
+        {actions}
+      </div>
+    )}
+  </div>
+);
+
+export default ErrorCard;

--- a/client/src/components/ui/SkeletonList.module.scss
+++ b/client/src/components/ui/SkeletonList.module.scss
@@ -1,0 +1,37 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--color-surface, #ffffff);
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+}
+
+.avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.line {
+  height: 0.75rem;
+  border-radius: 999px;
+}

--- a/client/src/components/ui/SkeletonList.tsx
+++ b/client/src/components/ui/SkeletonList.tsx
@@ -1,0 +1,52 @@
+import Shimmer from '../Shimmer';
+import styles from './SkeletonList.module.scss';
+
+interface SkeletonListProps {
+  count?: number;
+  lines?: number;
+  className?: string;
+  itemClassName?: string;
+  withAvatar?: boolean;
+}
+
+const SkeletonList = ({
+  count = 5,
+  lines = 2,
+  className,
+  itemClassName,
+  withAvatar = false,
+}: SkeletonListProps) => {
+  const items = Array.from({ length: Math.max(0, count) });
+  const lineCount = Math.max(1, lines);
+
+  return (
+    <div className={[styles.list, className].filter(Boolean).join(' ')}>
+      {items.map((_, itemIndex) => (
+        <div
+          key={itemIndex}
+          className={[styles.item, itemClassName].filter(Boolean).join(' ')}
+        >
+          {withAvatar && <Shimmer className={styles.avatar} />}
+          <div className={styles.body}>
+            {Array.from({ length: lineCount }).map((__, lineIndex) => {
+              const width = lineIndex === 0
+                ? '70%'
+                : lineIndex === lineCount - 1
+                  ? '45%'
+                  : '85%';
+              return (
+                <Shimmer
+                  key={`${itemIndex}-${lineIndex}`}
+                  className={styles.line}
+                  style={{ width }}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default SkeletonList;

--- a/client/src/pages/Verified/List.module.scss
+++ b/client/src/pages/Verified/List.module.scss
@@ -20,6 +20,18 @@
   gap: 1rem;
 }
 
+.skeletonGrid {
+  display: grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.cardSkeleton {
+  flex-direction: column !important;
+  align-items: stretch !important;
+  min-height: 160px;
+}
+
 .empty {
   text-align: center;
   margin-top: 2rem;


### PR DESCRIPTION
## Summary
- add shared SkeletonList and ErrorCard components and refresh the EmptyState visuals for reuse
- update admin list screens, verified users, and notifications to show skeleton, error, and empty states consistently
- improve home banner handling with retryable errors, empty messaging, and guarded mapping

## Testing
- npm run lint *(fails: missing @eslint/js package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e37c2c591c8332b3932af18b30ffd6