### PR TITLE
Persist product stock (stock_quantity) on create/update and accept stock aliases

### DIFF
--- a/server/controllers/adminProductController.js
+++ b/server/controllers/adminProductController.js
@@ -16,6 +16,28 @@ const parseSort = (raw, fallback = '-updatedAt') => {
   return { [key || 'updatedAt']: direction };
 };
 
+
+const getStockInput = (body = {}) => {
+  if (body.stock_quantity !== undefined) return body.stock_quantity;
+  if (body.stockQuantity !== undefined) return body.stockQuantity;
+  if (body.quantity !== undefined) return body.quantity;
+  return body.stock;
+};
+
+const parseStockQuantity = (body = {}, { required = false } = {}) => {
+  const rawStock = getStockInput(body);
+  if (rawStock === undefined || rawStock === null || rawStock === '') {
+    return { provided: false, stockQty: required ? 0 : undefined };
+  }
+
+  const stockQty = Number.parseInt(rawStock, 10);
+  if (Number.isNaN(stockQty) || stockQty < 0) {
+    throw AppError.badRequest('PRODUCT_STOCK_INVALID', 'PRODUCT_STOCK_INVALID');
+  }
+
+  return { provided: true, stockQty };
+};
+
 const sanitizeRegex = (value) => {
   if (!value || typeof value !== 'string') return null;
   const trimmed = value.trim();
@@ -53,6 +75,7 @@ const normalizeProduct = (doc) => {
     mrp: doc.mrp,
     discount: doc.discount,
     stock: doc.stock,
+    stock_quantity: doc.stock,
     status: doc.status,
     image: primaryImage,
     images,
@@ -69,7 +92,6 @@ exports.createProduct = async (req, res, next) => {
       category,
       price,
       mrp,
-      stock,
       image,
       images,
     } = req.body || {};
@@ -96,16 +118,12 @@ exports.createProduct = async (req, res, next) => {
 
     const priceValue = Number(price);
     const mrpValue = Number(mrp);
-    const stockValue = Number(stock);
-
     if (!Number.isFinite(priceValue) || priceValue <= 0)
       throw AppError.badRequest('INVALID_PRICE', 'Price must be greater than zero');
     if (!Number.isFinite(mrpValue) || mrpValue <= 0)
       throw AppError.badRequest('INVALID_MRP', 'MRP must be greater than zero');
     if (priceValue > mrpValue)
       throw AppError.badRequest('PRICE_GT_MRP', 'Price cannot exceed MRP');
-    if (!Number.isFinite(stockValue) || stockValue < 0)
-      throw AppError.badRequest('INVALID_STOCK', 'Stock must be zero or a positive number');
 
     const imageList = Array.isArray(images)
       ? images.filter((img) => typeof img === 'string' && img.trim())
@@ -116,6 +134,9 @@ exports.createProduct = async (req, res, next) => {
       imageList.unshift(imageSource);
     }
 
+    const { stockQty } = parseStockQuantity(req.body, { required: true });
+    console.log('[PRODUCT_STOCK_IN]', { productId: null, stockQty });
+
     const payload = {
       shop: shop._id,
       name: trimmedName,
@@ -123,7 +144,7 @@ exports.createProduct = async (req, res, next) => {
       category: trimmedCategory,
       price: priceValue,
       mrp: mrpValue,
-      stock: stockValue,
+      stock: stockQty,
       status: 'active',
       image: imageSource,
       images: imageList,
@@ -257,7 +278,6 @@ exports.updateProduct = async (req, res, next) => {
       name,
       price,
       mrp,
-      stock,
       status,
       category,
       images,
@@ -280,12 +300,10 @@ exports.updateProduct = async (req, res, next) => {
       }
       product.mrp = value;
     }
-    if (stock !== undefined) {
-      const value = Number(stock);
-      if (!Number.isFinite(value) || value < 0) {
-        throw AppError.badRequest('INVALID_STOCK', 'Stock must be a positive number');
-      }
-      product.stock = value;
+    const { provided: stockProvided, stockQty } = parseStockQuantity(req.body);
+    if (stockProvided) {
+      console.log('[PRODUCT_STOCK_IN]', { productId: product._id?.toString?.() || id, stockQty });
+      product.stock = stockQty;
     }
     if (status !== undefined) {
       const mapped = STATUS_TO_INTERNAL[status] || status;

--- a/server/controllers/productController.js
+++ b/server/controllers/productController.js
@@ -23,6 +23,30 @@ const ensurePaise = (value, field) => {
 
 const toPrice = (paise) => paise / 100;
 
+const getStockInput = (body = {}) => {
+  if (body.stock_quantity !== undefined) return body.stock_quantity;
+  if (body.stockQuantity !== undefined) return body.stockQuantity;
+  if (body.quantity !== undefined) return body.quantity;
+  return body.stock;
+};
+
+const parseStockQuantity = (body = {}, { required = false } = {}) => {
+  const rawStock = getStockInput(body);
+  if (rawStock === undefined || rawStock === null || rawStock === '') {
+    return { provided: false, stockQty: required ? 0 : undefined };
+  }
+
+  const stockQty = Number.parseInt(rawStock, 10);
+  if (Number.isNaN(stockQty) || stockQty < 0) {
+    throw Object.assign(new Error('PRODUCT_STOCK_INVALID'), {
+      statusCode: 400,
+      code: 'PRODUCT_STOCK_INVALID',
+    });
+  }
+
+  return { provided: true, stockQty };
+};
+
 const createSampleProductForShop = async (shop) => {
   return Product.create({
     shop: shop._id,
@@ -51,7 +75,6 @@ exports.createProduct = async (req, res, next) => {
       mrpPaise,
       category,
       imageUrl,
-      stock = 0,
       status,
       available,
       isSpecial,
@@ -88,8 +111,8 @@ exports.createProduct = async (req, res, next) => {
     }
 
     const trimmedImage = typeof imageUrl === 'string' ? imageUrl.trim() : '';
-    const numericStock = Number(stock);
-    const parsedStock = Number.isFinite(numericStock) && numericStock >= 0 ? numericStock : 0;
+    const { stockQty: parsedStock } = parseStockQuantity(req.body, { required: true });
+    console.log('[PRODUCT_STOCK_IN]', { productId: null, stockQty: parsedStock });
     const product = await Product.create({
       shop: shop._id,
       createdBy: req.user._id,
@@ -142,7 +165,6 @@ exports.updateProduct = async (req, res, next) => {
       imageUrl,
       image,
       images,
-      stock,
       status,
       available,
       isSpecial,
@@ -226,12 +248,10 @@ exports.updateProduct = async (req, res, next) => {
       }
     }
 
-    if (stock !== undefined) {
-      const nextStock = Number(stock);
-      if (!Number.isFinite(nextStock) || nextStock < 0) {
-        return res.status(400).json({ error: 'Stock must be a non-negative number' });
-      }
-      product.stock = nextStock;
+    const { provided: stockProvided, stockQty } = parseStockQuantity(req.body);
+    if (stockProvided) {
+      console.log('[PRODUCT_STOCK_IN]', { productId: product._id?.toString?.() || req.params.id, stockQty });
+      product.stock = stockQty;
     }
     if (status !== undefined) product.status = status;
     if (available !== undefined) product.available = available;
@@ -243,6 +263,9 @@ exports.updateProduct = async (req, res, next) => {
     invalidateProductCache();
     return res.json({ ok: true, data: { product: payload } });
   } catch (err) {
+    if (err?.statusCode) {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
     return next(err);
   }
 };

--- a/server/tests/productController.test.js
+++ b/server/tests/productController.test.js
@@ -1,10 +1,11 @@
 const Product = require('../models/Product');
 const Shop = require('../models/Shop');
 const { normalizeProduct } = require('../utils/normalize');
-const { createProduct } = require('../controllers/productController');
+const { createProduct, updateProduct } = require('../controllers/productController');
 
 jest.mock('../models/Product', () => ({
   create: jest.fn(),
+  findOne: jest.fn(),
 }));
 
 jest.mock('../models/Shop', () => ({
@@ -74,5 +75,64 @@ describe('productController.createProduct', () => {
       ok: true,
       data: { product: { _id: 'prod-1', shopId: 'shop-1', price: 123.45, pricePaise: 12345 } },
     });
+  });
+});
+
+
+describe('productController.updateProduct stock aliases', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates stock when quantity alias is provided', async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    Product.findOne.mockResolvedValue({
+      _id: 'prod-1',
+      shop: 'shop-1',
+      price: 100,
+      mrp: 120,
+      stock: 1,
+      save,
+    });
+    Shop.findOne.mockResolvedValue({ _id: 'shop-1', owner: 'user-1', location: 'City' });
+    normalizeProduct.mockReturnValue({ _id: 'prod-1', stock: 10, stock_quantity: 10 });
+
+    const req = {
+      params: { id: 'prod-1' },
+      body: { quantity: 10 },
+      user: { _id: 'user-1', role: 'business' },
+    };
+    const json = jest.fn();
+    const res = { json, status: jest.fn(() => res) };
+
+    await updateProduct(req, res, jest.fn());
+
+    expect(save).toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith({ ok: true, data: { product: { _id: 'prod-1', stock: 10, stock_quantity: 10 } } });
+  });
+
+  it('returns PRODUCT_STOCK_INVALID for negative stock alias', async () => {
+    Product.findOne.mockResolvedValue({
+      _id: 'prod-1',
+      shop: 'shop-1',
+      price: 100,
+      mrp: 120,
+      stock: 1,
+      save: jest.fn(),
+    });
+    Shop.findOne.mockResolvedValue({ _id: 'shop-1', owner: 'user-1', location: 'City' });
+
+    const req = {
+      params: { id: 'prod-1' },
+      body: { stockQuantity: -2 },
+      user: { _id: 'user-1', role: 'business' },
+    };
+    const json = jest.fn();
+    const res = { json, status: jest.fn(() => res) };
+
+    await updateProduct(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({ error: 'PRODUCT_STOCK_INVALID' });
   });
 });

--- a/server/tests/productCreation.integration.test.js
+++ b/server/tests/productCreation.integration.test.js
@@ -71,6 +71,38 @@ describe('POST /products', () => {
     expect(res.body.data.product.shopId).toBe('shop-1');
   });
 
+
+
+  it('accepts stock_quantity alias and persists stock', async () => {
+    Shop.findOne.mockResolvedValue({ _id: 'shop-1', owner: 'user-1', location: 'City' });
+    Product.create.mockResolvedValue({
+      _id: 'prod-2',
+      shop: 'shop-1',
+      name: 'Orange',
+      description: 'Fresh orange',
+      price: 100,
+      mrp: 120,
+      images: [],
+      category: 'Fruits',
+      stock: 10,
+    });
+
+    const app = buildApp();
+    const res = await request(app).post('/products').send({
+      shopId: 'shop-1',
+      name: 'Orange',
+      description: 'Fresh orange',
+      pricePaise: 10000,
+      mrpPaise: 12000,
+      category: 'Fruits',
+      stock_quantity: 10,
+    });
+
+    expect(res.status).toBe(201);
+    expect(Product.create).toHaveBeenCalledWith(expect.objectContaining({ stock: 10 }));
+    expect(res.body.data.product.stock_quantity).toBe(10);
+  });
+
   it('rejects invalid price payload', async () => {
     Shop.findOne.mockResolvedValue({ _id: 'shop-1', owner: 'user-1', location: 'City' });
     const app = buildApp();

--- a/server/utils/normalize.js
+++ b/server/utils/normalize.js
@@ -44,6 +44,7 @@ exports.normalizeProduct = (p) => {
     mrpPaise: toPaise(mrp),
     discount,
     stock,
+    stock_quantity: stock ?? 0,
     images: p.images,
     image: p.images?.[0] || p.image || '',
     category: p.category,


### PR DESCRIPTION
### Motivation
- Products were persisting with `stock` = 0 because clients send different keys (`stock_quantity`, `stockQuantity`, `quantity`) and handlers only read legacy `stock` in some paths.
- Make product create/update handlers accept backward-compatible aliases, validate and normalize stock, and avoid accidental overwrites when stock isn't provided.

### Description
- Added shared parsing helpers `getStockInput` and `parseStockQuantity` to `server/controllers/productController.js` and `server/controllers/adminProductController.js` to accept `stock_quantity`, `stockQuantity`, `quantity`, and fallback `stock`, and to normalize via `Number.parseInt(..., 10)`.
- On create the parsed stock defaults to `0` when omitted; on update stock is written only if a stock alias was provided; invalid stock (`NaN` or `< 0`) returns `400 PRODUCT_STOCK_INVALID`.
- Added minimal safe logging `console.log('[PRODUCT_STOCK_IN]', { productId, stockQty })` to confirm parsed values without logging request bodies.
- Updated `server/utils/normalize.js` to include `stock_quantity` in normalized product payloads (keeps `stock` for backward compatibility).
- Added/updated tests in `server/tests/productController.test.js` and `server/tests/productCreation.integration.test.js` to cover alias acceptance and invalid-stock behavior.

### Testing
- Static/parse checks: ran `node --check` against `server/controllers/productController.js`, `server/controllers/adminProductController.js`, `server/utils/normalize.js`, and updated test files, which succeeded.
- Attempted to run the targeted test set with `cd server && npm test -- --runTestsByPath tests/productController.test.js tests/productCreation.integration.test.js` but the job failed here because `jest` is not available in this environment (test runner not found).
- Added unit/integration tests for alias handling and invalid stock cases but those tests were not executed in this environment due to the missing `jest` executable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a565e601e08332af52445ef338b2dc)