### PR TITLE
Fix order status options and auth user lookup

### DIFF
--- a/client/src/pages/Orders/MyOrders.tsx
+++ b/client/src/pages/Orders/MyOrders.tsx
@@ -23,12 +23,16 @@ import { paths } from '@/routes/paths';
 
 const statusOptions: (OrderStatus | 'all')[] = [
   'all',
+  'draft',
+  'pending',
   'placed',
   'confirmed',
+  'accepted',
   'preparing',
   'ready',
   'out_for_delivery',
   'delivered',
+  'completed',
   'cancelled',
   'returned',
 ];
@@ -37,12 +41,16 @@ const cancellableStatuses = new Set<OrderStatus>(['placed', 'confirmed', 'prepar
 
 const statusDisplay: Record<OrderStatus | 'all', string> = {
   all: 'All',
+  draft: 'Draft',
+  pending: 'Pending',
   placed: 'Placed',
   confirmed: 'Confirmed',
+  accepted: 'Accepted',
   preparing: 'Preparing',
   ready: 'Ready',
   out_for_delivery: 'Out for delivery',
   delivered: 'Delivered',
+  completed: 'Completed',
   cancelled: 'Cancelled',
   returned: 'Returned',
 };

--- a/client/src/pages/Orders/OrderDetail.tsx
+++ b/client/src/pages/Orders/OrderDetail.tsx
@@ -18,7 +18,7 @@ const cancellableStatuses = new Set(['placed', 'confirmed', 'preparing']);
 const OrderDetail = () => {
   const { id } = useParams();
   const dispatch = useDispatch<AppDispatch>();
-  const authUserId = useSelector((state: RootState) => state.auth.user?._id || null);
+  const authUserId = useSelector((state: RootState) => state.auth.user?.id || null);
   const [order, setOrder] = useState<Order | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/client/src/pages/Orders/ReceivedOrders.tsx
+++ b/client/src/pages/Orders/ReceivedOrders.tsx
@@ -21,24 +21,32 @@ import { useNavigate } from 'react-router-dom';
 
 const statusOptions: (OrderStatus | 'all')[] = [
   'all',
+  'draft',
+  'pending',
   'placed',
   'confirmed',
+  'accepted',
   'preparing',
   'ready',
   'out_for_delivery',
   'delivered',
+  'completed',
   'cancelled',
   'returned',
 ];
 
 const statusDisplay: Record<OrderStatus | 'all', string> = {
   all: 'All',
+  draft: 'Draft',
+  pending: 'Pending',
   placed: 'Placed',
   confirmed: 'Confirmed',
+  accepted: 'Accepted',
   preparing: 'Preparing',
   ready: 'Ready',
   out_for_delivery: 'Out for delivery',
   delivered: 'Delivered',
+  completed: 'Completed',
   cancelled: 'Cancelled',
   returned: 'Returned',
 };


### PR DESCRIPTION
## Summary
- add the missing order status values to the status filters for my and received orders
- use the typed user id field in the order detail screen instead of a non-existent `_id`

## Testing
- npm run build *(fails: missing dependencies because npm packages could not be installed in this environment)*
- npm ci *(fails: npm registry responded with 403 when fetching prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e5272b8c8332b6bf57f0fefcdbb3