### PR TITLE
Publish admin created events by default

### DIFF
--- a/server/controllers/adminEventController.js
+++ b/server/controllers/adminEventController.js
@@ -183,7 +183,7 @@ exports.createEvent = async (req, res, next) => {
       mode: req.body.mode === 'venue' ? 'venue' : 'online',
       venue: req.body.venue,
       visibility: req.body.visibility === 'private' ? 'private' : 'public',
-      status: 'draft',
+      status: 'published',
       description: req.body.description || '',
       rules: req.body.rules || '',
       prizePool: req.body.prizePool,


### PR DESCRIPTION
## Summary
- ensure events created through the admin endpoint are published immediately so they appear in the public listing

## Testing
- npm test --prefix server *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f5e768788332b729a0f16df9b83d