### PR TITLE
Improve request editing authorization and provider note display

### DIFF
--- a/server/controllers/servicesModuleController.js
+++ b/server/controllers/servicesModuleController.js
@@ -633,8 +633,7 @@ exports.updateServiceRequest = async (req, res, next) => {
 
     const viewerId = req.user?._id;
     const isOwner = viewerId && String(request.userId) === String(viewerId);
-    const isAdmin = req.user?.role === 'admin';
-    if (!isOwner && !isAdmin) throw AppError.forbidden('NOT_AUTHORIZED', 'Not authorized to edit this request');
+    if (!isOwner) throw AppError.forbidden('NOT_AUTHORIZED', 'Not authorized to edit this request');
 
     const statusValue = normalizeStatusName(request.status);
     if (request.acceptedBy) {


### PR DESCRIPTION
## Summary
- restrict requester edits to their own service requests through the update endpoint
- keep provider messages visible only for direct requests that have already been accepted

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f2f85ce348325845918b148a69486)