### PR TITLE
Add reusable button mixins for order detail styles

### DIFF
--- a/client/src/styles/_mixins.scss
+++ b/client/src/styles/_mixins.scss
@@ -15,6 +15,34 @@
   }
 }
 
+@mixin button-reset {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: inherit;
+}
+
+@mixin button-base {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
 @mixin glass-card {
   background: rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(12px);


### PR DESCRIPTION
## Summary
- add shared `button-reset` and `button-base` mixins so pages can safely include them

## Testing
- npm run build *(fails: TypeScript cannot resolve React packages in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e70151bc8332bb74a96b0bb342e1