### PR TITLE
Fix retry counter access on axios config

### DIFF
--- a/client/src/lib/http.ts
+++ b/client/src/lib/http.ts
@@ -42,7 +42,7 @@ const shouldRetry = (error: AxiosError): error is AxiosError & {
   const method = (config.method || 'get').toLowerCase();
   if (!RETRYABLE_METHODS.has(method)) return false;
 
-  const retries = config.__retryCount ?? 0;
+  const retries = (config as AugmentedConfig).__retryCount ?? 0;
   if (retries >= MAX_RETRIES) return false;
 
   const status = response?.status;


### PR DESCRIPTION
## Summary
- ensure the axios retry logic reads the augmented request config via a type assertion to satisfy TypeScript

## Testing
- npm run build *(fails: existing TypeScript errors about missing modules and implicit any parameters)*

------
https://chatgpt.com/codex/tasks/task_e_68e390f4fff88332b0d8f6d74cddd5b6