### PR TITLE
Add global products listing page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -35,6 +35,7 @@ const MyOrders = lazy(() => import('./pages/Orders/MyOrders'));
 const ServiceOrders = lazy(() => import('./pages/Orders/ServiceOrders'));
 const OrderDetail = lazy(() => import('./pages/Orders/OrderDetail'));
 const Notifications = lazy(() => import('./pages/Notifications/Notifications'));
+const ProductsList = lazy(() => import('./pages/Products/ProductsList'));
 const AdminLogin = lazy(() => import('./pages/AdminLogin/AdminLogin'));
 const AdminDashboard = lazy(() => import('./pages/AdminDashboard'));
 const AdminShops = lazy(() => import('./pages/AdminShops'));
@@ -88,6 +89,7 @@ function App() {
           <Route element={<TabLayout />}>
             <Route path="/home" element={<Home />} />
             <Route path="/shops" element={<Shops />} />
+            <Route path="/products" element={<ProductsList />} />
             <Route path="/verified-users" element={<VerifiedList />} />
             <Route path="/events" element={<Events />} />
             <Route path="/special-shop" element={<SpecialShop />} />

--- a/client/src/components/ui/SectionHeader.tsx
+++ b/client/src/components/ui/SectionHeader.tsx
@@ -6,14 +6,21 @@ interface SectionHeaderProps {
   href?: string;
   onClick?: () => void;
   className?: string;
+  linkLabel?: string;
 }
 
-const SectionHeader = ({ title, href, onClick, className = '' }: SectionHeaderProps) => (
+const SectionHeader = ({
+  title,
+  href,
+  onClick,
+  className = '',
+  linkLabel = 'See all',
+}: SectionHeaderProps) => (
   <div className={`${styles.header} ${className}`}>
     <h2 className={styles.title}>{title}</h2>
     {(href || onClick) && (
       <a className={styles.link} href={href} onClick={onClick}>
-        See all
+        {linkLabel}
       </a>
     )}
   </div>

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -107,13 +107,14 @@ const Home = () => {
 
       <Section
         title="Shop Offers"
-        path={paths.shops()}
+        path={paths.products.list()}
         data={shops.items}
         status={shops.status}
         error={shops.error}
         type="product"
         onRetry={() => d(fetchShops({ sort: '-createdAt', pageSize: 10 }))}
         navigate={navigate}
+        linkLabel="See all products"
       />
       <Section
         title="Verified Users"
@@ -158,34 +159,45 @@ interface SectionProps {
   type: 'product' | 'user' | 'event';
   onRetry: () => void;
   navigate: ReturnType<typeof useNavigate>;
+  linkLabel?: string;
 }
 
-const Section = ({ title, path, data, status, error, type, onRetry, navigate }: SectionProps) => {
+const Section = ({
+  title,
+  path,
+  data,
+  status,
+  error,
+  type,
+  onRetry,
+  navigate,
+  linkLabel,
+}: SectionProps) => {
   const loading = status === 'loading';
   if (loading)
     return (
       <div className="section">
-        <SectionHeader title={title} onClick={() => navigate(path)} />
+        <SectionHeader title={title} onClick={() => navigate(path)} linkLabel={linkLabel} />
         {type === 'product' ? <ProductsSkeleton /> : type === 'event' ? <EventsSkeleton /> : <ShopsSkeleton />}
       </div>
     );
   if (status === 'failed')
     return (
       <div className="section">
-        <SectionHeader title={title} onClick={() => navigate(path)} />
+        <SectionHeader title={title} onClick={() => navigate(path)} linkLabel={linkLabel} />
         <ErrorCard message={error || `Failed to load ${title}`} onRetry={onRetry} />
       </div>
     );
   if (status === 'succeeded' && data.length === 0)
     return (
       <div className="section">
-        <SectionHeader title={title} onClick={() => navigate(path)} />
+        <SectionHeader title={title} onClick={() => navigate(path)} linkLabel={linkLabel} />
         <EmptyState message={`No ${title.toLowerCase()}`} />
       </div>
     );
   return (
     <div className="section">
-      <SectionHeader title={title} onClick={() => navigate(path)} />
+      <SectionHeader title={title} onClick={() => navigate(path)} linkLabel={linkLabel} />
       <HorizontalCarousel>
         {data.map((item: any) =>
           type === 'product' ? (

--- a/client/src/pages/Products/ProductsList.module.scss
+++ b/client/src/pages/Products/ProductsList.module.scss
@@ -1,0 +1,161 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem 1rem 4rem;
+
+  @media (min-width: 768px) {
+    padding: 2rem 2.5rem 4rem;
+  }
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.subtitle {
+  margin: 0;
+  max-width: 640px;
+  color: #4b5563;
+}
+
+.filters {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    align-items: end;
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.875rem;
+  color: #1f2937;
+
+  span {
+    font-weight: 600;
+  }
+
+  input,
+  select {
+    padding: 0.6rem 0.75rem;
+    border-radius: 10px;
+    border: 1px solid #d1d5db;
+    background: #f9fafb;
+    font: inherit;
+    transition: border-color 0.2s ease;
+
+    &:focus {
+      outline: none;
+      border-color: var(--color-primary, #6366f1);
+      background: #fff;
+      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+    }
+  }
+}
+
+.sortField {
+  @media (max-width: 1023px) {
+    order: 1;
+  }
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+
+  button {
+    border: none;
+    border-radius: 9999px;
+    padding: 0.65rem 1.4rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 16px rgba(15, 23, 42, 0.15);
+    }
+  }
+}
+
+.apply {
+  background: var(--color-primary, #6366f1);
+  color: #fff;
+}
+
+.clear {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.cardWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #4b5563;
+}
+
+.shop {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.category {
+  flex: 0 0 auto;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--color-primary, #4f46e5);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.feedback {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 0;
+}
+
+.loadingHint {
+  margin-top: -0.5rem;
+  color: #6b7280;
+  font-size: 0.875rem;
+  text-align: center;
+}

--- a/client/src/pages/Products/ProductsList.tsx
+++ b/client/src/pages/Products/ProductsList.tsx
@@ -1,0 +1,365 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import ProductCard, { type Product as ProductCardProduct } from '@/components/ui/ProductCard.tsx';
+import SkeletonProductCard from '@/components/ui/Skeletons/SkeletonProductCard';
+import EmptyState from '@/components/ui/EmptyState';
+import ErrorCard from '@/components/ui/ErrorCard';
+import { http } from '@/lib/http';
+import { toErrorMessage, toItems } from '@/lib/response';
+import { paths } from '@/routes/paths';
+import styles from './ProductsList.module.scss';
+
+interface Product extends ProductCardProduct {
+  category?: string;
+  shop?: string | { _id?: string; id?: string; name?: string };
+  shopId?: string;
+  shopMeta?: {
+    id?: string;
+    name?: string;
+    image?: string | null;
+    location?: string | null;
+  };
+  updatedAt?: string;
+  createdAt?: string;
+}
+
+type FiltersState = {
+  search: string;
+  shopId: string;
+  category: string;
+};
+
+type RequestStatus = 'idle' | 'loading' | 'succeeded' | 'failed';
+
+const defaultFilters: FiltersState = {
+  search: '',
+  shopId: '',
+  category: '',
+};
+
+const sortOptions = [
+  { value: 'newest', label: 'Newest' },
+  { value: 'oldest', label: 'Oldest' },
+  { value: 'priceDesc', label: 'Price: High to Low' },
+  { value: 'priceAsc', label: 'Price: Low to High' },
+  { value: 'discountDesc', label: 'Best Discount' },
+];
+
+const normalizeShopId = (product: Product): string => {
+  if (product.shopMeta?.id) return product.shopMeta.id;
+  if (product.shopId) return product.shopId;
+  const rawShop = product.shop as any;
+  if (typeof rawShop === 'string') return rawShop;
+  if (rawShop?.id) return rawShop.id;
+  if (rawShop?._id) return rawShop._id;
+  return '';
+};
+
+const getShopName = (product: Product): string => {
+  if (product.shopMeta?.name) return product.shopMeta.name;
+  const rawShop = product.shop as any;
+  if (rawShop?.name) return rawShop.name;
+  if ((product as any).shopName) return String((product as any).shopName);
+  return 'Unknown shop';
+};
+
+const getDiscount = (product: Product): number => {
+  if (typeof product.discount === 'number') return product.discount;
+  if (typeof product.mrp === 'number' && product.mrp > 0) {
+    return Math.round(((product.mrp - product.price) / product.mrp) * 100);
+  }
+  return 0;
+};
+
+const getTimestamp = (product: Product): number => {
+  const updated = product.updatedAt || (product as any).updatedAt;
+  const created = product.createdAt || (product as any).createdAt;
+  const source = updated || created;
+  if (!source) return 0;
+  const time = new Date(source).getTime();
+  return Number.isFinite(time) ? time : 0;
+};
+
+const ProductsList = () => {
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<RequestStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [items, setItems] = useState<Product[]>([]);
+  const [filters, setFilters] = useState<FiltersState>(defaultFilters);
+  const [appliedFilters, setAppliedFilters] = useState<FiltersState>(defaultFilters);
+  const [sort, setSort] = useState<string>('newest');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const handleApply = useCallback(
+    (event?: React.FormEvent<HTMLFormElement>) => {
+      event?.preventDefault();
+      const trimmedSearch = filters.search.trim();
+      const nextFilters: FiltersState = {
+        search: trimmedSearch,
+        shopId: filters.shopId,
+        category: filters.category,
+      };
+      const isSame =
+        nextFilters.search === appliedFilters.search &&
+        nextFilters.shopId === appliedFilters.shopId &&
+        nextFilters.category === appliedFilters.category;
+      setFilters(nextFilters);
+      setAppliedFilters(nextFilters);
+      if (isSame) {
+        setReloadKey((key) => key + 1);
+      }
+    },
+    [filters, appliedFilters]
+  );
+
+  const handleClear = useCallback(() => {
+    setFilters(defaultFilters);
+    setAppliedFilters(defaultFilters);
+    setReloadKey((key) => key + 1);
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
+    const load = async () => {
+      setStatus('loading');
+      setError(null);
+      try {
+        const response = await http.get('/products', {
+          params: {
+            query: appliedFilters.search || undefined,
+            shopId: appliedFilters.shopId || undefined,
+            category: appliedFilters.category || undefined,
+          },
+          signal: controller.signal,
+        });
+        if (!active) return;
+        const data = (toItems(response) ?? []) as Product[];
+        setItems(data);
+        setStatus('succeeded');
+      } catch (err: any) {
+        if (!active) return;
+        if (err?.code === 'ERR_CANCELED') return;
+        setError(toErrorMessage(err));
+        setStatus('failed');
+      }
+    };
+
+    void load();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [appliedFilters.search, appliedFilters.shopId, appliedFilters.category, reloadKey]);
+
+  const shopOptions = useMemo(() => {
+    const map = new Map<string, string>();
+    items.forEach((product) => {
+      const id = normalizeShopId(product);
+      if (!id) return;
+      if (!map.has(id)) {
+        map.set(id, getShopName(product));
+      }
+    });
+    return Array.from(map.entries()).map(([value, label]) => ({ value, label }));
+  }, [items]);
+
+  const categoryOptions = useMemo(() => {
+    const set = new Set<string>();
+    items.forEach((product) => {
+      const category = product.category || (product as any).category;
+      if (typeof category === 'string' && category.trim()) {
+        set.add(category.trim());
+      }
+    });
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [items]);
+
+  const visibleItems = useMemo(() => {
+    const filtered = items.filter((product) => {
+      const nameMatch = appliedFilters.search
+        ? product.name.toLowerCase().includes(appliedFilters.search.toLowerCase())
+        : true;
+      const shopMatch = appliedFilters.shopId
+        ? normalizeShopId(product) === appliedFilters.shopId
+        : true;
+      const categoryMatch = appliedFilters.category
+        ? (product.category || '').toLowerCase() === appliedFilters.category.toLowerCase()
+        : true;
+      return nameMatch && shopMatch && categoryMatch;
+    });
+
+    const sorted = [...filtered];
+    switch (sort) {
+      case 'priceAsc':
+        sorted.sort((a, b) => a.price - b.price);
+        break;
+      case 'priceDesc':
+        sorted.sort((a, b) => b.price - a.price);
+        break;
+      case 'discountDesc':
+        sorted.sort((a, b) => getDiscount(b) - getDiscount(a));
+        break;
+      case 'oldest':
+        sorted.sort((a, b) => getTimestamp(a) - getTimestamp(b));
+        break;
+      case 'newest':
+      default:
+        sorted.sort((a, b) => getTimestamp(b) - getTimestamp(a));
+        break;
+    }
+    return sorted;
+  }, [
+    items,
+    appliedFilters.search,
+    appliedFilters.shopId,
+    appliedFilters.category,
+    sort,
+  ]);
+
+  const isLoading = status === 'loading' && items.length === 0;
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>All Products</h1>
+        <p className={styles.subtitle}>
+          Browse every product available across shops and refine the list with search and filters.
+        </p>
+      </header>
+
+      <form className={styles.filters} onSubmit={handleApply}>
+        <label className={styles.field}>
+          <span>Search</span>
+          <input
+            type="search"
+            name="search"
+            value={filters.search}
+            onChange={(event) =>
+              setFilters((prev) => ({ ...prev, search: event.target.value }))
+            }
+            placeholder="Search by product name"
+          />
+        </label>
+        <label className={styles.field}>
+          <span>Shop</span>
+          <select
+            name="shopId"
+            value={filters.shopId}
+            onChange={(event) =>
+              setFilters((prev) => ({ ...prev, shopId: event.target.value }))
+            }
+          >
+            <option value="">All shops</option>
+            {shopOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className={styles.field}>
+          <span>Category</span>
+          <select
+            name="category"
+            value={filters.category}
+            onChange={(event) =>
+              setFilters((prev) => ({ ...prev, category: event.target.value }))
+            }
+          >
+            <option value="">All categories</option>
+            {categoryOptions.map((category) => (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className={`${styles.field} ${styles.sortField}`}>
+          <span>Sort</span>
+          <select value={sort} onChange={(event) => setSort(event.target.value)}>
+            {sortOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className={styles.actions}>
+          <button type="submit" className={styles.apply}>
+            Apply filters
+          </button>
+          <button type="button" className={styles.clear} onClick={handleClear}>
+            Clear filters
+          </button>
+        </div>
+      </form>
+
+      {status === 'failed' ? (
+        <div className={styles.feedback}>
+          <ErrorCard
+            message={error || 'Failed to load products'}
+            onRetry={() => setReloadKey((key) => key + 1)}
+          />
+        </div>
+      ) : isLoading ? (
+        <div className={styles.grid}>
+          {Array.from({ length: 8 }).map((_, index) => (
+            <SkeletonProductCard key={index} />
+          ))}
+        </div>
+      ) : visibleItems.length === 0 ? (
+        <div className={styles.feedback}>
+          <EmptyState
+            title="No products found"
+            message="Adjust your filters or refresh to explore products from every shop."
+            ctaLabel="Refresh"
+            onCtaClick={() => setReloadKey((key) => key + 1)}
+          />
+        </div>
+      ) : (
+        <div className={styles.grid}>
+          {visibleItems.map((product) => {
+            const id = product._id || (product as any).id;
+            const shopId = normalizeShopId(product);
+            return (
+              <div key={id ?? product.name} className={styles.cardWrapper} data-testid="product-card">
+                <ProductCard
+                  product={product}
+                  onClick={() => {
+                    if (id) {
+                      navigate(paths.products.detail(String(id)));
+                    }
+                  }}
+                />
+                <div className={styles.meta}>
+                  <span className={styles.shop} title={getShopName(product)}>
+                    {getShopName(product)}
+                  </span>
+                  {product.category && (
+                    <span className={styles.category}>
+                      {product.category}
+                    </span>
+                  )}
+                  {!product.category && shopId && (
+                    <span className={styles.category}>Shop #{shopId.slice(-4)}</span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {status === 'loading' && items.length > 0 && (
+        <div className={styles.loadingHint} role="status">
+          Updating results…
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProductsList;

--- a/server/tests/productsPage.e2e.test.js
+++ b/server/tests/productsPage.e2e.test.js
@@ -1,0 +1,93 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../models/Product', () => ({
+  find: jest.fn(),
+}));
+
+const Product = require('../models/Product');
+const productRoutes = require('../routes/productRoutes');
+
+const buildApp = () => {
+  const app = express();
+  app.use('/products', productRoutes);
+  return app;
+};
+
+describe('GET /products', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns normalized products for the products listing page', async () => {
+    const mockProducts = [
+      {
+        _id: 'prod-1',
+        name: 'Golden Mango',
+        description: 'Juicy alphonso mangoes',
+        price: 120,
+        mrp: 150,
+        images: ['https://img/mango.jpg'],
+        category: 'Fruits',
+        stock: 5,
+        shop: { _id: 'shop-1', name: 'Fresh Cart', image: null, location: 'Bangalore' },
+        updatedAt: new Date('2024-02-02T10:00:00Z'),
+      },
+      {
+        _id: 'prod-2',
+        name: 'Herbal Tea',
+        description: 'Relaxing infusion',
+        price: 60,
+        mrp: 80,
+        images: ['https://img/tea.jpg'],
+        category: 'Beverages',
+        stock: 10,
+        shop: { _id: 'shop-2', name: 'Wellness Hub', image: null, location: 'Mysuru' },
+        updatedAt: new Date('2024-02-01T09:30:00Z'),
+      },
+    ];
+    const populate = jest.fn().mockReturnThis();
+    const lean = jest.fn().mockResolvedValue(mockProducts);
+    Product.find.mockReturnValue({ populate, lean });
+
+    const app = buildApp();
+    const res = await request(app).get('/products');
+
+    expect(res.status).toBe(200);
+    expect(Product.find).toHaveBeenCalledWith({ isDeleted: false });
+    expect(populate).toHaveBeenCalledWith('shop', 'name image location');
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0]).toEqual(
+      expect.objectContaining({
+        _id: 'prod-1',
+        name: 'Golden Mango',
+        price: 120,
+        mrp: 150,
+        discount: 20,
+        category: 'Fruits',
+        shopId: 'shop-1',
+        shopMeta: expect.objectContaining({ name: 'Fresh Cart' }),
+      })
+    );
+  });
+
+  it('applies query filters when fetching products', async () => {
+    const populate = jest.fn().mockReturnThis();
+    const lean = jest.fn().mockResolvedValue([]);
+    Product.find.mockReturnValue({ populate, lean });
+
+    const app = buildApp();
+    await request(app)
+      .get('/products')
+      .query({ query: 'tea', category: 'Beverages', shopId: 'shop-2' });
+
+    expect(Product.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDeleted: false,
+        category: 'Beverages',
+        shop: 'shop-2',
+        name: { $regex: 'tea', $options: 'i' },
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement a user-facing /products page with global filters, sorting, and loading states
- expose the new page through the router and home "Shop Offers" section using a configurable section header link
- add an integration test that exercises GET /products and asserts normalized payloads and filtering behaviour

## Testing
- npm test -- --runTestsByPath tests/productsPage.e2e.test.js *(fails: jest dependencies unavailable in offline env)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bf9db0fc83329753d68aea7339f7